### PR TITLE
Support mean squared error layers

### DIFF
--- a/legacy/include/distconv/cudnn/CMakeLists.txt
+++ b/legacy/include/distconv/cudnn/CMakeLists.txt
@@ -5,6 +5,7 @@ h2_set_full_path(THIS_DIR_HEADERS
   pooling.hpp
   relu.hpp
   leaky_relu.hpp
+  mean_squared_error.hpp
   softmax.hpp
   cross_entropy.hpp
   )

--- a/legacy/include/distconv/cudnn/backend.hpp
+++ b/legacy/include/distconv/cudnn/backend.hpp
@@ -569,3 +569,4 @@ class BackendCUDNN {
 #include "distconv/cudnn/batchnorm.hpp"
 #include "distconv/cudnn/softmax.hpp"
 #include "distconv/cudnn/cross_entropy.hpp"
+#include "distconv/cudnn/mean_squared_error.hpp"

--- a/legacy/include/distconv/cudnn/mean_squared_error.hpp
+++ b/legacy/include/distconv/cudnn/mean_squared_error.hpp
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "distconv/cudnn/backend.hpp"
+
+#include <Al.hpp>
+
+#include <memory>
+
+namespace distconv {
+
+template <>
+class MeanSquaredError<cudnn::BackendCUDNN> {
+ public:
+  MeanSquaredError(cudnn::BackendCUDNN &backend): m_be(backend) {}
+
+  ~MeanSquaredError() = default;
+
+  MeanSquaredError &operator=(const MeanSquaredError &x) {
+    assert_always(&m_be == &x.m_be);
+    return *this;
+  }
+
+  template <typename Tensor>
+  void setup(const Tensor &x_pred, const Tensor &x_truth,
+             const Tensor &y) {
+    // Both tensors must have the same process grid
+    assert_eq(x_pred.get_locale_shape(),
+              x_truth.get_locale_shape());
+    // Must have the same global and locale shapes
+    assert_eq(x_pred.get_shape(), x_truth.get_shape());
+    assert_eq(x_pred.get_local_shape(), x_truth.get_local_shape());
+    // No halo for simplicity
+    assert_eq(x_pred.get_local_shape(),
+              x_pred.get_local_real_shape());
+    assert_eq(x_truth.get_local_shape(),
+              x_truth.get_local_real_shape());
+    // y is a 1-d vector of length as long as the number of samples
+    assert_eq(x_pred.get_local_shape()[-1], y.get_local_shape()[-1]);
+    assert_eq(y.get_local_shape()[-1], y.get_local_size());
+    // same process grid
+    assert_eq(x_pred.get_locale_shape(), y.get_locale_shape());
+    // no partitioning except for the sample dimension
+    assert_eq(y.get_split_shape().reduce_prod(), y.get_split_shape()[-1]);
+    assert_eq(y.get_locale_shape()[-1], y.get_split_shape()[-1]);
+
+    auto loc_shape = x_pred.get_locale_shape();
+    m_num_procs_per_sample = loc_shape.reduce_sum() / loc_shape[-1];
+    if (m_num_procs_per_sample > 1) {
+      auto sample_loc = x_pred.get_sub_locale_except_dim(-1);
+      m_al.reset(new Al::NCCLBackend::comm_type(
+          sample_loc.get_comm(), m_be.get_stream()));
+    }
+  }
+
+  template <typename Tensor>
+  int forward(const Tensor &x_pred, const Tensor &x_truth, Tensor &y);
+
+  template <typename Tensor>
+  int backward(const Tensor &x_pred, const Tensor &x_truth,
+               Tensor &dy, Tensor &dx_pred,
+               Tensor &dx_truth);
+
+ protected:
+  cudnn::BackendCUDNN &m_be;
+  int m_num_procs_per_sample;
+  std::unique_ptr<Al::NCCLBackend::comm_type> m_al;
+};
+
+} // namespace distconv

--- a/legacy/include/distconv/layers.hpp
+++ b/legacy/include/distconv/layers.hpp
@@ -137,4 +137,10 @@ class CrossEntropy {
   CrossEntropy(Backend &backend);
 };
 
+template <typename Backend>
+class MeanSquaredError {
+ public:
+  MeanSquaredError(Backend &backend);
+};
+
 } // namespace distconv

--- a/legacy/src/cudnn/CMakeLists.txt
+++ b/legacy/src/cudnn/CMakeLists.txt
@@ -5,6 +5,7 @@ h2_set_full_path(THIS_DIR_CU_SOURCES
   pooling.cu
   batchnorm.cu
   leaky_relu.cu
+  mean_squared_error.cu
   softmax.cu
   cross_entropy.cu
   )

