### PR TITLE
Update to use Aluminum v0.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,13 +146,14 @@ if (H2_HAS_CUDA OR H2_HAS_HIP_ROCM)
   set(H2_HAS_GPU TRUE)
 endif ()
 
-find_package(Aluminum NO_MODULE QUIET
+set(H2_MINIMUM_ALUMINUM_VERSION 0.5.0)
+find_package(Aluminum ${H2_MINIMUM_ALUMINUM_VERSION} NO_MODULE QUIET
   HINTS ${Aluminum_DIR} ${ALUMINUM_DIR} ${AL_DIR}
   $ENV{Aluminum_DIR} $ENV{ALUMINUM_DIR} $ENV{AL_DIR}
   PATH_SUFFIXES lib64/cmake/aluminum lib/cmake/aluminum
   NO_DEFAULT_PATH)
 if (NOT Aluminum_FOUND)
-  find_package(Aluminum NO_MODULE REQUIRED)
+  find_package(Aluminum ${H2_MINIMUM_ALUMINUM_VERSION NO_MODULE REQUIRED)
 endif ()
 
 # DiHydrogen will use MPI-3 features extensively. Until proven

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,7 @@ find_package(Aluminum ${H2_MINIMUM_ALUMINUM_VERSION} NO_MODULE QUIET
   PATH_SUFFIXES lib64/cmake/aluminum lib/cmake/aluminum
   NO_DEFAULT_PATH)
 if (NOT Aluminum_FOUND)
-  find_package(Aluminum ${H2_MINIMUM_ALUMINUM_VERSION NO_MODULE REQUIRED)
+  find_package(Aluminum ${H2_MINIMUM_ALUMINUM_VERSION} NO_MODULE REQUIRED)
 endif ()
 
 # DiHydrogen will use MPI-3 features extensively. Until proven

--- a/cmake/config/DiHydrogenConfig.cmake.in
+++ b/cmake/config/DiHydrogenConfig.cmake.in
@@ -25,16 +25,17 @@ set(H2_DISTCONV_HAS_P2P @P2P_FOUND@)
 set(H2_DISTCONV_HAS_NVSHMEM @NVSHMEM_FOUND@)
 
 set(_BUILD_AL_DIR "@Aluminum_DIR@")
-find_package(Aluminum NO_MODULE QUIET
+set(_MIN_AL_VERSION "@H2_MINIMUM_ALUMINUM_VERSION@")
+find_package(Aluminum ${_MIN_AL_VERSION} NO_MODULE QUIET
   HINTS "${_BUILD_AL_DIR}"
   NO_DEFAULT_PATH)
-find_package(Aluminum NO_MODULE QUIET
+find_package(Aluminum ${_MIN_AL_VERSION} NO_MODULE QUIET
   HINTS ${Aluminum_DIR} ${ALUMINUM_DIR} ${AL_DIR}
   $ENV{Aluminum_DIR} $ENV{ALUMINUM_DIR} $ENV{AL_DIR}
   PATH_SUFFIXES lib64/cmake/aluminum lib/cmake/aluminum
   NO_DEFAULT_PATH)
 if (NOT Aluminum_FOUND)
-  find_package(Aluminum NO_MODULE REQUIRED)
+  find_package(Aluminum ${_MIN_AL_VERSION} NO_MODULE REQUIRED)
 endif ()
 
 find_dependency(BLASImpl)

--- a/legacy/benchmarks/shuffle_benchmark.cpp
+++ b/legacy/benchmarks/shuffle_benchmark.cpp
@@ -26,7 +26,7 @@
 using DataType = float;
 using namespace distconv;
 using distconv::tensor::Shape;
-using AlBackend = Al::MPICUDABackend;
+using AlBackend = Al::HostTransferBackend;
 
 namespace distconv_benchmark {
 

--- a/legacy/include/distconv/cudnn/backend.hpp
+++ b/legacy/include/distconv/cudnn/backend.hpp
@@ -299,7 +299,7 @@ class BackendCUDNN {
     return m_comm;
   }
 
-  std::shared_ptr<Al::MPICUDABackend::comm_type> get_al_mpi_cuda_comm() {
+  std::shared_ptr<Al::HostTransferBackend::comm_type> get_al_mpi_cuda_comm() {
     return m_al_mpi_cuda_comm;
   }
 
@@ -356,7 +356,7 @@ class BackendCUDNN {
     return m_internal_streams_pr[idx];
   }
 
-  std::shared_ptr<Al::MPICUDABackend::comm_type> &get_internal_al_mpi_cuda_comm(int idx) {
+  std::shared_ptr<Al::HostTransferBackend::comm_type> &get_internal_al_mpi_cuda_comm(int idx) {
     assert_always(idx < (int)m_internal_streams_pr.size());
     return m_internal_al_mpi_cuda_comms[idx];
   }
@@ -452,7 +452,7 @@ class BackendCUDNN {
 
  protected:
   MPI_Comm m_comm;
-  std::shared_ptr<Al::MPICUDABackend::comm_type> m_al_mpi_cuda_comm;
+  std::shared_ptr<Al::HostTransferBackend::comm_type> m_al_mpi_cuda_comm;
   // Keeps a heap object as copying a NCCLCommunicator destroys
   // ncclComm_t
   std::unique_ptr<Al::NCCLBackend::comm_type> m_al_nccl_comm;
@@ -469,10 +469,10 @@ class BackendCUDNN {
   std::vector<cudaStream_t> m_internal_streams;
   static constexpr int m_num_internal_streams_pr = 8;
   std::vector<cudaStream_t> m_internal_streams_pr;
-  // The communicator of MPICUDABackend creates new MPI communicators
+  // The communicator of HostTransferBackend creates new MPI communicators
   // when constructed even without no argument. Having them as heap
   // objects prevent that.
-  std::vector<std::shared_ptr<Al::MPICUDABackend::comm_type>> m_internal_al_mpi_cuda_comms;
+  std::vector<std::shared_ptr<Al::HostTransferBackend::comm_type>> m_internal_al_mpi_cuda_comms;
   Options m_opts;
 
   // Segmented communicators for channel/filter communication.
@@ -481,7 +481,7 @@ class BackendCUDNN {
 
   void init(MPI_Comm comm) {
     DISTCONV_CHECK_MPI(MPI_Comm_dup(comm, &m_comm));
-    m_al_mpi_cuda_comm = std::make_shared<Al::MPICUDABackend::comm_type>(
+    m_al_mpi_cuda_comm = std::make_shared<Al::HostTransferBackend::comm_type>(
         m_comm, m_stream);
     m_al_nccl_comm.reset(new Al::NCCLBackend::comm_type(m_comm, m_stream));
     DISTCONV_CHECK_CUDNN(cudnnSetStream(m_cudnn_h, m_stream));
@@ -503,7 +503,7 @@ class BackendCUDNN {
   void setup_al_comms() {
     for (int i = 0; i < m_num_internal_streams_pr; ++i) {
       m_internal_al_mpi_cuda_comms.push_back(
-          std::make_shared<Al::MPICUDABackend::comm_type>(m_comm, m_internal_streams_pr[i]));
+          std::make_shared<Al::HostTransferBackend::comm_type>(m_comm, m_internal_streams_pr[i]));
     }
   }
 

--- a/legacy/include/distconv/cudnn/convolution.hpp
+++ b/legacy/include/distconv/cudnn/convolution.hpp
@@ -920,35 +920,35 @@ class Convolution<cudnn::BackendCUDNN, DataType> {
   HaloExchangeMethod m_halo_xch_method;
   using HaloExchange = tensor::HaloExchange<DataType,
                                             tensor::CUDAAllocator,
-                                            Al::MPICUDABackend>;
+                                            Al::HostTransferBackend>;
   using HaloExchangeMPI = tensor::HaloExchangeMPI<DataType,
                                                   tensor::CUDAAllocator,
-                                                  Al::MPICUDABackend>;
+                                                  Al::HostTransferBackend>;
   using HaloExchangeAL = tensor::HaloExchangeAL<DataType,
                                                 tensor::CUDAAllocator,
-                                                Al::MPICUDABackend>;
+                                                Al::HostTransferBackend>;
 #ifdef DISTCONV_HAS_P2P
   using HaloExchangeP2P = tensor::HaloExchangeP2P<DataType,
                                                   tensor::CUDAAllocator,
-                                                  Al::MPICUDABackend>;
+                                                  Al::HostTransferBackend>;
   using HaloExchangeHybrid = tensor::HaloExchangeHybrid<DataType,
                                                         tensor::CUDAAllocator,
-                                                        Al::MPICUDABackend>;
+                                                        Al::HostTransferBackend>;
 #endif // DISTCONV_HAS_P2P
 #ifdef DISTCONV_HAS_NVSHMEM
   using HaloExchangeNVSHMEM = tensor::HaloExchangeNVSHMEM<DataType,
                                                           tensor::CUDAAllocator,
-                                                          Al::MPICUDABackend>;
+                                                          Al::HostTransferBackend>;
 #ifdef DISTCONV_HAS_CUDA_GRAPH
   using HaloExchangeNVSHMEMGraph = tensor::HaloExchangeNVSHMEMGraph<DataType,
                                                                     tensor::CUDAAllocator,
-                                                                    Al::MPICUDABackend>;
+                                                                    Al::HostTransferBackend>;
 #endif // DISTCONV_HAS_CUDA_GRAPH
   using HaloExchangeNVSHMEMDirect = tensor::HaloExchangeNVSHMEMDirect<DataType,
                                                                       tensor::CUDAAllocator,
-                                                                      Al::MPICUDABackend>;
+                                                                      Al::HostTransferBackend>;
   using HaloExchangeNVSHMEMFusedNotify = tensor::HaloExchangeNVSHMEMFusedNotify<
-    DataType, tensor::CUDAAllocator, Al::MPICUDABackend>;
+    DataType, tensor::CUDAAllocator, Al::HostTransferBackend>;
 #endif // DISTCONV_HAS_NVSHMEM
   std::unique_ptr<HaloExchange> m_halo_xch_input;
   std::unique_ptr<HaloExchange> m_halo_xch_d_output;
@@ -968,7 +968,7 @@ class Convolution<cudnn::BackendCUDNN, DataType> {
   BoundaryAttributesV<index_t> m_output_boundary_offsets = 0;
   BoundaryAttributesV<cudaStream_t> m_boundary_streams;
   BoundaryAttributesV<
-    std::shared_ptr<Al::MPICUDABackend::comm_type>> m_boundary_comms;
+    std::shared_ptr<Al::HostTransferBackend::comm_type>> m_boundary_comms;
 
   bool m_enable_profiling;
   cudaEvent_t m_event_comp_start;

--- a/legacy/include/distconv/cudnn/pooling.hpp
+++ b/legacy/include/distconv/cudnn/pooling.hpp
@@ -314,36 +314,36 @@ class Pooling<cudnn::BackendCUDNN, DataType> {
   HaloExchangeMethod m_halo_xch_method;
   using HaloExchange = tensor::HaloExchange<DataType,
                                             tensor::CUDAAllocator,
-                                            Al::MPICUDABackend>;
+                                            Al::HostTransferBackend>;
   using HaloExchangeMPI = tensor::HaloExchangeMPI<DataType,
                                                   tensor::CUDAAllocator,
-                                                  Al::MPICUDABackend>;
+                                                  Al::HostTransferBackend>;
   using HaloExchangeAL = tensor::HaloExchangeAL<DataType,
                                                 tensor::CUDAAllocator,
-                                                Al::MPICUDABackend>;
+                                                Al::HostTransferBackend>;
 #ifdef DISTCONV_HAS_P2P
   using HaloExchangeP2P = tensor::HaloExchangeP2P<DataType,
                                                   tensor::CUDAAllocator,
-                                                  Al::MPICUDABackend>;
+                                                  Al::HostTransferBackend>;
   using HaloExchangeHybrid = tensor::HaloExchangeHybrid<DataType,
                                                         tensor::CUDAAllocator,
-                                                        Al::MPICUDABackend>;
+                                                        Al::HostTransferBackend>;
 #endif // DISTCONV_HAS_P2P
 #ifdef DISTCONV_HAS_NVSHMEM
   using HaloExchangeNVSHMEM = tensor::HaloExchangeNVSHMEM<
-    DataType, tensor::CUDAAllocator, Al::MPICUDABackend>;
+    DataType, tensor::CUDAAllocator, Al::HostTransferBackend>;
 #ifdef DISTCONV_HAS_CUDA_GRAPH
   using HaloExchangeNVSHMEMGraph = tensor::HaloExchangeNVSHMEMGraph<
-    DataType, tensor::CUDAAllocator, Al::MPICUDABackend>;
+    DataType, tensor::CUDAAllocator, Al::HostTransferBackend>;
 #endif // DISTCONV_HAS_CUDA_GRAPH
   using HaloExchangeNVSHMEMDirect = tensor::HaloExchangeNVSHMEMDirect<
-    DataType, tensor::CUDAAllocator, Al::MPICUDABackend>;
+    DataType, tensor::CUDAAllocator, Al::HostTransferBackend>;
   using HaloExchangeNVSHMEMFusedNotify = tensor::HaloExchangeNVSHMEMFusedNotify<
-    DataType, tensor::CUDAAllocator, Al::MPICUDABackend>;
+    DataType, tensor::CUDAAllocator, Al::HostTransferBackend>;
 #endif // DISTCONV_HAS_NVSHMEM
   std::unique_ptr<HaloExchange> m_halo_xch_input;
   std::unique_ptr<HaloExchange> m_halo_xch_d_input;
-  BoundaryAttributesV<std::shared_ptr<Al::MPICUDABackend::comm_type>> m_boundary_comms;
+  BoundaryAttributesV<std::shared_ptr<Al::HostTransferBackend::comm_type>> m_boundary_comms;
 
   template <typename Tensor>
   void setup_pooling_descriptor(const Tensor &input,

--- a/legacy/include/distconv/tensor/shuffle_mpi_cuda_al.hpp
+++ b/legacy/include/distconv/tensor/shuffle_mpi_cuda_al.hpp
@@ -14,7 +14,7 @@ class TensorMPICUDAShufflerAL:
  public:
   TensorMPICUDAShufflerAL(const TensorType &src_tensor,
                           const TensorType &dst_tensor,
-                          Al::MPICUDABackend::comm_type &al_comm,
+                          Al::HostTransferBackend::comm_type &al_comm,
                           DataType *src_buf=nullptr,
                           DataType *dst_buf=nullptr):
       TensorMPICUDAShuffler<DataType>(src_tensor, dst_tensor, src_buf, dst_buf),
@@ -24,7 +24,7 @@ class TensorMPICUDAShufflerAL:
   virtual ~TensorMPICUDAShufflerAL() = default;
 
  protected:
-  Al::MPICUDABackend::comm_type &m_al_comm;
+  Al::HostTransferBackend::comm_type &m_al_comm;
 
   void transfer(const DataType *send_buf,
                 size_t send_buffer_size,
@@ -32,12 +32,12 @@ class TensorMPICUDAShufflerAL:
                 size_t recv_buffer_size,
                 bool is_forward, cudaStream_t stream) override {
     // Assumes stream is the same as m_al_comm.get_stream()
-    std::vector<Al::MPICUDABackend::req_type> requests;
+    std::vector<Al::HostTransferBackend::req_type> requests;
     for (int i = 0; i < this->get_num_peers(); ++i) {
-      requests.push_back(Al::MPICUDABackend::null_req);
+      requests.push_back(Al::HostTransferBackend::null_req);
       auto &req = requests.back();
       auto peer = this->m_peers[i];
-      Al::NonblockingSendRecv<Al::MPICUDABackend, DataType>(
+      Al::NonblockingSendRecv<Al::HostTransferBackend, DataType>(
           send_buf +this->get_send_displs_h(is_forward)[peer],
           this->get_send_counts(is_forward)[peer], peer,
             recv_buf + this->get_recv_displs_h(is_forward)[peer],
@@ -45,7 +45,7 @@ class TensorMPICUDAShufflerAL:
           m_al_comm, req);
     }
     for (auto &req: requests) {
-      Al::Wait<Al::MPICUDABackend>(req);
+      Al::Wait<Al::HostTransferBackend>(req);
     }
   }
 };

--- a/legacy/include/distconv/tensor/shuffle_mpi_cuda_hybrid.hpp
+++ b/legacy/include/distconv/tensor/shuffle_mpi_cuda_hybrid.hpp
@@ -16,7 +16,7 @@ class TensorMPICUDAShufflerHybrid:
   TensorMPICUDAShufflerHybrid(const TensorType &src_tensor,
                               const TensorType &dst_tensor,
                               p2p::P2P &p2p,
-                              Al::MPICUDABackend::comm_type &al_comm,
+                              Al::HostTransferBackend::comm_type &al_comm,
                               DataType *src_buf=nullptr,
                               DataType *dst_buf=nullptr):
       TensorMPICUDAShuffler<DataType>(src_tensor, dst_tensor, src_buf, dst_buf),
@@ -48,7 +48,7 @@ class TensorMPICUDAShufflerHybrid:
 
  protected:
   p2p::P2P &m_p2p;
-  Al::MPICUDABackend::comm_type &m_al_comm;
+  Al::HostTransferBackend::comm_type &m_al_comm;
   p2p::P2P::connection_type *m_conns;
   void **m_peer_addrs[2];
   size_t *m_peer_offsets[2];
@@ -159,7 +159,7 @@ class TensorMPICUDAShufflerHybrid:
                 DataType *recv_buf,
                 size_t recv_buffer_size,
                 bool is_forward, cudaStream_t stream) override {
-    std::vector<Al::MPICUDABackend::req_type> requests;
+    std::vector<Al::HostTransferBackend::req_type> requests;
     int num_peers = this->get_num_peers();
     for (int i = 0; i < num_peers; ++i) {
       auto peer = this->m_peers[i];
@@ -178,9 +178,9 @@ class TensorMPICUDAShufflerHybrid:
                   * sizeof(DataType),
                   m_streams[i]);
       } else {
-        requests.push_back(Al::MPICUDABackend::null_req);
+        requests.push_back(Al::HostTransferBackend::null_req);
         auto &req = requests.back();
-        Al::NonblockingSendRecv<Al::MPICUDABackend, DataType>(
+        Al::NonblockingSendRecv<Al::HostTransferBackend, DataType>(
           send_buf +this->get_send_displs_h(is_forward)[peer],
           this->get_send_counts(is_forward)[peer], peer,
             recv_buf + this->get_recv_displs_h(is_forward)[peer],
@@ -197,7 +197,7 @@ class TensorMPICUDAShufflerHybrid:
     }
     // synchornize the Al transfers
     for (auto &req: requests) {
-      Al::Wait<Al::MPICUDABackend>(req);
+      Al::Wait<Al::HostTransferBackend>(req);
     }
   }
 

--- a/legacy/src/tensor/halo_exchange_cuda.cu
+++ b/legacy/src/tensor/halo_exchange_cuda.cu
@@ -9,7 +9,7 @@ namespace distconv {
 namespace tensor {
 
 template <>
-void HaloExchange<float, CUDAAllocator, Al::MPICUDABackend>::pack_or_unpack(
+void HaloExchange<float, CUDAAllocator, Al::HostTransferBackend>::pack_or_unpack(
     int dim, Side side, int width, cudaStream_t stream,
     void *buf, bool is_pack, bool is_reverse,
     HaloExchangeAccumOp op) {
@@ -19,7 +19,7 @@ void HaloExchange<float, CUDAAllocator, Al::MPICUDABackend>::pack_or_unpack(
 }
 
 template <>
-void HaloExchange<double, CUDAAllocator, Al::MPICUDABackend>::pack_or_unpack(
+void HaloExchange<double, CUDAAllocator, Al::HostTransferBackend>::pack_or_unpack(
     int dim, Side side, int width, cudaStream_t stream,
     void *buf, bool is_pack, bool is_reverse,
     HaloExchangeAccumOp op) {

--- a/legacy/src/tensor/halo_exchange_cuda_nvshmem.cu
+++ b/legacy/src/tensor/halo_exchange_cuda_nvshmem.cu
@@ -12,7 +12,7 @@ namespace tensor {
 
 #define DEFINE_FUNC(TYPE)                                               \
   template <>                                                           \
-  void HaloExchangeNVSHMEMDirect<TYPE, CUDAAllocator, Al::MPICUDABackend>::pack_and_put( \
+  void HaloExchangeNVSHMEMDirect<TYPE, CUDAAllocator, Al::HostTransferBackend>::pack_and_put( \
       int dim, Side side, int width, cudaStream_t stream,               \
       void *buf, bool is_reverse,                                       \
       void *dst, int peer) {                                            \
@@ -26,7 +26,7 @@ LIST_OF_TYPES
 
 #define DEFINE_FUNC(TYPE)                                               \
   template <>                                                           \
-  void HaloExchangeNVSHMEMFusedNotify<TYPE, CUDAAllocator, Al::MPICUDABackend>:: \
+  void HaloExchangeNVSHMEMFusedNotify<TYPE, CUDAAllocator, Al::HostTransferBackend>:: \
   pack_put_notify(                                                      \
       int dim, Side side, int width, cudaStream_t stream,               \
       void *buf, bool is_reverse,                                       \
@@ -43,7 +43,7 @@ LIST_OF_TYPES
 
 #define DEFINE_FUNC(TYPE)                                               \
   template <>                                                           \
-  void HaloExchangeNVSHMEMFusedNotify<TYPE, CUDAAllocator, Al::MPICUDABackend>:: \
+  void HaloExchangeNVSHMEMFusedNotify<TYPE, CUDAAllocator, Al::HostTransferBackend>:: \
   wait_and_unpack(                                                      \
       int dim, Side side, int width, cudaStream_t stream,               \
       void *buf, bool is_reverse, HaloExchangeAccumOp op) {             \

--- a/legacy/tests/tensor/test_halo_exchange_cuda.cu
+++ b/legacy/tests/tensor/test_halo_exchange_cuda.cu
@@ -505,12 +505,12 @@ int test_halo_exchange(const Array<ND> &shape,
     dims.push_back(i);
   cudaStream_t stream_main;
   cudaStreamCreate(&stream_main);
-  BoundaryAttributesV<std::shared_ptr<Al::MPICUDABackend::comm_type>> comms;
+  BoundaryAttributesV<std::shared_ptr<Al::HostTransferBackend::comm_type>> comms;
   apply_to_spatial_sides(ND, [&](int i, Side side) {
       cudaStream_t stream;
       cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking);
       comms(i, side) =
-          std::make_shared<Al::MPICUDABackend::comm_type>(
+          std::make_shared<Al::HostTransferBackend::comm_type>(
               tensor.get_locale().get_comm(), stream);
     });
   for (int i = 0; i < ND - 2; ++i) {
@@ -519,7 +519,7 @@ int test_halo_exchange(const Array<ND> &shape,
     }
   }
 
-  HaloExchange<DataType, CUDAAllocator, Al::MPICUDABackend> *halo_exc = nullptr;
+  HaloExchange<DataType, CUDAAllocator, Al::HostTransferBackend> *halo_exc = nullptr;
 #ifdef DISTCONV_HAS_P2P
   p2p::P2P p2p(MPI_COMM_WORLD);
 #endif
@@ -527,47 +527,47 @@ int test_halo_exchange(const Array<ND> &shape,
   switch (method) {
     case HaloExchangeMethod::MPI:
       halo_exc = new HaloExchangeMPI<
-        DataType, CUDAAllocator, Al::MPICUDABackend>(tensor);
+        DataType, CUDAAllocator, Al::HostTransferBackend>(tensor);
       util::MPIRootPrintStreamInfo() << "HaloExchangeMPI created";
       break;
     case HaloExchangeMethod::AL:
       halo_exc = new HaloExchangeAL<DataType, CUDAAllocator,
-                                    Al::MPICUDABackend>(tensor);
+                                    Al::HostTransferBackend>(tensor);
       util::MPIRootPrintStreamInfo() << "HaloExchangeAL created";
       break;
 #ifdef DISTCONV_HAS_P2P
     case HaloExchangeMethod::P2P:
       halo_exc = new HaloExchangeP2P<
-        DataType, CUDAAllocator, Al::MPICUDABackend>(tensor, p2p);
+        DataType, CUDAAllocator, Al::HostTransferBackend>(tensor, p2p);
       util::MPIRootPrintStreamInfo() << "HaloExchangeP2P created";
       break;
     case HaloExchangeMethod::HYBRID:
       halo_exc = new HaloExchangeHybrid<DataType, CUDAAllocator,
-                                        Al::MPICUDABackend>(tensor, p2p);
+                                        Al::HostTransferBackend>(tensor, p2p);
       util::MPIRootPrintStreamInfo() << "HaloExchangeHybrid created";
       break;
 #endif // DISTCONV_HAS_P2P
 #ifdef DISTCONV_HAS_NVSHMEM
     case HaloExchangeMethod::NVSHMEM:
       halo_exc = new HaloExchangeNVSHMEM<DataType, CUDAAllocator,
-                                         Al::MPICUDABackend>(tensor);
+                                         Al::HostTransferBackend>(tensor);
       util::MPIRootPrintStreamInfo() << "HaloExchangeNVSHMEM created";
       break;
 #ifdef DISTCONV_HAS_CUDA_GRAPH
     case HaloExchangeMethod::NVSHMEM_GRAPH:
       halo_exc = new HaloExchangeNVSHMEMGraph<DataType, CUDAAllocator,
-                                              Al::MPICUDABackend>(tensor);
+                                              Al::HostTransferBackend>(tensor);
       util::MPIRootPrintStreamInfo() << "HaloExchangeNVSHMEMGraph created";
       break;
 #endif // DISTCONV_HAS_CUDA_GRAPH
     case HaloExchangeMethod::NVSHMEM_DIRECT:
       halo_exc = new HaloExchangeNVSHMEMDirect<DataType, CUDAAllocator,
-                                               Al::MPICUDABackend>(tensor);
+                                               Al::HostTransferBackend>(tensor);
       util::MPIRootPrintStreamInfo() << "HaloExchangeNVSHMEMDirect created";
       break;
     case HaloExchangeMethod::NVSHMEM_FUSED_NOTIFY:
       halo_exc = new HaloExchangeNVSHMEMFusedNotify<DataType, CUDAAllocator,
-                                                    Al::MPICUDABackend>(tensor);
+                                                    Al::HostTransferBackend>(tensor);
       util::MPIRootPrintStreamInfo() << "HaloExchangeNVSHMEMFusedNotify created";
       break;
 #endif // DISTCONV_HAS_NVSHMEM
@@ -676,12 +676,12 @@ int test_halo_exchange_reverse(const Array<ND> &shape,
     dims.push_back(i);
   cudaStream_t stream_main;
   cudaStreamCreate(&stream_main);
-  SpatialAttributes<ND, std::shared_ptr<Al::MPICUDABackend::comm_type>> comms;
+  SpatialAttributes<ND, std::shared_ptr<Al::HostTransferBackend::comm_type>> comms;
   apply_to_spatial_sides<ND>([&](int i, Side side) {
       cudaStream_t stream;
       cudaStreamCreate(&stream);
       comms(i, side) =
-          std::make_shared<Al::MPICUDABackend::comm_type>(
+          std::make_shared<Al::HostTransferBackend::comm_type>(
               tensor.get_locale().get_comm(), stream);
     });
   for (int i = 0; i < ND - 2; ++i) {
@@ -690,7 +690,7 @@ int test_halo_exchange_reverse(const Array<ND> &shape,
     }
   }
 
-  HaloExchange<DataType, CUDAAllocator, Al::MPICUDABackend> *halo_exc = nullptr;
+  HaloExchange<DataType, CUDAAllocator, Al::HostTransferBackend> *halo_exc = nullptr;
 #ifdef DISTCONV_HAS_P2P
   p2p::P2P p2p(MPI_COMM_WORLD);
 #endif // DISTCONV_HAS_P2P
@@ -698,47 +698,47 @@ int test_halo_exchange_reverse(const Array<ND> &shape,
   switch (method) {
     case HaloExchangeMethod::MPI:
       halo_exc = new HaloExchangeMPI<DataType, CUDAAllocator,
-                                     Al::MPICUDABackend>(tensor);
+                                     Al::HostTransferBackend>(tensor);
       util::MPIRootPrintStreamInfo() << "HaloExchangeMPI created";
       break;
     case HaloExchangeMethod::AL:
       halo_exc = new HaloExchangeAL<DataType, CUDAAllocator,
-                                    Al::MPICUDABackend>(tensor);
+                                    Al::HostTransferBackend>(tensor);
       util::MPIRootPrintStreamInfo() << "HaloExchangeAL created";
       break;
 #ifdef DISTCONV_HAS_P2P
     case HaloExchangeMethod::P2P:
       halo_exc = new HaloExchangeP2P<DataType, CUDAAllocator,
-                                     Al::MPICUDABackend>(tensor, p2p);
+                                     Al::HostTransferBackend>(tensor, p2p);
       util::MPIRootPrintStreamInfo() << "HaloExchangeP2P created";
       break;
     case HaloExchangeMethod::HYBRID:
       halo_exc = new HaloExchangeHybrid<DataType, CUDAAllocator,
-                                        Al::MPICUDABackend>(tensor, p2p);
+                                        Al::HostTransferBackend>(tensor, p2p);
       util::MPIRootPrintStreamInfo() << "HaloExchangeHybrid created";
       break;
 #endif // DISTCONV_HAS_P2P
 #ifdef DISTCONV_HAS_NVSHMEM
     case HaloExchangeMethod::NVSHMEM:
       halo_exc = new HaloExchangeNVSHMEM<DataType, CUDAAllocator,
-                                         Al::MPICUDABackend>(tensor);
+                                         Al::HostTransferBackend>(tensor);
       util::MPIRootPrintStreamInfo() << "HaloExchangeNVSHMEM created";
       break;
 #ifdef DISTCONV_HAS_CUDA_GRAPH
     case HaloExchangeMethod::NVSHMEM_GRAPH:
       halo_exc = new HaloExchangeNVSHMEMGraph<DataType, CUDAAllocator,
-                                              Al::MPICUDABackend>(tensor);
+                                              Al::HostTransferBackend>(tensor);
       util::MPIRootPrintStreamInfo() << "HaloExchangeNVSHMEMGraph created";
       break;
 #endif // DISTCONV_HAS_CUDA_GRAPH
     case HaloExchangeMethod::NVSHMEM_DIRECT:
       halo_exc = new HaloExchangeNVSHMEMDirect<DataType, CUDAAllocator,
-                                               Al::MPICUDABackend>(tensor);
+                                               Al::HostTransferBackend>(tensor);
       util::MPIRootPrintStreamInfo() << "HaloExchangeNVSHMEMDirect created";
       break;
     case HaloExchangeMethod::NVSHMEM_FUSED_NOTIFY:
       halo_exc = new HaloExchangeNVSHMEMFusedNotify<DataType, CUDAAllocator,
-                                                    Al::MPICUDABackend>(tensor);
+                                                    Al::HostTransferBackend>(tensor);
       util::MPIRootPrintStreamInfo() << "HaloExchangeNVSHMEMFusedNotify created";
       break;
 #endif // DISTCONV_HAS_NVSHMEM

--- a/legacy/tests/tensor/test_tensor_mpi_cuda_shuffle.cu
+++ b/legacy/tests/tensor/test_tensor_mpi_cuda_shuffle.cu
@@ -21,7 +21,7 @@ using DataType = float;
 
 using namespace distconv;
 using namespace distconv::tensor;
-using AlBackend = Al::MPICUDABackend;
+using AlBackend = Al::HostTransferBackend;
 
 MPI_Comm local_comm;
 int local_comm_size;


### PR DESCRIPTION
The main significant change is the replacement of "MPICUDABackend" with the more aptly named "HostTransferBackend".