### PR TITLE
arch support for older cuda capabilities

### DIFF
--- a/legacy/include/distconv/util/util_cuda.hpp
+++ b/legacy/include/distconv/util/util_cuda.hpp
@@ -39,23 +39,50 @@
 #define DISTCONV_CUDA_MALLOC(p, s)                              \
   distconv::util::cuda_malloc((void**)p, s, __FILE__, __LINE__)
 
-#if __CUDA_ARCH__ < 600
-inline __device__ double atomicAdd(double* address, double val)
+#ifdef __CUDACC__
+template <typename T>
+__device__ __forceinline__ T atomic_add(T* address, T value)
 {
-    unsigned long long int* address_as_ull =
-      (unsigned long long int*)address;
-    unsigned long long int old = *address_as_ull, assumed;
-    do {
-      assumed = old;
-      old = atomicCAS(address_as_ull, assumed,
-                      __double_as_longlong(val +
-                                           __longlong_as_double(assumed)));
-      // Note: uses integer comparison to avoid hang in case of NaN
-      // (since NaN != NaN)
-    } while (assumed != old);
-    return __longlong_as_double(old);
+  return atomicAdd(address, value);
 }
-#endif
+
+// Handle fp16
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 700 && __CUDA_ARCH__ >= 530
+#include <cuda_fp16.h>
+__device__ __forceinline__ __half atomic_add(__half* address, __half val)
+{
+  unsigned int* address_as_uint = (unsigned int*) address;
+  unsigned int old = *address_as_uint;
+  __half* old_as_half = (__half*) &old;
+  unsigned int assumed;
+  unsigned int updated;
+  __half* updated_as_half = (__half*) &updated;
+  do {
+    assumed = old;
+    updated = old;
+    *updated_as_half += val;
+    old = atomicCAS(address_as_uint, assumed, updated);
+  } while (assumed != old);
+  return *old_as_half;
+}
+#endif // defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 700 && __CUDA_ARCH__ >= 530
+
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 600
+__device__ __forceinline__ double atomic_add(double* address, double val)
+{
+  unsigned long long int* address_as_ull =
+    (unsigned long long int*)address;
+  unsigned long long int old = *address_as_ull, assumed;
+  do {
+    assumed = old;
+    old = atomicCAS(address_as_ull, assumed,
+                    __double_as_longlong(val +
+                                         __longlong_as_double(assumed)));
+  } while (assumed != old);
+  return __longlong_as_double(old);
+}
+#endif // defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 600
+#endif // __CUDACC__
 
 namespace distconv {
 namespace util {

--- a/legacy/src/cudnn/batchnorm.cu
+++ b/legacy/src/cudnn/batchnorm.cu
@@ -60,8 +60,8 @@ __global__ void channel_sums_and_sqsums_kernel(
   sqsum = BlockReduce(temp_storage_sqsum).Sum(sqsum);
   // Output channel sum to global memory
   if(tid == 0) {
-    atomicAdd(&sums[ch_idx], sum);
-    atomicAdd(&sqsums[ch_idx], sqsum);
+    atomic_add(&sums[ch_idx], sum);
+    atomic_add(&sqsums[ch_idx], sqsum);
   }
 }
 
@@ -98,8 +98,8 @@ __global__ void channel_sums_and_sqsums_opt_kernel(
   sqsum = BlockReduce(temp_storage_sqsum).Sum(sqsum);
   // Output channel sum to global memory
   if(tid == 0) {
-    atomicAdd(&sums[ch_idx], sum);
-    atomicAdd(&sqsums[ch_idx], sqsum);
+    atomic_add(&sums[ch_idx], sum);
+    atomic_add(&sqsums[ch_idx], sqsum);
   }
 }
 
@@ -751,10 +751,10 @@ void __global__ backprop1_kernel(const DataType * __restrict__ input,
 
   // Output channel sum to global memory
   if (tid == 0) {
-    atomicAdd(&global_dscale[ch_idx], dscale);
-    atomicAdd(&global_dbias[ch_idx], dbias);
-    atomicAdd(&global_dmean[ch_idx], dmean);
-    atomicAdd(&global_dvar[ch_idx], dvar);
+    atomic_add(&global_dscale[ch_idx], dscale);
+    atomic_add(&global_dbias[ch_idx], dbias);
+    atomic_add(&global_dmean[ch_idx], dmean);
+    atomic_add(&global_dvar[ch_idx], dvar);
   }
 }
 
@@ -821,10 +821,10 @@ void __global__ backprop1_opt_kernel(const DataTypeV * __restrict__ input,
 
   // Output channel sum to global memory
   if (tid == 0) {
-    atomicAdd(&global_dscale[ch_idx], dscale);
-    atomicAdd(&global_dbias[ch_idx], dbias);
-    atomicAdd(&global_dmean[ch_idx], dmean);
-    atomicAdd(&global_dvar[ch_idx], dvar);
+    atomic_add(&global_dscale[ch_idx], dscale);
+    atomic_add(&global_dbias[ch_idx], dbias);
+    atomic_add(&global_dmean[ch_idx], dmean);
+    atomic_add(&global_dvar[ch_idx], dvar);
   }
 }
 

--- a/legacy/src/cudnn/cross_entropy.cu
+++ b/legacy/src/cudnn/cross_entropy.cu
@@ -52,7 +52,7 @@ __global__ void fp_local(const DataType * __restrict__ prediction,
   psum = BlockReduce(temp_storage).Sum(psum);
 
   if (tid == 0) {
-    atomicAdd(&y[sample_idx], psum);
+    atomic_add(&y[sample_idx], psum);
   }
 }
 

--- a/legacy/src/cudnn/softmax.cu
+++ b/legacy/src/cudnn/softmax.cu
@@ -110,10 +110,10 @@ struct atomic_max<double> {
 };
 
 template <typename DataType>
-struct atomic_add {
+struct atomic_add_fn {
   __device__ __forceinline__ DataType operator()(DataType *addr,
                                                  DataType value) const {
-    return atomicAdd(addr, value);
+    return atomic_add(addr, value);
   }
 };
 
@@ -332,10 +332,10 @@ void compute_exp(const Tensor &x, const DataType *sample_max,
   map_and_reduce_per_sample_kernel
       <DataType, block_size,
        exp_shifted<DataType>, sum<DataType>,
-       atomic_add<DataType>>
+       atomic_add_fn<DataType>>
       <<<gdim, block_size, 0, stream>>>(
           x.get_base_ptr(), sample_size, sample_max,
-          exp_shifted<DataType>(), sum<DataType>(), atomic_add<DataType>(),
+          exp_shifted<DataType>(), sum<DataType>(), atomic_add_fn<DataType>(),
           y.get_base_ptr(), sample_exp);
 }
 
@@ -383,10 +383,10 @@ void bp_dotproduct(const Tensor &y, const Tensor &dy, DataType *sample_dp,
 
   reduce_per_sample_kernel
       <DataType, block_size,
-       mul<DataType>, sum<DataType>, atomic_add<DataType>>
+       mul<DataType>, sum<DataType>, atomic_add_fn<DataType>>
       <<<gdim, block_size, 0, stream>>>(
           y.get_base_ptr(), dy.get_base_ptr(), sample_size,
-          mul<DataType>(), sum<DataType>(), atomic_add<DataType>(),
+          mul<DataType>(), sum<DataType>(), atomic_add_fn<DataType>(),
           sample_dp);
 }
 


### PR DESCRIPTION
Added psuedo-atomicAdd for double data types on devices with cuda capability <6.x