### PR TITLE
Quick hack to support 1x1 convolution with stride 2

### DIFF
--- a/legacy/include/distconv/distconv.hpp
+++ b/legacy/include/distconv/distconv.hpp
@@ -88,6 +88,13 @@ void get_halo_sizes(const tensor::Tensor<DataType, Locale, Allocator> &input,
       const auto offset_from_next_stride = (s - (yp1 % s)) % s;
       fwd_halo_send[i] = radius - offset_from_next_stride;
     }
+
+    // Make sure halo sizes are non-negative
+    fwd_halo_send[i] = std::max(fwd_halo_send[i], 0);
+    fwd_halo_recv[i] = std::max(fwd_halo_recv[i], 0);
+    bwd_halo_send[i] = std::max(bwd_halo_send[i], 0);
+    bwd_halo_recv[i] = std::max(bwd_halo_recv[i], 0);
+
   }
 }
 


### PR DESCRIPTION
I experience cuDNN errors when attempting to run 1x1 or 1x1x1 convolution with a stride of 2. It turns out cuDNN doesn't seem to support non-contiguous data for the backward filter computation. I've been able to work around this issue by making sure the halo sizes are non-negative (we previously had halo sizes of -1 when boundary positions were skipped by the stride). This passes gradient checking in LBANN when (and only when) the tensor dimensions are nice, e.g. powers of 2.