--- a/legacy/src/cudnn/mean_squared_error.cu
+++ b/legacy/src/cudnn/mean_squared_error.cu
@@ -1,0 +1,209 @@
+#include "distconv/cudnn/mean_squared_error.hpp"
+#include "distconv/util/util_mpi.hpp"
+#include "distconv/util/util_cuda.hpp"
+#include "distconv/tensor/algorithms_cuda.hpp"
+
+#include <limits>
+
+#include <cub/block/block_reduce.cuh>
+
+using distconv::tensor::LocaleMPI;
+using distconv::tensor::CUDAAllocator;
+
+template <typename DataType>
+using TensorCUDA = distconv::tensor::Tensor<DataType, LocaleMPI, CUDAAllocator>;
+using MeanSquaredErrorCUDNN = distconv::MeanSquaredError<distconv::cudnn::BackendCUDNN>;
+
+namespace distconv {
+namespace mean_squared_error {
+
+/*
+  - gridDim.y == number of samples
+  - Each sample is taken care by gridDim.x blocks
+*/
+template <typename DataType, int BLOCK_SIZE>
+__global__ void fp_local(const DataType * __restrict__ prediction,
+                         const DataType * __restrict__ ground_truth,
+                         DataType * __restrict__ y,
+                         const index_t sample_size,
+                         const index_t sample_spatial_size,
+                         const index_t sample_channel_size,
+                         int thread_work_size) {
+  const int tid = threadIdx.x;
+  const int sample_idx = blockIdx.y;
+
+  prediction += sample_idx * sample_size;
+  ground_truth += sample_idx * sample_size;
+
+  index_t offset = tid + blockIdx.x * BLOCK_SIZE;
+  const int offset_stride = BLOCK_SIZE * gridDim.x;
+  const index_t offset_limit = min(
+      sample_size, offset + offset_stride * thread_work_size);
+
+  auto psum = DataType(0.);
+  for (; offset < offset_limit; offset += offset_stride) {
+    const DataType x = prediction[offset];
+    const DataType xhat = ground_truth[offset];
+    const DataType err = x - xhat;
+    psum += err * err;
+  }
+
+  using BlockReduce = cub::BlockReduce<DataType, BLOCK_SIZE>;
+  __shared__ typename BlockReduce::TempStorage temp_storage;
+  psum = BlockReduce(temp_storage).Sum(psum) / sample_size;
+
+  if (tid == 0) {
+    atomic_add(&y[sample_idx], psum);
+  }
+}
+
+
+/*
+  - gridDim.y == number of samples
+  - Each sample is taken care by gridDim.x blocks
+*/
+template <typename DataType, int BLOCK_SIZE>
+__global__ void bp_local(const DataType * __restrict__ x_pred,
+                         const DataType * __restrict__ x_truth,
+                         const DataType * __restrict__ dy,
+                         DataType * __restrict__ dx_pred,
+                         DataType * __restrict__ dx_truth,
+                         const index_t sample_size,
+                         const index_t sample_spatial_size,
+                         const index_t sample_channel_size,
+                         int thread_work_size) {
+  const int tid = threadIdx.x;
+  const int sample_idx = blockIdx.y;
+
+  x_pred += sample_idx * sample_size;
+  dx_pred += sample_idx * sample_size;
+  x_truth += sample_idx * sample_size;
+  dx_truth += sample_idx * sample_size;
+
+  index_t offset = tid + blockIdx.x * BLOCK_SIZE;
+  const int offset_stride = BLOCK_SIZE * gridDim.x;
+  const index_t offset_limit = min(
+      sample_size, offset + offset_stride * thread_work_size);
+
+  const auto dy_sample = dy[sample_idx];
+  const DataType scale = static_cast<DataType>(DataType(2) / sample_size);
+  for (; offset < offset_limit; offset += offset_stride) {
+    const DataType x = x_pred[offset];
+    const DataType xhat = x_truth[offset];
+    const DataType err = x - xhat;
+    dx_pred[offset] = scale * err * dy_sample;
+    dx_truth[offset] = - scale * err * dy_sample;
+  }
+}
+
+} // namespace mean_squared_error
+
+template <typename Tensor>
+int MeanSquaredErrorCUDNN::forward(const Tensor &x_pred, const Tensor &x_truth,
+                                   Tensor &y) {
+  using DataType = typename Tensor::data_type;
+  util::MPIPrintStreamDebug()
+      << "Mean squared error FP: " << x_pred << ", "
+      << x_truth << ", " << y;
+
+  constexpr int block_size = 256;
+  constexpr int thread_work_size = 8;
+
+  // Assumes no halo for simplicity
+  assert_eq(x_pred.get_local_size(), x_pred.get_local_real_size());
+  assert_eq(x_truth.get_local_size(), x_truth.get_local_real_size());
+
+  const auto num_samples = x_pred.get_local_shape()[-1];
+
+  if (num_samples == 0) return 0;
+
+  y.zero(m_be.get_stream());
+
+  if (x_pred.get_local_size() > 0) {
+    auto sample_size = x_pred.get_local_size() / num_samples;
+    auto num_blocks_per_sample = util::ceil(
+        sample_size, (index_t)block_size * thread_work_size);
+
+    dim3 bdim(block_size);
+    dim3 gdim(num_blocks_per_sample, num_samples);
+
+    const auto sample_channel_size = x_pred.get_local_shape()[x_pred.get_num_spatial_dims()];
+    const auto sample_spatial_size = sample_size / sample_channel_size;
+    assert_eq(sample_channel_size*sample_spatial_size, sample_size);
+
+    mean_squared_error::fp_local<DataType, block_size>
+        <<<gdim, bdim, 0, m_be.get_stream()>>>(
+            x_pred.get_const_buffer(), x_truth.get_const_buffer(),
+            y.get_buffer(), sample_size, sample_spatial_size,
+            sample_channel_size, thread_work_size);
+  }
+
+  if (m_num_procs_per_sample > 1) {
+    Al::Allreduce<Al::NCCLBackend, DataType>(
+        y.get_buffer(), num_samples,
+        Al::ReductionOperator::sum, *m_al.get());
+  }
+
+  return 0;
+}
+
+template <typename Tensor>
+int MeanSquaredErrorCUDNN::backward(const Tensor &x_pred, const Tensor &x_truth,
+                                    Tensor &dy, Tensor &dx_pred,
+                                    Tensor &dx_truth) {
+  using DataType = typename Tensor::data_type;
+  util::MPIPrintStreamDebug()
+      << "Mean squared error BP: " << dy << ", " << dx_pred << ", " << dx_truth;
+
+  if (m_num_procs_per_sample > 1) {
+    const auto num_samples = x_pred.get_local_shape()[-1];
+    Al::Bcast<Al::NCCLBackend, DataType>(
+        dy.get_buffer(), num_samples, 0,
+        *m_al.get());
+  }
+
+  constexpr int block_size = 256;
+  constexpr int thread_work_size = 8;
+
+  // Assumes no halo for simplicity
+  assert_eq(dx_pred.get_local_size(), dx_pred.get_local_real_size());
+  assert_eq(dx_truth.get_local_size(), dx_truth.get_local_real_size());
+
+  if (x_pred.get_local_size() == 0) return 0;
+
+  auto num_samples = x_pred.get_local_shape()[-1];
+  auto sample_size = x_pred.get_local_size() / num_samples;
+  auto num_blocks_per_sample = util::ceil(
+      sample_size, (index_t)block_size * thread_work_size);
+
+  dim3 bdim(block_size);
+  dim3 gdim(num_blocks_per_sample, num_samples);
+
+  const auto sample_channel_size = x_pred.get_local_shape()[x_pred.get_num_spatial_dims()];
+  const auto sample_spatial_size = sample_size / sample_channel_size;
+  assert_eq(sample_channel_size*sample_spatial_size, sample_size);
+
+  mean_squared_error::bp_local<DataType, block_size>
+      <<<gdim, bdim, 0, m_be.get_stream()>>>(
+          x_pred.get_const_buffer(), x_truth.get_const_buffer(),
+          dy.get_const_buffer(),
+          dx_pred.get_buffer(), dx_truth.get_buffer(),
+          sample_size, sample_spatial_size, sample_channel_size,
+          thread_work_size);
+  return 0;
+}
+
+#define PROTO(T)                                                        \
+  template int MeanSquaredErrorCUDNN::forward<TensorCUDA<T>>(           \
+      const TensorCUDA<T> &x_pred, const TensorCUDA<T> &x_truth,        \
+      TensorCUDA<T> &y);                                                \
+  template int MeanSquaredErrorCUDNN::backward<TensorCUDA<T>>(          \
+      const TensorCUDA<T> &x_pred, const TensorCUDA<T> &x_truth,        \
+      TensorCUDA<T> &dy, TensorCUDA<T> &dx_pred,                        \
+      TensorCUDA<T> &dx_truth);
+
+PROTO(float)
+PROTO(double)
+#undef PROTO
+
+} // namespace distconv


### PR DESCRIPTION
This PR implements mean squared error layers for Distconv-enabled networks. The architectural requirements of mean squared error layers are the same as those of cross-entropy loss layers.