### PR TITLE
Debugging Distconv with NVSHMEM

### DIFF
--- a/cmake/modules/FindNVSHMEM.cmake
+++ b/cmake/modules/FindNVSHMEM.cmake
@@ -71,10 +71,12 @@ mark_as_advanced(FORCE NVSHMEM_LIBRARY)
 if (NVSHMEM_FOUND)
   set_property(TARGET cuda::toolkit APPEND PROPERTY
     INTERFACE_LINK_LIBRARIES ${CUDA_cudadevrt_LIBRARY})
+  # Build static libraries to get around a bug in NVSHMEM
+  set(BUILD_SHARED_LIBS OFF)
   # Workaround for separable compilation with cooperative threading. see
   # https://stackoverflow.com/questions/53492528/cooperative-groupsthis-grid-causes-any-cuda-api-call-to-return-unknown-erro.
   # Adding this to INTERFACE_COMPILE_OPTIONS does not seem to solve the problem.
   # It seems that CMake does not add necessary options for device linking when cuda_add_executable/library is NOT used. See also
   # https://github.com/dealii/dealii/pull/5405
-  string(APPEND CMAKE_CUDA_FLAGS "-gencode arch=compute_70,code=sm_70")
+  string(APPEND CMAKE_CUDA_FLAGS "-gencode arch=compute_70,code=compute_70")
 endif ()

--- a/legacy/include/distconv/tensor/allreduce_nvshmem.hpp
+++ b/legacy/include/distconv/tensor/allreduce_nvshmem.hpp
@@ -53,7 +53,7 @@ struct AllreduceNVSHMEMDevice {
       // Inter-device reduction
       for (int i = 0; i < m_num_steps; ++i) {
         int peer = m_pid ^ (1 << i);
-        put_nbi(tmp_buf + 1, tmp_buf, 1, peer);
+        util::nvshmem::put_nbi(tmp_buf + 1, tmp_buf, 1, peer);
         m_sync.sync(peer, true, true, st, sync_idx + i);
         tmp_buf[1] += tmp_buf[0];
         ++tmp_buf;

--- a/legacy/include/distconv/util/nvshmem.hpp
+++ b/legacy/include/distconv/util/nvshmem.hpp
@@ -9,6 +9,7 @@
 #ifndef NVSHMEM_TARGET
 #define NVSHMEM_TARGET
 #endif
+#define NVSHMEM_USE_NCCL
 #include "nvshmem.h"
 #include "nvshmemx.h"
 #endif // DISTCONV_HAS_NVSHMEM
@@ -217,7 +218,7 @@ DEFINE_PUT(long)
 
 #endif // __NVCC__
 
-// Set the team to all possible PEs. May affect correctness but builds succesfully 
+// Set the team to all possible PEs. May affect correctness but builds succesfully
 #define DEFINE_SUM_TO_ALL(TYPE)                                         \
   inline void sum_to_all_on_stream(TYPE *target, const TYPE *source, int nreduce, \
                                    int PE_start, int logPE_stride, int PE_size, \


### PR DESCRIPTION
These are miscellaneous changes needed to get distconv working with NVSHMEM 2.2:
- Build static libraries when NVSHMEM is detected. There are subtle bugs with CUDA constant memory if we build a shared library.
- Define the `NVSHMEM_USE_NCCL` macro before including the NVSHMEM headers. NVSHMEM 2.2 seems to be missing a config header file.

With these changes and the work in https://github.com/LLNL/lbann/pull/1976, I can run distconv using NVSHMEM for the halo exchange.