### PR TITLE
Cross entropy layers with label tensors

### DIFF
--- a/legacy/include/distconv/cudnn/cross_entropy.hpp
+++ b/legacy/include/distconv/cudnn/cross_entropy.hpp
@@ -27,8 +27,9 @@ class CrossEntropy<cudnn::BackendCUDNN> {
     assert_eq(x_pred.get_locale_shape(),
               x_truth.get_locale_shape());
     // Must have the same global and locale shapes
-    assert_eq(x_pred.get_shape(), x_truth.get_shape());
-    assert_eq(x_pred.get_local_shape(), x_truth.get_local_shape());
+    // FIXME: Comapre spatial shapes when label-based CE is enabled.
+    // assert_eq(x_pred.get_shape(), x_truth.get_shape());
+    // assert_eq(x_pred.get_local_shape(), x_truth.get_local_shape());
     // No halo for simplicity
     assert_eq(x_pred.get_local_shape(),
               x_pred.get_local_real_shape());

--- a/legacy/include/distconv/cudnn/cross_entropy.hpp
+++ b/legacy/include/distconv/cudnn/cross_entropy.hpp
@@ -11,7 +11,7 @@ namespace distconv {
 template <>
 class CrossEntropy<cudnn::BackendCUDNN> {
  public:
-  CrossEntropy(cudnn::BackendCUDNN &backend, const bool use_labels): m_be(backend), m_use_labels(use_labels) {}
+  CrossEntropy(cudnn::BackendCUDNN &backend, const bool use_labels=false): m_be(backend), m_use_labels(use_labels) {}
 
   ~CrossEntropy() = default;
 

--- a/legacy/include/distconv/cudnn/cross_entropy.hpp
+++ b/legacy/include/distconv/cudnn/cross_entropy.hpp
@@ -72,7 +72,7 @@ class CrossEntropy<cudnn::BackendCUDNN> {
 
   template <typename Tensor>
   int backward(const Tensor &x_pred, const Tensor &x_truth,
-               const Tensor &dy, Tensor &dx_pred,
+               Tensor &dy, Tensor &dx_pred,
                Tensor &dx_truth);
 
  protected:

--- a/legacy/include/distconv/cudnn/cross_entropy.hpp
+++ b/legacy/include/distconv/cudnn/cross_entropy.hpp
@@ -11,12 +11,13 @@ namespace distconv {
 template <>
 class CrossEntropy<cudnn::BackendCUDNN> {
  public:
-  CrossEntropy(cudnn::BackendCUDNN &backend): m_be(backend) {}
+  CrossEntropy(cudnn::BackendCUDNN &backend, const bool use_labels): m_be(backend), m_use_labels(use_labels) {}
 
   ~CrossEntropy() = default;
 
   CrossEntropy &operator=(const CrossEntropy &x) {
     assert_always(&m_be == &x.m_be);
+    assert_always(m_use_labels == x.m_use_labels);
     return *this;
   }
 
@@ -26,10 +27,23 @@ class CrossEntropy<cudnn::BackendCUDNN> {
     // Both tensors must have the same process grid
     assert_eq(x_pred.get_locale_shape(),
               x_truth.get_locale_shape());
-    // Must have the same global and locale shapes
-    // FIXME: Comapre spatial shapes when label-based CE is enabled.
-    // assert_eq(x_pred.get_shape(), x_truth.get_shape());
-    // assert_eq(x_pred.get_local_shape(), x_truth.get_local_shape());
+    if(m_use_labels) {
+      // Must have the same number of samples
+      assert_eq(x_pred.get_shape()[-1], x_truth.get_shape()[-1]);
+      assert_eq(x_pred.get_local_shape()[-1], x_truth.get_local_shape()[-1]);
+      // Must have the same global and locale spatial shapes
+      for(int i = 0; i < x_pred.get_num_spatial_dims(); i++) {
+        assert_eq(x_pred.get_shape()[i], x_truth.get_shape()[i]);
+        assert_eq(x_pred.get_local_shape()[i], x_truth.get_local_shape()[i]);
+      }
+      // Must have only one channel
+      assert_eq(x_truth.get_shape()[-2], 1);
+      assert_eq(x_truth.get_local_shape()[-2], 1);
+    } else {
+      // Must have the same global and locale shapes
+      assert_eq(x_pred.get_shape(), x_truth.get_shape());
+      assert_eq(x_pred.get_local_shape(), x_truth.get_local_shape());
+    }
     // No halo for simplicity
     assert_eq(x_pred.get_local_shape(),
               x_pred.get_local_real_shape());
@@ -63,6 +77,7 @@ class CrossEntropy<cudnn::BackendCUDNN> {
 
  protected:
   cudnn::BackendCUDNN &m_be;
+  const bool m_use_labels;
   int m_num_procs_per_sample;
   std::unique_ptr<Al::NCCLBackend::comm_type> m_al;
 };

--- a/legacy/src/cudnn/cross_entropy.cu
+++ b/legacy/src/cudnn/cross_entropy.cu
@@ -49,7 +49,7 @@ __global__ void fp_local(const DataType * __restrict__ prediction,
       const auto channel = (offset/sample_spatial_size)%sample_channel_size;
       const auto sample = offset/sample_spatial_size/sample_channel_size;
       const auto offset_truth = spatial+sample*sample_spatial_size;
-      const auto truth_label = ground_truth[offset_truth];
+      const int truth_label = ground_truth[offset_truth];
       xhat = DataType(truth_label == channel ? 1. : 0.);
     } else {
       xhat = ground_truth[offset];
@@ -107,7 +107,7 @@ __global__ void bp_local(const DataType * __restrict__ x_pred,
       const auto channel = (offset/sample_spatial_size)%sample_channel_size;
       const auto sample = offset/sample_spatial_size/sample_channel_size;
       const auto offset_truth = spatial+sample*sample_spatial_size;
-      const auto truth_label = x_truth[offset_truth];
+      const int truth_label = x_truth[offset_truth];
       xhat = DataType(truth_label == channel ? 1. : 0.);
     } else {
       xhat = x_truth[offset];

--- a/legacy/src/cudnn/cross_entropy.cu
+++ b/legacy/src/cudnn/cross_entropy.cu
@@ -140,6 +140,12 @@ int CrossEntopyCUDNN::forward(const Tensor &x_pred, const Tensor &x_truth,
     dim3 bdim(block_size);
     dim3 gdim(num_blocks_per_sample, num_samples);
 
+    // TODO: Support ND tensors
+    assert_eq(x_pred.get_local_shape().num_dims(), 5);
+    const auto sample_channel_size = x_pred.get_local_shape()[3];
+    const auto sample_spatial_size = sample_size / sample_channel_size;
+    assert_eq(sample_channel_size*sample_spatial_size, sample_size);
+
     cross_entropy::fp_local<DataType, block_size>
         <<<gdim, bdim, 0, m_be.get_stream()>>>(
             x_pred.get_const_buffer(), x_truth.get_const_buffer(),
@@ -180,6 +186,12 @@ int CrossEntopyCUDNN::backward(const Tensor &x_pred, const Tensor &x_truth,
 
   dim3 bdim(block_size);
   dim3 gdim(num_blocks_per_sample, num_samples);
+
+  // TODO: Support ND tensors
+  assert_eq(x_pred.get_local_shape().num_dims(), 5);
+  const auto sample_channel_size = x_pred.get_local_shape()[3];
+  const auto sample_spatial_size = sample_size / sample_channel_size;
+  assert_eq(sample_channel_size*sample_spatial_size, sample_size);
 
   cross_entropy::bp_local<DataType, block_size>
       <<<gdim, bdim, 0, m_be.get_stream()>>>(


### PR DESCRIPTION
This PR adds the `use_labels` option to cross-entropy layers that use an integer label tensor as the ground truth input.
When `use_labels` is enabled, the layer assumes that the ground truth tensor has the same sample and spatial dimensions to the input tensor, but the number of channels is one. Each value of the tensor is casted to `int` and then used to compare with channel indices. 
When `use_labels` is disabled, the layer uses the ground truth tensor as `xhat` as usual.

This PR also adds broadcasting of the previous error tensor at the beginning of the backward pass when the layer is spatially partitioned, to assume that both child activation/error tensors are gathered to the root process in LBANN.