### PR TITLE
Make the modifies_tensors consistent with the comments on #58.

### DIFF
--- a/legacy/include/distconv/tensor/halo_cuda.hpp
+++ b/legacy/include/distconv/tensor/halo_cuda.hpp
@@ -655,9 +655,9 @@ void TraverseHalo(Tensor &tensor, int dim,
                   bool inner, OpType op,
                   cudaStream_t s) {
   // ConstDataType is const DataType if the operation only reads the tensor.
-  using ConstDataType = typename std::conditional<
-    OpType::modifies_tensor, typename Tensor::data_type,
-    typename std::add_const<typename Tensor::data_type>::type>::type;
+  using ConstDataType = std::conditional_t<OpType::modifies_tensor,
+                                           typename Tensor::data_type,
+                                           typename Tensor::const_data_type>;
   const int num_dims = tensor.get_num_dims();
   int available_halo_width = tensor.get_halo_width(dim);
   assert_always(halo_width <= available_halo_width);

--- a/legacy/include/distconv/tensor/halo_packing_cuda.hpp
+++ b/legacy/include/distconv/tensor/halo_packing_cuda.hpp
@@ -65,6 +65,7 @@ struct PackFunctor {
   static constexpr bool has_pre_grid = false;
   static constexpr bool has_post_grid = false;
   static constexpr bool modifies_tensor = true;
+
   DataType *m_buf;
   PackFunctor(DataType *buf): m_buf(buf) {}
   template <typename T> __device__
@@ -149,7 +150,8 @@ struct PackAndPutBlockFunctor {
   static constexpr HaloTraversalOpGroup group = HaloTraversalOpGroup::BLOCK;
   static constexpr bool has_pre_grid = false;
   static constexpr bool has_post_grid = false;
-  static constexpr bool modifies_tensor = true;
+  static constexpr bool modifies_tensor = false;
+
   DataType *m_buf;
   DataType *m_dst;
   int m_peer;
@@ -189,7 +191,8 @@ struct PackPutNotifyBlockFunctor {
   static constexpr HaloTraversalOpGroup group = HaloTraversalOpGroup::BLOCK;
   static constexpr bool has_pre_grid = false;
   static constexpr bool has_post_grid = true;
-  static constexpr bool modifies_tensor = true;
+  static constexpr bool modifies_tensor = false;
+
   DataType *m_buf;
   DataType *m_dst;
   int m_peer;
@@ -240,6 +243,7 @@ struct WaitAndUnpackFunctor {
   static constexpr bool has_pre_grid = true;
   static constexpr bool has_post_grid = false;
   static constexpr bool modifies_tensor = true;
+
   DataType *m_buf;
   util::nvshmem::PairwiseSyncDevice m_sync;
   WaitAndUnpackFunctor(DataType *buf, util::nvshmem::PairwiseSync &sync):

--- a/legacy/include/distconv/tensor/tensor.hpp
+++ b/legacy/include/distconv/tensor/tensor.hpp
@@ -48,6 +48,7 @@ class Tensor: public AbstractTensor {
  public:
 
   using data_type = DataType;
+  using const_data_type = DataType const;
   using locale_type = Locale;
   using allocator_type = Allocator;
 

--- a/legacy/src/tensor/tensor_mpi_cuda.cu
+++ b/legacy/src/tensor/tensor_mpi_cuda.cu
@@ -20,6 +20,7 @@ struct ClearHaloFunctor {
   static constexpr bool has_pre_grid = false;
   static constexpr bool has_post_grid = false;
   static constexpr bool modifies_tensor = true;
+
   ClearHaloFunctor() {}
   __device__ void operator()(DataType &x, size_t) {
     x = DataType(0);


### PR DESCRIPTION
I think this is an NVCC issue where it's not "forcing" the "suspended"
type held in the `std::add_const` object at the right time. This is
definitely a side-step, not a true fix.

This change also assumes that the Op's DataType matches the Tensor's
DataType in the calling code.

Pinging @szaman19.