### PR TITLE
[DistConv] Add proxy classes to pack/unpack from/to non-fully-packed tensors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,9 +133,6 @@ if (CMAKE_CXX_COMPILER_ID MATCHES ".*Clang"
   # PREPEND the options.
   set(CMAKE_CXX_FLAGS "${H2_CMAKE_CXX_FLAGS_STR} ${CMAKE_CXX_FLAGS}")
 
-  # Disable all optimization in debug.
-  #list(APPEND CMAKE_CXX_FLAGS_DEBUG -O0)
-
 else ()
 
   message(NOTICE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES ".*Clang"
   set(CMAKE_CXX_FLAGS "${H2_CMAKE_CXX_FLAGS_STR} ${CMAKE_CXX_FLAGS}")
 
   # Disable all optimization in debug.
-  list(APPEND CMAKE_CXX_FLAGS_DEBUG -O0)
+  #list(APPEND CMAKE_CXX_FLAGS_DEBUG -O0)
 
 else ()
 

--- a/include/h2/gpu/rocm/runtime.hpp
+++ b/include/h2/gpu/rocm/runtime.hpp
@@ -9,6 +9,7 @@
 #define H2_INCLUDE_H2_GPU_ROCM_RUNTIME_HPP_INCLUDED
 
 #include <hip/hip_runtime.h>
+#include <sstream>
 
 #define H2_CHECK_HIP(CMD)                                                      \
     do                                                                         \

--- a/include/h2/utils/Error.hpp
+++ b/include/h2/utils/Error.hpp
@@ -44,7 +44,7 @@
  *                `false`.
  *  @param ... The arguments to pass to the exception.
  */
-#define H2_ASSERT_MSG(cond, excptn, ...)                                       \
+#define H2_ASSERT(cond, excptn, ...)                                           \
     if (!(cond))                                                               \
         throw excptn(__VA_ARGS__);
 

--- a/include/h2/utils/IntegerMath.hpp
+++ b/include/h2/utils/IntegerMath.hpp
@@ -1,0 +1,239 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "Error.hpp"
+#include "h2/meta/Core.hpp"
+#include "h2_config.hpp"
+
+#include <cstdint>
+#include <stdexcept>
+
+// TODO: Move this elsewhere.
+#if defined H2_HAS_GPU
+
+#if (defined __HIP_DEVICE_COMPILE__ && __HIP_DEVICE_COMPILE__)
+#define H2_GPU_DEVICE_COMPILING 1
+#else
+#define H2_GPU_DEVICE_COMPILING 0
+#endif
+
+#endif // H2_HAS_GPU
+
+// TODO: Move these defines elsewhere
+#if H2_GPU_DEVICE_COMPILING
+#include "h2/gpu/runtime.hpp"
+#define H2_GPU_DEVICE __device__
+#define H2_GPU_FORCE_INLINE __forceinline__
+#define H2_GPU_HOST __host__
+#define H2_GPU_HOST_DEVICE __host__ __device__
+#else
+#define H2_GPU_DEVICE
+#define H2_GPU_FORCE_INLINE inline
+#define H2_GPU_HOST
+#define H2_GPU_HOST_DEVICE
+#endif
+
+namespace h2
+{
+
+// FIXME (trb 03/16/2023): These should continue migrating elsewhere,
+// perhaps to the meta directory?
+template <typename T>
+struct IntegerTraits;
+
+template <>
+struct IntegerTraits<int32_t>
+{
+    using type = int32_t;
+    using signed_type = int32_t;
+    using unsigned_type = uint32_t;
+    static constexpr int nbits = 32;
+};
+
+template <>
+struct IntegerTraits<uint32_t>
+{
+    using type = uint32_t;
+    using signed_type = int32_t;
+    using unsigned_type = uint32_t;
+    static constexpr int nbits = 32;
+};
+
+template <>
+struct IntegerTraits<int64_t>
+{
+    using type = int64_t;
+    using signed_type = int64_t;
+    using unsigned_type = uint64_t;
+    static constexpr int nbits = 64;
+};
+
+template <>
+struct IntegerTraits<uint64_t>
+{
+    using type = uint64_t;
+    using signed_type = int64_t;
+    using unsigned_type = uint64_t;
+    static constexpr int nbits = 64;
+};
+
+template <typename IType>
+using SType = typename IntegerTraits<IType>::signed_type;
+
+template <typename IType>
+using UType = typename IntegerTraits<IType>::unsigned_type;
+
+template <typename IType>
+inline constexpr auto NBits = IntegerTraits<IType>::nbits;
+
+template <typename IType>
+inline constexpr bool IsSigned = meta::EqV<SType<IType>, IType>();
+
+template <typename IType>
+inline constexpr bool IsUnsigned = meta::EqV<UType<IType>, IType>();
+
+/** @brief Compute `ceil(log_2(d))`.
+ *
+ *  Mathematically this doesn't exist for `d=0`. We define this
+ *  function to return 0 when `d=0`.
+ */
+template <typename IType, typename = meta::EnableWhen<IsUnsigned<IType>>>
+H2_GPU_FORCE_INLINE H2_GPU_HOST_DEVICE auto ceillog2(IType const& d)
+{
+    static constexpr auto nbits = NBits<IType>;
+    int ell = 0;
+    for (ell = 0; ell < nbits; ++ell)
+        if ((static_cast<IType>(1) << ell) >= d)
+            break;
+    return ell;
+}
+
+/** @brief Determine if n is a power of 2. */
+template <typename IType, typename = meta::EnableWhen<IsUnsigned<IType>>>
+H2_GPU_FORCE_INLINE H2_GPU_HOST_DEVICE auto ispow2(IType const& d)
+{
+    return (d & (d - 1)) == 0;
+}
+
+/** @brief Computes the upper 32 bits of `x*y`. */
+H2_GPU_FORCE_INLINE H2_GPU_HOST_DEVICE uint32_t mulhi(uint32_t x,
+                                                      uint32_t y) noexcept
+{
+#if H2_GPU_DEVICE_COMPILING
+    return __umulhi(x, y);
+#else
+    return static_cast<uint32_t>(
+        (static_cast<uint64_t>(x) * static_cast<uint64_t>(y)) >> 32);
+#endif // H2_GPU_DEVICE_COMPILING
+}
+
+/** @brief Computes the upper 64 bits of `x*y`. */
+H2_GPU_FORCE_INLINE H2_GPU_HOST_DEVICE uint64_t mulhi(uint64_t x,
+                                                      uint64_t y) noexcept
+{
+#if H2_GPU_DEVICE_COMPILING
+    return __umul64hi(x, y);
+#else
+    return static_cast<uint64_t>(
+        (static_cast<__uint128_t>(x) * static_cast<__uint128_t>(y)) >> 64);
+#endif // H2_GPU_DEVICE_COMPILING
+}
+
+/** @class FastDiv
+ *  @brief Compute division and mods quickly.
+ *
+ *  The division and mod operations are expensive on pretty much every
+ *  processor, but especially on GPUs. There are ways to work around
+ *  this. This is a persistent container for the "l" and "m'" values
+ *  in Figure 4.1 of [this
+ *  paper](https://gmplib.org/~tege/divcnst-pldi94.pdf).
+ *
+ *  The typical use-case here is breaking down a 1-D index into an N-D
+ *  mutli-index. This class can be used to compute the quotients and
+ *  remainders needed in that calculation. In this case, the constant
+ *  divisor that gets stored is the extent of some dimension. Objects
+ *  of this class implicitly convert back to their IType so that
+ *  extent value does not need to be multiply stored.
+ *
+ *  The setup is all done on the host for performance reasons.
+ *
+ *  @todo Is it worth branching when d=2^l? Shame C++ doesn't have
+ *        dependent typing...
+ */
+template <typename IType, typename = meta::EnableWhen<IsUnsigned<IType>>>
+class FastDiv
+{
+    static_assert(IsUnsigned<IType>, "FastDiv for unsigned division only");
+
+public:
+    using UInt = UType<IType>;
+
+public:
+    FastDiv() : FastDiv(1u) {}
+    FastDiv(UInt d) : div_{d}
+    {
+        H2_ASSERT(d > 0, std::runtime_error, "divisor must be positive.");
+        using BigUInt = meta::
+            IfThenElse<meta::EqV<UInt, uint32_t>(), uint64_t, __uint128_t>;
+        static constexpr auto N = NBits<UInt>;
+        static constexpr auto one = static_cast<UInt>(1);
+        static constexpr auto bigone = static_cast<BigUInt>(1);
+        int ell = ceillog2(d);
+        mprime_ = static_cast<UInt>(((bigone << N) * ((bigone << ell) - d) / d)
+                                    + one);
+        sh1_ = (ell < 1 ? ell : 1);
+        sh2_ = (ell = 0 ? 0 : ell - 1);
+    }
+
+    // This lets it masquerade as a dim if needed
+    H2_GPU_FORCE_INLINE H2_GPU_HOST_DEVICE operator UInt const&() const noexcept
+    {
+        return div_;
+    }
+
+    H2_GPU_FORCE_INLINE H2_GPU_HOST_DEVICE void div(UInt const& in,
+                                                    UInt& q) const noexcept
+    {
+        UInt const t1 = mulhi(mprime_, in);
+        // There's a warning in the paper not to compute it this way
+        // since the sum may overflow N bits. In preliminary tests,
+        // overflow was not observed, but the measurable impact on
+        // performance was negligible. So safety first and all that...
+        // But I'm leaving it here in case anyone wants to reevaluate
+        // that claim later on. One shift is better than two. (An
+        // alternative approach could be to use 2*N bits for the
+        // result of (t1+in) and cast the result of the shift back to
+        // N bits before return. I have not looked into any
+        // performance implications of this.)
+        // q = (t1 + in) >> ell_;
+        q = (t1 + ((in - t1) >> sh1_)) >> sh2_;
+    }
+
+    H2_GPU_FORCE_INLINE H2_GPU_HOST_DEVICE UInt
+    div(UInt const& in) const noexcept
+    {
+        UInt q;
+        div(in, q);
+        return q;
+    }
+
+    H2_GPU_FORCE_INLINE H2_GPU_HOST_DEVICE void
+    divmod(UInt const& in, UInt& q, UInt& r) const noexcept
+    {
+        div(in, q);
+        r = in - (q * div_);
+    }
+
+private:
+    UInt div_;
+    UInt mprime_;
+    int sh1_;
+    int sh2_;
+}; // class FastDiv
+} // namespace h2

--- a/include/h2/utils/IntegerMath.hpp
+++ b/include/h2/utils/IntegerMath.hpp
@@ -188,7 +188,7 @@ public:
         mprime_ = static_cast<UInt>(((bigone << N) * ((bigone << ell) - d) / d)
                                     + one);
         sh1_ = (ell < 1 ? ell : 1);
-        sh2_ = (ell = 0 ? 0 : ell - 1);
+        sh2_ = (ell == 0 ? 0 : ell - 1);
     }
 
     // This lets it masquerade as a dim if needed

--- a/legacy/include/distconv/dnn_backend/backend.hpp
+++ b/legacy/include/distconv/dnn_backend/backend.hpp
@@ -4,6 +4,8 @@
 
 #include <distconv_config.hpp>
 
+#include "pack_unpack.hpp"
+
 #if H2_HAS_CUDA
 #include "backend_cudnn.hpp"
 namespace distconv

--- a/legacy/include/distconv/dnn_backend/backend_cudnn.hpp
+++ b/legacy/include/distconv/dnn_backend/backend_cudnn.hpp
@@ -669,10 +669,10 @@ inline void activation_forward(cudnnHandle_t handle,
                                cudnnActivationDescriptor_t const& desc,
                                T const& alpha,
                                cudnnTensorDescriptor_t const& in_desc,
-                               T const* in_data,
+                               void const* in_data,
                                T const& beta,
                                cudnnTensorDescriptor_t const& out_desc,
-                               T* out_data)
+                               void* out_data)
 {
     DISTCONV_CHECK_CUDNN(cudnnActivationForward(
         handle, desc, &alpha, in_desc, in_data, &beta, out_desc, out_data));
@@ -683,14 +683,14 @@ inline void activation_backward(cudnnHandle_t handle,
                                 cudnnActivationDescriptor_t const& desc,
                                 T const& alpha,
                                 cudnnTensorDescriptor_t const& out_desc,
-                                T const* out_data,
+                                void const* out_data,
                                 cudnnTensorDescriptor_t const& d_out_desc,
-                                T const* d_out_data,
+                                void const* d_out_data,
                                 cudnnTensorDescriptor_t const& in_desc,
-                                T const* in_data,
+                                void const* in_data,
                                 T const& beta,
                                 cudnnTensorDescriptor_t const& d_in_desc,
-                                T* d_in_data)
+                                void* d_in_data)
 {
     DISTCONV_CHECK_CUDNN(cudnnActivationBackward(handle,
                                                  desc,

--- a/legacy/include/distconv/dnn_backend/backend_cudnn.hpp
+++ b/legacy/include/distconv/dnn_backend/backend_cudnn.hpp
@@ -47,8 +47,8 @@ using PoolingMode_t = cudnnPoolingMode_t;
 using TensorDescriptor_t = cudnnTensorDescriptor_t;
 using Handle_t = cudnnHandle_t;
 using Stream_t = cudaStream_t;
-
 using Event_t = cudaEvent_t;
+
 inline Event_t make_event()
 {
     cudaEvent_t event;
@@ -91,6 +91,13 @@ inline Handle_t make_handle()
 inline void destroy_handle(cudnnHandle_t handle)
 {
     DISTCONV_CHECK_CUDNN(cudnnDestroy(handle));
+}
+
+inline Stream_t get_stream(cudnnHandle_t handle)
+{
+    Stream_t stream;
+    DISTCONV_CHECK_CUDNN(cudnnGetStream(handle, &stream));
+    return stream;
 }
 
 inline void set_stream(cudnnHandle_t handle, Stream_t stream)
@@ -885,35 +892,35 @@ public:
     }
 
     cudnnConvolutionFwdAlgo_t
-    get_fwd_algorithm(const std::string& name,
-                      const cudnnTensorDescriptor_t* input_desc,
+    get_fwd_algorithm(std::string name,
+                      cudnnTensorDescriptor_t input_desc,
                       const void* input,
-                      const cudnnFilterDescriptor_t* filter_desc,
+                      cudnnFilterDescriptor_t filter_desc,
                       const void* filter,
-                      const cudnnConvolutionDescriptor_t* conv_desc,
-                      const cudnnTensorDescriptor_t* output_desc,
+                      cudnnConvolutionDescriptor_t conv_desc,
+                      cudnnTensorDescriptor_t output_desc,
                       void* output,
                       size_t ws_size);
 
     cudnnConvolutionBwdDataAlgo_t
-    get_bwd_data_algorithm(const std::string& name,
-                           const cudnnFilterDescriptor_t* filter_desc,
+    get_bwd_data_algorithm(std::string name,
+                           cudnnFilterDescriptor_t filter_desc,
                            const void* filter,
-                           const cudnnTensorDescriptor_t* d_output_desc,
+                           cudnnTensorDescriptor_t d_output_desc,
                            const void* d_output,
-                           const cudnnConvolutionDescriptor_t* conv_desc,
-                           const cudnnTensorDescriptor_t* d_input_desc,
+                           cudnnConvolutionDescriptor_t conv_desc,
+                           cudnnTensorDescriptor_t d_input_desc,
                            void* d_input,
                            size_t ws_size);
 
     cudnnConvolutionBwdFilterAlgo_t
-    get_bwd_filter_algorithm(const std::string& name,
-                             const cudnnTensorDescriptor_t* input_desc,
+    get_bwd_filter_algorithm(std::string name,
+                             cudnnTensorDescriptor_t input_desc,
                              const void* input,
-                             const cudnnTensorDescriptor_t* d_output_desc,
+                             cudnnTensorDescriptor_t d_output_desc,
                              const void* d_output,
-                             const cudnnConvolutionDescriptor_t* conv_desc,
-                             const cudnnFilterDescriptor_t* d_filter_desc,
+                             cudnnConvolutionDescriptor_t conv_desc,
+                             cudnnFilterDescriptor_t d_filter_desc,
                              void* d_filter,
                              size_t ws_size);
 

--- a/legacy/include/distconv/dnn_backend/backend_miopen.hpp
+++ b/legacy/include/distconv/dnn_backend/backend_miopen.hpp
@@ -93,6 +93,13 @@ inline void set_stream(miopenHandle_t handle, Stream_t stream)
     DISTCONV_CHECK_MIOPEN(miopenSetStream(handle, stream));
 }
 
+inline Stream_t get_stream(miopenHandle_t handle)
+{
+    Stream_t stream;
+    DISTCONV_CHECK_MIOPEN(miopenGetStream(handle, &stream));
+    return stream;
+}
+
 inline miopenTensorDescriptor_t make_tensor_descriptor()
 {
     miopenTensorDescriptor_t desc;
@@ -938,35 +945,35 @@ public:
     }
 
     miopenConvFwdAlgorithm_t
-    get_fwd_algorithm(std::string const& name,
-                      miopenTensorDescriptor_t const* input_desc,
+    get_fwd_algorithm(std::string name,
+                      miopenTensorDescriptor_t input_desc,
                       void const* input,
-                      miopenTensorDescriptor_t const* filter_desc,
+                      miopenTensorDescriptor_t filter_desc,
                       void const* filter,
-                      miopenConvolutionDescriptor_t const* conv_desc,
-                      miopenTensorDescriptor_t const* output_desc,
+                      miopenConvolutionDescriptor_t conv_desc,
+                      miopenTensorDescriptor_t output_desc,
                       void* output,
                       size_t ws_size);
 
     miopenConvBwdDataAlgorithm_t
-    get_bwd_data_algorithm(std::string const& name,
-                           miopenTensorDescriptor_t const* filter_desc,
+    get_bwd_data_algorithm(std::string name,
+                           miopenTensorDescriptor_t filter_desc,
                            void const* filter,
-                           miopenTensorDescriptor_t const* d_output_desc,
+                           miopenTensorDescriptor_t d_output_desc,
                            void const* d_output,
-                           miopenConvolutionDescriptor_t const* conv_desc,
-                           miopenTensorDescriptor_t const* d_input_desc,
+                           miopenConvolutionDescriptor_t conv_desc,
+                           miopenTensorDescriptor_t d_input_desc,
                            void* d_input,
                            size_t ws_size);
 
     miopenConvBwdWeightsAlgorithm_t
-    get_bwd_filter_algorithm(std::string const& name,
-                             miopenTensorDescriptor_t const* input_desc,
+    get_bwd_filter_algorithm(std::string name,
+                             miopenTensorDescriptor_t input_desc,
                              void const* input,
-                             miopenTensorDescriptor_t const* d_output_desc,
+                             miopenTensorDescriptor_t d_output_desc,
                              void const* d_output,
-                             miopenConvolutionDescriptor_t const* conv_desc,
-                             miopenTensorDescriptor_t const* d_filter_desc,
+                             miopenConvolutionDescriptor_t conv_desc,
+                             miopenTensorDescriptor_t d_filter_desc,
                              void* d_filter,
                              size_t ws_size);
 

--- a/legacy/include/distconv/dnn_backend/backend_miopen.hpp
+++ b/legacy/include/distconv/dnn_backend/backend_miopen.hpp
@@ -724,10 +724,10 @@ inline void activation_forward(miopenHandle_t handle,
                                miopenActivationDescriptor_t const& desc,
                                T const& alpha,
                                miopenTensorDescriptor_t const& in_desc,
-                               T const* in_data,
+                               void const* in_data,
                                T const& beta,
                                miopenTensorDescriptor_t const& out_desc,
-                               T* out_data)
+                               void* out_data)
 {
     DISTCONV_CHECK_MIOPEN(miopenActivationForward(
         handle, desc, &alpha, in_desc, in_data, &beta, out_desc, out_data));
@@ -738,14 +738,14 @@ inline void activation_backward(miopenHandle_t handle,
                                 miopenActivationDescriptor_t const& desc,
                                 T const& alpha,
                                 miopenTensorDescriptor_t const& out_desc,
-                                T const* out_data,
+                                void const* out_data,
                                 miopenTensorDescriptor_t const& d_out_desc,
-                                T const* d_out_data,
+                                void const* d_out_data,
                                 miopenTensorDescriptor_t const& in_desc,
-                                T const* in_data,
+                                void const* in_data,
                                 T const& beta,
                                 miopenTensorDescriptor_t const& d_in_desc,
-                                T* d_in_data)
+                                void* d_in_data)
 {
     DISTCONV_CHECK_MIOPEN(miopenActivationBackward(handle,
                                                    desc,

--- a/legacy/include/distconv/dnn_backend/convolution.hpp
+++ b/legacy/include/distconv/dnn_backend/convolution.hpp
@@ -2461,12 +2461,12 @@ protected:
                 "stationary-x setup algos backward-filter");
             m_bwd_filter_algo = m_be.get_bwd_filter_algorithm(
                 m_bwd_filter_find_algo,
-                &m_input_d,
+                dnn_lib::read_proxy(m_input_d).desc(),
                 input,
-                &m_d_output_gathered_d,
+                dnn_lib::read_proxy(m_d_output_gathered_d).desc(),
                 m_d_output_gathered_t.get_buffer(),
-                &m_conv_bwd_filter_d,
-                &m_d_filter_d,
+                m_conv_bwd_filter_d,
+                m_d_filter_d,
                 filter,
                 ws_size);
             release_tmp_tensor_buffer(m_d_output_gathered_t);
@@ -2481,12 +2481,12 @@ protected:
                 "stationary-y setup algos backward-filter");
             m_bwd_filter_algo =
                 m_be.get_bwd_filter_algorithm(m_bwd_filter_find_algo,
-                                              &m_input_gathered_d,
+                                              dnn_lib::read_proxy(m_input_gathered_d).desc(),
                                               m_input_gathered_t.get_buffer(),
-                                              &m_d_output_d,
+                                              dnn_lib::read_proxy(m_d_output_d).desc(),
                                               output,
-                                              &m_conv_bwd_filter_d,
-                                              &m_d_filter_d,
+                                              m_conv_bwd_filter_d,
+                                              m_d_filter_d,
                                               filter,
                                               ws_size);
             release_tmp_tensor_buffer(m_input_gathered_t);
@@ -2502,12 +2502,12 @@ protected:
                 "stationary-w setup algos backward-filter");
             m_bwd_filter_algo = m_be.get_bwd_filter_algorithm(
                 m_bwd_filter_find_algo,
-                &m_input_gathered_d,
+                dnn_lib::read_proxy(m_input_gathered_d).desc(),
                 m_input_gathered_t.get_buffer(),
-                &m_d_output_gathered_d,
+                dnn_lib::read_proxy(m_d_output_gathered_d).desc(),
                 m_d_output_gathered_t.get_buffer(),
-                &m_conv_bwd_filter_d,
-                &m_d_filter_d,
+                m_conv_bwd_filter_d,
+                m_d_filter_d,
                 filter,
                 ws_size);
             release_tmp_tensor_buffer(m_input_gathered_t);

--- a/legacy/include/distconv/dnn_backend/pack_unpack.hpp
+++ b/legacy/include/distconv/dnn_backend/pack_unpack.hpp
@@ -1,0 +1,159 @@
+#pragma once
+#include <distconv_config.hpp>
+
+#ifndef H2_LEGACY_INCLUDE_DISTCONV_CUDNN_BACKEND_HPP_INCLUDED
+#error "Do not #include this file; just #include backend.hpp"
+#endif
+
+// Just need the typedefs for this file
+#if H2_HAS_CUDA
+#include <cudnn.h>
+namespace distconv
+{
+namespace cudnn
+{
+using TensorDescriptor_t = cudnnTensorDescriptor_t;
+using Handle_t = cudnnHandle_t;
+using DataType_t = cudnnDataType_t;
+}
+}
+#define H2_DNN_BACKEND_NS cudnn
+#elif H2_HAS_ROCM
+#include <miopen/miopen.h>
+namespace distconv
+{
+namespace miopen
+{
+using TensorDescriptor_t = miopenTensorDescriptor_t;
+using Handle_t = miopenHandle_t;
+using DataType_t = miopenDataType_t;
+}
+}
+#define H2_DNN_BACKEND_NS miopen
+#endif
+
+namespace distconv
+{
+namespace H2_DNN_BACKEND_NS
+{
+
+// This models a strided INPUT to a cuDNN operation. This object is
+// simple: on construction, we allocate a buffer and copy the strided
+// tensor into it. At destruction, we simply free the buffer (stack
+// unwinding is irrelevant).
+class PackedTensorReadProxy
+{
+    TensorDescriptor_t m_unpacked_desc = 0;
+    TensorDescriptor_t m_packed_desc = 0;
+    void const* m_unpacked_data = nullptr;
+    void* m_packed_data = nullptr;
+
+public:
+    PackedTensorReadProxy(TensorDescriptor_t unpacked_desc);
+    PackedTensorReadProxy(Handle_t handle,
+                          TensorDescriptor_t unpacked_desc,
+                          void const* unpacked_data);
+    // This dtor can throw -- if the proxy code were "unrolled", this
+    // would correspond to freeing any allocated memory/descriptors,
+    // which can detect async errors and should be allowed to
+    // (non-fatally) throw (don't ask whether any of our downstreams
+    // are actually prepared to recover from such an error).
+    ~PackedTensorReadProxy();
+
+    // Direct access for those who know what they want
+    TensorDescriptor_t unpacked_desc() const noexcept { return m_unpacked_desc; }
+    TensorDescriptor_t packed_desc() const noexcept { return m_packed_desc; }
+    void const* unpacked_data() const noexcept { return m_unpacked_data; }
+    void const* packed_data() const noexcept { return m_packed_data; }
+
+    // The "right" thing
+    TensorDescriptor_t desc() const noexcept { return packed_desc(); }
+    void const* ptr() const noexcept { return packed_data(); }
+
+};// class PackedTensorReadProxy
+
+// This models a strided output tensor. We need to allocate a packable
+// buffer up front, then copy the values on destruction (as long as
+// the stack is not unnaturally unwinding), and finally free the
+// buffer. There's a potential complication when dealing with outputs
+// of "accumulating operations": output = a * op(inputs) + b *
+// output. I'm like 98% sure we only ever use a=1, b=0. HOWEVER, if b
+// != 0, then we need to do some extra crap. There are 2 obvious
+// options:
+//
+// 1. Copy the unpacked values into the packed buffer on construction,
+//    copy the packed values into the unpacked buffer on destruction,
+//    pass a'=a, b'=b to the backend call.
+//
+// 2. Allocate the packed buffer but do not initialize. Pass a'=1,
+//    b'=0 to the backend call. Sum into the unpacked buffer at
+//    destruction with "a * packed + b * unpacked" (this is similar to
+//    what hipDNN does when a!=1,b!=0 anyway).
+//
+// Option 1 is less intrusive (doesn't require modifying the calling
+// code's alpha, beta values). It might be more work but we can avoid
+// it when b=0. (Also, cuDNN strongly encourages users to use beta=0
+// whenever possible.)
+class PackedTensorWriteProxy
+{
+    TensorDescriptor_t m_unpacked_desc = 0;
+    TensorDescriptor_t m_packed_desc = 0;
+    void* m_unpacked_data = nullptr;
+    void* m_packed_data = nullptr;
+
+    Handle_t m_handle;
+    DataType_t m_dt;
+
+public:
+    PackedTensorWriteProxy(TensorDescriptor_t unpacked_desc);
+    // Per the discussion above, this class will "copy on
+    // construction" if beta!=0. If we switch to option 2 in the
+    // future, we would need to add an alpha argument as well.
+    PackedTensorWriteProxy(Handle_t handle,
+                           TensorDescriptor_t unpacked_desc,
+                           void* unpacked_data,
+                           double beta = 0.);
+    // This dtor can throw. See explanation/details below.
+    ~PackedTensorWriteProxy();
+
+    // Direct access for those who know what they want
+    TensorDescriptor_t unpacked_desc() const noexcept { return m_unpacked_desc; }
+    TensorDescriptor_t packed_desc() const noexcept { return m_packed_desc; }
+    void const* unpacked_data() const noexcept { return m_unpacked_data; }
+    void* packed_data() const noexcept { return m_packed_data; }
+
+    // The "right" thing
+    TensorDescriptor_t desc() const noexcept { return packed_desc(); }
+    void* ptr() const noexcept { return packed_data(); }
+
+};// class PackedTensorWriteProxy
+
+inline PackedTensorReadProxy read_proxy(TensorDescriptor_t desc)
+{
+    return PackedTensorReadProxy{desc};
+}
+
+inline PackedTensorReadProxy read_proxy(Handle_t handle,
+                                 TensorDescriptor_t desc,
+                                 void const* data)
+{
+    return PackedTensorReadProxy{handle, desc, data};
+}
+
+inline PackedTensorWriteProxy write_proxy(TensorDescriptor_t desc)
+{
+    return PackedTensorWriteProxy{desc};
+}
+
+inline PackedTensorWriteProxy write_proxy(Handle_t handle,
+                                          TensorDescriptor_t desc,
+                                          void* data,
+                                          double beta = 0.)
+{
+    return PackedTensorWriteProxy{handle, desc, data, beta};
+}
+
+}// namespace H2_DNN_BACKEND_NS
+}// namespace distconv
+
+#undef H2_DNN_BACKEND_NS

--- a/legacy/include/distconv/dnn_backend/relu.hpp
+++ b/legacy/include/distconv/dnn_backend/relu.hpp
@@ -79,10 +79,10 @@ public:
                                     m_activation_d,
                                     alpha,
                                     input_proxy.desc(),
-                                    input_proxy.data(),
+                                    input_proxy.ptr(),
                                     beta,
                                     output_proxy.desc(),
-                                    output_proxy.data());
+                                    output_proxy.ptr());
         return 0;
     }
 
@@ -120,14 +120,14 @@ public:
                                      m_activation_d,
                                      alpha,
                                      y_proxy.desc(),
-                                     y_proxy.data(),
+                                     y_proxy.ptr(),
                                      dy_proxy.desc(),
-                                     dy_proxy.data(),
+                                     dy_proxy.ptr(),
                                      x_proxy.desc(),
-                                     x_proxy.data(),
+                                     x_proxy.ptr(),
                                      beta,
                                      dx_proxy.desc(),
-                                     dx_proxy.data());
+                                     dx_proxy.ptr());
         return 0;
     }
 

--- a/legacy/src/CMakeLists.txt
+++ b/legacy/src/CMakeLists.txt
@@ -62,7 +62,8 @@ target_link_libraries(distconv PUBLIC
   ${H2_CUDA_LIBS}
   ${H2_ROCM_LIBS}
   ${Aluminum_LIBRARIES}
-  MPI::MPI_CXX)
+  MPI::MPI_CXX
+  $<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_CXX>)
 
 get_target_property(DISTCONV_MPI_CXX_INCL_DIRS
   MPI::MPI_CXX INTERFACE_INCLUDE_DIRECTORIES)

--- a/legacy/src/dnn_backend/CMakeLists.txt
+++ b/legacy/src/dnn_backend/CMakeLists.txt
@@ -1,7 +1,7 @@
 if (H2_HAS_CUDA)
-  h2_set_full_path(THIS_DIR_SOURCES backend.cpp)
+  h2_set_full_path(THIS_DIR_SOURCES backend.cpp pack_unpack.cpp)
 elseif (H2_HAS_ROCM)
-  h2_set_full_path(THIS_DIR_SOURCES backend_miopen.cpp)
+  h2_set_full_path(THIS_DIR_SOURCES backend_miopen.cpp pack_unpack.cpp)
 endif ()
 
 h2_set_full_path(THIS_DIR_CU_SOURCES
@@ -11,7 +11,12 @@ h2_set_full_path(THIS_DIR_CU_SOURCES
   mean_squared_error.cu
   softmax.cu
   cross_entropy.cu
-  )
+)
+
+if (H2_HAS_ROCM)
+  h2_set_full_path(PACK_UNPACK_KERNEL_FILE pack_unpack.cu)
+  list(APPEND THIS_DIR_CU_SOURCES "${PACK_UNPACK_KERNEL_FILE}")
+endif ()
 
 set(HEADERS "${HEADERS}" "${THIS_DIR_HEADERS}" PARENT_SCOPE)
 set(SOURCES "${SOURCES}" "${THIS_DIR_SOURCES}" PARENT_SCOPE)

--- a/legacy/src/dnn_backend/backend.cpp
+++ b/legacy/src/dnn_backend/backend.cpp
@@ -13,16 +13,16 @@ constexpr size_t CONVOLUTION_WORKSPACE_SIZE = 1 << 30;
 #endif // CUDNN_MAJOR < 8
 
 cudnnConvolutionFwdAlgo_t BackendCUDNN::get_fwd_algorithm(
-    const std::string &name,
-    const cudnnTensorDescriptor_t *input_desc,
+    std::string name,
+    const cudnnTensorDescriptor_t input_desc,
     const void *input,
-    const cudnnFilterDescriptor_t *filter_desc,
+    const cudnnFilterDescriptor_t filter_desc,
     const void *filter,
-    const cudnnConvolutionDescriptor_t *conv_desc,
-    const cudnnTensorDescriptor_t *output_desc,
+    const cudnnConvolutionDescriptor_t conv_desc,
+    const cudnnTensorDescriptor_t output_desc,
     void *output,
     size_t ws_size) {
-  std::string n = name;
+  std::string& n = name;
   if (name == "DEFAULT") {
     // Default selection
     n = "HEURISTIC";
@@ -36,18 +36,13 @@ cudnnConvolutionFwdAlgo_t BackendCUDNN::get_fwd_algorithm(
     if (p.second == n) return p.first;
   }
 
-  assert_always(input_desc);
-  assert_always(filter_desc);
-  assert_always(conv_desc);
-  assert_always(output_desc);
-
   if (n == "HEURISTIC") {
     return get_fwd_algorithm_by_heuristics(
-        *input_desc, *filter_desc, *conv_desc, *output_desc,
+        input_desc, filter_desc, conv_desc, output_desc,
         ws_size);
   } else if (n == "AUTOTUNE") {
     return autotune_fwd_algorithm(
-        *input_desc, input, *filter_desc, filter, *conv_desc, *output_desc,
+        input_desc, input, filter_desc, filter, conv_desc, output_desc,
         output, ws_size);
   }
 
@@ -199,16 +194,16 @@ cudnnConvolutionFwdAlgo_t BackendCUDNN::autotune_fwd_algorithm(
 }
 
 cudnnConvolutionBwdDataAlgo_t BackendCUDNN::get_bwd_data_algorithm(
-    const std::string &name,
-    const cudnnFilterDescriptor_t *filter_desc,
+    std::string name,
+    const cudnnFilterDescriptor_t filter_desc,
     const void *filter,
-    const cudnnTensorDescriptor_t *d_output_desc,
+    const cudnnTensorDescriptor_t d_output_desc,
     const void *d_output,
-    const cudnnConvolutionDescriptor_t *conv_desc,
-    const cudnnTensorDescriptor_t *d_input_desc,
+    const cudnnConvolutionDescriptor_t conv_desc,
+    const cudnnTensorDescriptor_t d_input_desc,
     void *d_input,
     size_t ws_size) {
-  std::string n = name;
+  std::string& n = name;
   if (name == "DEFAULT") {
     // Default selection
     n = "HEURISTIC";
@@ -222,19 +217,14 @@ cudnnConvolutionBwdDataAlgo_t BackendCUDNN::get_bwd_data_algorithm(
     if (p.second == n) return p.first;
   }
 
-  assert_always(filter_desc);
-  assert_always(d_output_desc);
-  assert_always(conv_desc);
-  assert_always(d_input_desc);
-
   if (n == "HEURISTIC") {
     return get_bwd_data_algorithm_by_heuristics(
-        *filter_desc, *d_output_desc, *conv_desc, *d_input_desc,
+        filter_desc, d_output_desc, conv_desc, d_input_desc,
         ws_size);
   } else if (n == "AUTOTUNE") {
     return autotune_bwd_data_algorithm(
-        *filter_desc, filter, *d_output_desc, d_output, *conv_desc,
-        *d_input_desc, d_input, ws_size);
+        filter_desc, filter, d_output_desc, d_output, conv_desc,
+        d_input_desc, d_input, ws_size);
   }
 
   util::MPIRootPrintStreamError()
@@ -361,16 +351,16 @@ cudnnConvolutionBwdDataAlgo_t BackendCUDNN::autotune_bwd_data_algorithm(
 }
 
 cudnnConvolutionBwdFilterAlgo_t BackendCUDNN::get_bwd_filter_algorithm(
-    const std::string &name,
-    const cudnnTensorDescriptor_t *input_desc,
+    std::string name,
+    const cudnnTensorDescriptor_t input_desc,
     const void *input,
-    const cudnnTensorDescriptor_t *d_output_desc,
+    const cudnnTensorDescriptor_t d_output_desc,
     const void *d_output,
-    const cudnnConvolutionDescriptor_t *conv_desc,
-    const cudnnFilterDescriptor_t *d_filter_desc,
+    const cudnnConvolutionDescriptor_t conv_desc,
+    const cudnnFilterDescriptor_t d_filter_desc,
     void *d_filter,
     size_t ws_size) {
-  std::string n = name;
+  std::string& n = name;
   if (name == "DEFAULT") {
     // Default selection
     n = "HEURISTIC";
@@ -391,12 +381,12 @@ cudnnConvolutionBwdFilterAlgo_t BackendCUDNN::get_bwd_filter_algorithm(
 
   if (n == "HEURISTIC") {
     return get_bwd_filter_algorithm_by_heuristics(
-        *input_desc, *d_output_desc, *conv_desc, *d_filter_desc,
+        input_desc, d_output_desc, conv_desc, d_filter_desc,
         ws_size);
   } else if (n == "AUTOTUNE") {
     return autotune_bwd_filter_algorithm(
-        *input_desc, input, *d_output_desc, d_output, *conv_desc,
-        *d_filter_desc, d_filter, ws_size);
+        input_desc, input, d_output_desc, d_output, conv_desc,
+        d_filter_desc, d_filter, ws_size);
   }
 
   util::MPIRootPrintStreamError()

--- a/legacy/src/dnn_backend/backend_miopen.cpp
+++ b/legacy/src/dnn_backend/backend_miopen.cpp
@@ -251,13 +251,13 @@ autotune_fwd_algorithm(miopenHandle_t handle,
 
 // FIXME (trb 08/11/2022): CLEANUP THE ws_size ARGUMENT TO THE MIOpen CALLS!
 miopenConvFwdAlgorithm_t
-BackendMIOpen::get_fwd_algorithm(std::string const& name,
-                                 miopenTensorDescriptor_t const* input_desc,
+BackendMIOpen::get_fwd_algorithm(std::string const name,
+                                 miopenTensorDescriptor_t const input_desc,
                                  void const* input,
-                                 miopenTensorDescriptor_t const* filter_desc,
+                                 miopenTensorDescriptor_t const filter_desc,
                                  void const* filter,
-                                 miopenConvolutionDescriptor_t const* conv_desc,
-                                 miopenTensorDescriptor_t const* output_desc,
+                                 miopenConvolutionDescriptor_t const conv_desc,
+                                 miopenTensorDescriptor_t const output_desc,
                                  void* output,
                                  size_t ws_size)
 {
@@ -279,23 +279,23 @@ BackendMIOpen::get_fwd_algorithm(std::string const& name,
     WSBuffer ws(CONVOLUTION_WORKSPACE_SIZE);
     if (n == "HEURISTIC")
         return get_fwd_algorithm_by_heuristics(get_handle(),
-                                               *input_desc,
+                                               input_desc,
                                                input,
-                                               *filter_desc,
+                                               filter_desc,
                                                filter,
-                                               *conv_desc,
-                                               *output_desc,
+                                               conv_desc,
+                                               output_desc,
                                                output,
                                                ws,
                                                ws_size);
     else if (n == "AUTOTUNE")
         return autotune_fwd_algorithm(get_handle(),
-                                      *input_desc,
+                                      input_desc,
                                       input,
-                                      *filter_desc,
+                                      filter_desc,
                                       filter,
-                                      *conv_desc,
-                                      *output_desc,
+                                      conv_desc,
+                                      output_desc,
                                       output,
                                       ws,
                                       ws_size);
@@ -409,13 +409,13 @@ autotune_bwd_data_algorithm(miopenHandle_t handle,
 }
 
 miopenConvBwdDataAlgorithm_t BackendMIOpen::get_bwd_data_algorithm(
-    std::string const& name,
-    miopenTensorDescriptor_t const* filter_desc,
+    std::string const name,
+    miopenTensorDescriptor_t const filter_desc,
     void const* filter,
-    miopenTensorDescriptor_t const* d_output_desc,
+    miopenTensorDescriptor_t const d_output_desc,
     void const* d_output,
-    miopenConvolutionDescriptor_t const* conv_desc,
-    miopenTensorDescriptor_t const* d_input_desc,
+    miopenConvolutionDescriptor_t const conv_desc,
+    miopenTensorDescriptor_t const d_input_desc,
     void* d_input,
     size_t ws_size)
 {
@@ -437,23 +437,23 @@ miopenConvBwdDataAlgorithm_t BackendMIOpen::get_bwd_data_algorithm(
     WSBuffer ws(CONVOLUTION_WORKSPACE_SIZE);
     if (n == "HEURISTIC")
         return get_bwd_data_algorithm_by_heuristics(get_handle(),
-                                                    *filter_desc,
+                                                    filter_desc,
                                                     filter,
-                                                    *d_output_desc,
+                                                    d_output_desc,
                                                     d_output,
-                                                    *conv_desc,
-                                                    *d_input_desc,
+                                                    conv_desc,
+                                                    d_input_desc,
                                                     d_input,
                                                     ws,
                                                     ws_size);
     else if (n == "AUTOTUNE")
         return autotune_bwd_data_algorithm(get_handle(),
-                                           *filter_desc,
+                                           filter_desc,
                                            filter,
-                                           *d_output_desc,
+                                           d_output_desc,
                                            d_output,
-                                           *conv_desc,
-                                           *d_input_desc,
+                                           conv_desc,
+                                           d_input_desc,
                                            d_input,
                                            ws,
                                            ws_size);
@@ -566,13 +566,13 @@ autotune_bwd_weights_algorithm(miopenHandle_t handle,
 }
 
 miopenConvBwdWeightsAlgorithm_t BackendMIOpen::get_bwd_filter_algorithm(
-    std::string const& name,
-    miopenTensorDescriptor_t const* input_desc,
+    std::string const name,
+    miopenTensorDescriptor_t const input_desc,
     void const* input,
-    miopenTensorDescriptor_t const* d_output_desc,
+    miopenTensorDescriptor_t const d_output_desc,
     void const* d_output,
-    miopenConvolutionDescriptor_t const* conv_desc,
-    miopenTensorDescriptor_t const* d_filter_desc,
+    miopenConvolutionDescriptor_t const conv_desc,
+    miopenTensorDescriptor_t const d_filter_desc,
     void* d_filter,
     size_t ws_size)
 {
@@ -598,12 +598,12 @@ miopenConvBwdWeightsAlgorithm_t BackendMIOpen::get_bwd_filter_algorithm(
     if (n == "HEURISTIC")
     {
         return get_bwd_weights_algorithm_by_heuristics(get_handle(),
-                                                       *input_desc,
+                                                       input_desc,
                                                        input,
-                                                       *d_output_desc,
+                                                       d_output_desc,
                                                        d_output,
-                                                       *conv_desc,
-                                                       *d_filter_desc,
+                                                       conv_desc,
+                                                       d_filter_desc,
                                                        d_filter,
                                                        ws,
                                                        ws_size);
@@ -611,12 +611,12 @@ miopenConvBwdWeightsAlgorithm_t BackendMIOpen::get_bwd_filter_algorithm(
     else if (n == "AUTOTUNE")
     {
         return autotune_bwd_weights_algorithm(get_handle(),
-                                              *input_desc,
+                                              input_desc,
                                               input,
-                                              *d_output_desc,
+                                              d_output_desc,
                                               d_output,
-                                              *conv_desc,
-                                              *d_filter_desc,
+                                              conv_desc,
+                                              d_filter_desc,
                                               d_filter,
                                               ws,
                                               ws_size);

--- a/legacy/src/dnn_backend/pack_unpack.cpp
+++ b/legacy/src/dnn_backend/pack_unpack.cpp
@@ -1,0 +1,454 @@
+#include "distconv/dnn_backend/backend.hpp"
+#include "h2/gpu/logger.hpp"
+
+#include <numeric>
+#include <stdexcept>
+#include <variant>
+#include <vector>
+
+#if H2_HAS_CUDA
+#define H2_DNN_BACKEND_NS cudnn
+#elif H2_HAS_ROCM
+#define H2_DNN_BACKEND_NS miopen
+namespace distconv
+{
+namespace miopen
+{
+void do_gpu_tensor_repack(
+    float const& alpha,
+    float const& beta,
+    size_t const ndims,
+    int const* dims,
+    int const* src_strides,
+    int const* tgt_strides,
+    int const* packed_strides,
+    float const* src_data,
+    float* tgt_data,
+    hipStream_t stream);
+} // namespace miopen
+} // namespace distconv
+#endif
+
+namespace distconv
+{
+namespace H2_DNN_BACKEND_NS
+{
+namespace
+{
+
+// The behavior we WANT is to just be able to shove whatever tensor we
+// want through these interfaces. Thus, packing is "opt-in". In LBANN,
+// we can force this to be ON for ROCm platforms.
+bool do_pack_unpack() noexcept
+{
+    static bool const val = []() {
+        char const* env = std::getenv("H2_DISTCONV_FORCE_PACKED");
+        bool const tf = (env && std::strlen(env) && env[0] != '0');
+        H2_GPU_INFO("Doing pack/unpack: {}", tf);
+        return tf;
+        // Any nonempty string matching "[^0].*" is truthy.
+    } ();
+
+    return val;
+}
+
+// This is just a quick wrapper around the "alpha"/"beta" scaling
+// parameters needed for the cuDNN/MIOpen interface.
+struct host_scalar
+{
+    std::variant<float, double> val;
+    explicit host_scalar(float const v)
+        : val{v}
+    {}
+    explicit host_scalar(double const v)
+        : val{v}
+    {}
+    void const* get() const
+    {
+        return std::visit([](auto&& x)
+        {
+            return static_cast<void const*>(&x);
+        },
+            val);
+    }
+    operator void const* () const { return get(); }
+};// host_scalar
+
+host_scalar make_host_scalar(DataType_t const dt, double const v)
+{
+#if H2_HAS_CUDA
+    switch (dt)
+    {
+    case CUDNN_DATA_FLOAT: [[fallthrough]];
+    case CUDNN_DATA_HALF:
+        return host_scalar{static_cast<float>(v)};
+    case CUDNN_DATA_DOUBLE:
+        return host_scalar{v};
+    default:
+        throw std::runtime_error(
+            "Only float, double, and half are supported.");
+    }
+#elif H2_HAS_ROCM
+    switch (dt)
+    {
+    case miopenFloat: [[fallthrough]];
+    case miopenHalf:
+        return host_scalar{static_cast<float>(v)};
+    default:
+        throw std::runtime_error("Only float and half are supported.");
+    }
+#endif
+}
+
+size_t datatype_size(DataType_t dt)
+{
+#if H2_HAS_CUDA
+    switch (dt) {
+    case CUDNN_DATA_FLOAT: return sizeof(float);
+    case CUDNN_DATA_DOUBLE: return sizeof(double);
+    case CUDNN_DATA_HALF: return sizeof(short);
+    default:
+        throw std::runtime_error(
+            "Only float, double, and half are supported.");
+    }
+#elif H2_HAS_ROCM
+    switch (dt)
+    {
+    case miopenHalf: return sizeof(short);
+    case miopenFloat: return sizeof(float);
+    default:
+        throw std::runtime_error("Only float and half are supported.");
+    }
+#endif
+    return 1UL;
+}
+
+bool is_fully_packed(std::vector<int> const& dims,
+                     std::vector<int> const& strides)
+{
+    // As far as I know, LBANN doesn't do any overlapping striding
+    // (this is exceptionally poorly supported in the real world and
+    // it has semantic issues). Thus, a tensor is fully packed if and
+    // only if strides[0] == prod(dims[1:]).
+    return strides.front() == std::accumulate(std::next(dims.cbegin()),
+                                              dims.cend(),
+                                              1,
+                                              std::multiplies<int>{});
+}
+
+std::vector<int> get_fully_packed_strides(std::vector<int> const& dims)
+{
+    size_t const ndims = dims.size();
+    std::vector<int> strides(ndims, 1);
+    std::partial_sum(dims.rbegin(),
+                     std::prev(dims.rend()),
+                     std::next(strides.rbegin()),
+                     std::multiplies<int>{});
+    return strides;
+}
+
+// std::tuple<cudnnDataType_t, std::vector<int>, std::vector<int>>
+// but with nice names.
+struct MyTensorDesc
+{
+    DataType_t dt;
+    std::vector<int> dims;
+    std::vector<int> strides;
+    void set_ndims(size_t ndims)
+    {
+        dims.resize(ndims);
+        strides.resize(ndims);
+    }
+    size_t memory_size() const
+    {
+        assert_eq(dims.size(), strides.size());
+        assert_always(dims.size() > 0);
+        return dims[0] * strides[0] * datatype_size(dt);
+    }
+};
+
+MyTensorDesc get_details(TensorDescriptor_t desc)
+{
+    int ndims = get_tensor_num_dimensions(desc);
+    DataType_t dt;
+    std::vector<int> dims(ndims), strides(ndims);
+#if H2_HAS_CUDA
+    DISTCONV_CHECK_CUDNN(
+        cudnnGetTensorNdDescriptor(
+            desc, ndims, &dt, &ndims, dims.data(), strides.data()));
+#elif H2_HAS_ROCM
+    DISTCONV_CHECK_MIOPEN(
+        miopenGetTensorDescriptor(
+            desc, &dt, dims.data(), strides.data()));
+#endif
+    return {dt, std::move(dims), std::move(strides)};
+};
+
+DataType_t get_data_type(TensorDescriptor_t desc)
+{
+#if H2_HAS_CUDA
+    DataType_t dt;
+    int dim=-1, stride=-1, ndims=1;
+    DISTCONV_CHECK_CUDNN(
+        cudnnGetTensorNdDescriptor(
+            desc, ndims, &dt, &ndims, &dim, &stride));
+    return dt;
+#elif H2_HAS_ROCM
+    return get_details(desc).dt; // ugh
+#endif
+}
+
+TensorDescriptor_t make_backend_desc(MyTensorDesc my_desc)
+{
+    auto desc = make_tensor_descriptor();
+#if H2_HAS_CUDA
+    auto const& [dt, dims, strides] = my_desc;
+    DISTCONV_CHECK_CUDNN(
+        cudnnSetTensorNdDescriptor(
+            desc, dt, dims.size(), dims.data(), strides.data()));
+#elif H2_HAS_ROCM
+    auto& [dt, dims, strides] = my_desc;
+    DISTCONV_CHECK_MIOPEN(
+        miopenSetTensorDescriptor(
+            desc, dt, dims.size(), dims.data(), strides.data()));
+#endif
+    return desc;
+}
+
+// If the input tensor descriptor is already packed, then return it
+// directly. Otherwise, create a new handle and set it up with the
+// same dimensions but fully packed strides.
+TensorDescriptor_t get_packed_desc(TensorDescriptor_t desc)
+{
+    auto const [dt, dims, strides] = get_details(desc);
+    if (is_fully_packed(dims, strides))
+        return desc;
+    else
+        return make_backend_desc({dt, dims, get_fully_packed_strides(dims)});
+}
+
+struct MyTypeErasedPtr
+{
+    void* data;
+    DataType_t dt;
+    template <typename T, typename U>
+    operator std::tuple<T,U>() { return {data, dt}; }
+};
+
+MyTypeErasedPtr allocate(Handle_t handle, TensorDescriptor_t desc)
+{
+#if H2_HAS_CUDA
+    size_t mem_size;
+    DISTCONV_CHECK_CUDNN(cudnnGetTensorSizeInBytes(desc, &mem_size));
+#elif H2_HAS_ROCM
+    auto const [dt, dims, strides] = get_details(desc);
+    auto const mem_size = dims[0] * strides[0] * datatype_size(dt);
+#endif
+
+    // Stream-aware allocation
+    void* data;
+    DISTCONV_CHECK_GPU(
+        h2::gpu::default_cub_allocator().DeviceAllocate(
+            &data,
+            mem_size,
+            get_stream(handle)));
+    return {data, dt};
+}
+
+void copy_tensor(
+    Handle_t handle,
+    host_scalar const& alpha,
+    TensorDescriptor_t src_desc,
+    void const* src_data,
+    host_scalar const& beta,
+    TensorDescriptor_t tgt_desc,
+    void* tgt_data)
+{
+#if H2_HAS_CUDA
+    DISTCONV_CHECK_CUDNN(
+        cudnnTransformTensor(handle,
+                             alpha,
+                             src_desc,
+                             src_data,
+                             beta,
+                             tgt_desc,
+                             tgt_data));
+#elif H2_HAS_ROCM
+    hipStream_t const stream = get_stream(handle);
+    auto const [src_dt, src_dims, src_strides] = get_details(src_desc);
+    auto const [tgt_dt, tgt_dims, tgt_strides] = get_details(tgt_desc);
+    assert_always(src_dt == tgt_dt);
+    assert_always(src_dims == tgt_dims);
+    auto const packed_strides = get_fully_packed_strides(src_dims);
+    switch (src_dt)
+    {
+    case miopenFloat:
+        do_gpu_tensor_repack(
+            *reinterpret_cast<float const*>(alpha.get()),
+            *reinterpret_cast<float const*>(beta.get()),
+            src_dims.size(),
+            src_dims.data(),
+            src_strides.data(),
+            tgt_strides.data(),
+            packed_strides.data(),
+            reinterpret_cast<float const*>(src_data),
+            reinterpret_cast<float*>(tgt_data),
+            stream);
+        break;
+    default:
+        throw std::runtime_error("Only float.");
+    }
+#endif
+}
+
+}// namespace
+
+// Read proxy impl
+
+PackedTensorReadProxy::PackedTensorReadProxy(TensorDescriptor_t unpacked_desc)
+    : m_unpacked_desc{unpacked_desc},
+      m_packed_desc{unpacked_desc},
+      m_unpacked_data{nullptr},
+      m_packed_data{nullptr}
+{
+    if (do_pack_unpack())
+        m_packed_desc = get_packed_desc(m_unpacked_desc);
+}
+
+PackedTensorReadProxy::PackedTensorReadProxy(Handle_t handle,
+                                             TensorDescriptor_t unpacked_desc,
+                                             void const* unpacked_data)
+    : m_unpacked_desc{unpacked_desc},
+      m_packed_desc{unpacked_desc},
+      m_unpacked_data{unpacked_data},
+      m_packed_data{nullptr}
+{
+    if (do_pack_unpack())
+        m_packed_desc = get_packed_desc(m_unpacked_desc);
+
+    if (m_unpacked_desc == m_packed_desc)
+        m_packed_data = const_cast<void*>(m_unpacked_data);
+    else
+    {
+        DataType_t dt;
+        std::tie(m_packed_data, dt) = allocate(handle, m_packed_desc);
+        copy_tensor(handle,
+                    make_host_scalar(dt, 1.0),
+                    m_unpacked_desc,
+                    m_unpacked_data,
+                    make_host_scalar(dt, 0.0),
+                    m_packed_desc,
+                    m_packed_data);
+    }
+}
+
+PackedTensorReadProxy::~PackedTensorReadProxy()
+{
+    if ((m_packed_data != m_unpacked_data)
+        && m_packed_data)
+    {
+        DISTCONV_CHECK_GPU(
+            h2::gpu::default_cub_allocator().DeviceFree(m_packed_data));
+        m_packed_data = nullptr;
+        m_unpacked_data = nullptr;
+    }
+    if (m_unpacked_desc != m_packed_desc)
+        destroy_tensor_descriptor(m_packed_desc);
+    m_packed_desc = 0;
+    m_unpacked_desc = 0;
+}
+
+// Write proxy -- possibly copy in/copy out
+
+PackedTensorWriteProxy::PackedTensorWriteProxy(TensorDescriptor_t unpacked_desc)
+    : m_unpacked_desc{unpacked_desc},
+      m_packed_desc{unpacked_desc},
+      m_unpacked_data{nullptr},
+      m_packed_data{nullptr}
+{
+    if (do_pack_unpack())
+        m_packed_desc = get_packed_desc(unpacked_desc);
+}
+
+PackedTensorWriteProxy::PackedTensorWriteProxy(
+    Handle_t handle,
+    TensorDescriptor_t unpacked_desc,
+    void* unpacked_data,
+    double beta)
+    : m_unpacked_desc{unpacked_desc},
+      m_packed_desc{unpacked_desc},
+      m_unpacked_data{unpacked_data},
+      m_packed_data{nullptr},
+      m_handle{handle}
+{
+    if (do_pack_unpack())
+        m_packed_desc = get_packed_desc(unpacked_desc);
+
+    // When "unpacked" == "packed", we don't actually need dt, so we
+    // leave it as the default.
+    if (m_unpacked_desc == m_packed_desc)
+        m_packed_data = m_unpacked_data;
+    else
+    {
+#if 0
+        auto [ptr, data_type] = allocate(m_handle, m_packed_desc);
+        m_packed_data = ptr;
+        m_dt = data_type;
+#endif
+        std::tie(m_packed_data, m_dt) = allocate(m_handle, m_packed_desc);
+
+        if (beta != 0.)
+        {
+            copy_tensor(m_handle,
+                        make_host_scalar(m_dt, 1.0),
+                        m_unpacked_desc,
+                        m_unpacked_data,
+                        make_host_scalar(m_dt, 0.0),
+                        m_packed_desc,
+                        m_packed_data);
+        }
+    }
+}
+
+// This is a "special" dtor because it can throw (and more
+// importantly, semantically, it should be able to throw!). If we
+// "unrolled" the code, this class replaces a pattern something like:
+//
+// x = make_writeable_proxy(unpacked_tensor);
+// do_write_stuff(x);
+// copy(x, unpacked_tensor)
+//
+// and we wouldn't terminate just because "copy(x, unpacked_tensor)"
+// threw... It'd just be a normal exception that someone else could
+// catch.
+//
+// However, the C++ rule is that a dtor cannot throw an exception
+// while unwinding the stack to handle another exception -- such
+// behavior guarantees an std::terminate. We can check for this,
+// though, with std::uncaught_exceptions().
+PackedTensorWriteProxy::~PackedTensorWriteProxy()
+{
+    if ((m_unpacked_data != m_packed_data)
+        && m_packed_data)
+    {
+        if (!std::uncaught_exceptions())
+        {
+            copy_tensor(m_handle,
+                        make_host_scalar(m_dt, 1.0),
+                        m_packed_desc,
+                        m_packed_data,
+                        make_host_scalar(m_dt, 0.0),
+                        m_unpacked_desc,
+                        m_unpacked_data);
+        }
+        DISTCONV_CHECK_GPU(h2::gpu::default_cub_allocator().DeviceFree(m_packed_data));
+        m_packed_data = nullptr;
+        m_unpacked_data = nullptr;
+    }
+    if (m_unpacked_desc != m_packed_desc)
+        destroy_tensor_descriptor(m_packed_desc);
+    m_packed_desc = 0;
+    m_unpacked_desc = 0;
+}
+}// namespace details
+}// namespace distconv

--- a/legacy/src/dnn_backend/pack_unpack.cpp
+++ b/legacy/src/dnn_backend/pack_unpack.cpp
@@ -48,19 +48,17 @@ namespace
 bool do_pack_unpack() noexcept
 {
     static bool const val = []() {
+#if H2_HAS_ROCM
+        bool tf = true;
+#else
+        bool tf = false;
+#endif
         char const* env = std::getenv("H2_DISTCONV_FORCE_PACKED");
         if (env)
-        {
-            bool const tf = (env && std::strlen(env) && env[0] != '0');
-            H2_GPU_INFO("Doing pack/unpack: {}", tf);
-            return tf;
-        }
-#if H2_HAS_ROCM
-        return true;
-#else
-        return false;
-#endif
+            tf = (env && std::strlen(env) && env[0] != '0');
         // Any nonempty string matching "[^0].*" is truthy.
+        H2_GPU_INFO("Doing pack/unpack: {}", tf);
+        return tf;
     } ();
 
     return val;

--- a/legacy/src/dnn_backend/pack_unpack.cpp
+++ b/legacy/src/dnn_backend/pack_unpack.cpp
@@ -57,7 +57,7 @@ bool do_pack_unpack() noexcept
         if (env)
             tf = (env && std::strlen(env) && env[0] != '0');
         // Any nonempty string matching "[^0].*" is truthy.
-        H2_GPU_INFO("Doing pack/unpack: {}", tf);
+        H2_GPU_DEBUG("Doing pack/unpack: {}", tf);
         return tf;
     } ();
 

--- a/legacy/src/dnn_backend/pack_unpack.cpp
+++ b/legacy/src/dnn_backend/pack_unpack.cpp
@@ -21,7 +21,6 @@ void do_gpu_tensor_repack(
     int const* dims,
     int const* src_strides,
     int const* tgt_strides,
-    int const* packed_strides,
     float const* src_data,
     float* tgt_data,
     hipStream_t stream);
@@ -274,7 +273,6 @@ void copy_tensor(
     auto const [tgt_dt, tgt_dims, tgt_strides] = get_details(tgt_desc);
     assert_always(src_dt == tgt_dt);
     assert_always(src_dims == tgt_dims);
-    auto const packed_strides = get_fully_packed_strides(src_dims);
     switch (src_dt)
     {
     case miopenFloat:
@@ -285,7 +283,6 @@ void copy_tensor(
             src_dims.data(),
             src_strides.data(),
             tgt_strides.data(),
-            packed_strides.data(),
             reinterpret_cast<float const*>(src_data),
             reinterpret_cast<float*>(tgt_data),
             stream);

--- a/legacy/src/dnn_backend/pack_unpack.cu
+++ b/legacy/src/dnn_backend/pack_unpack.cu
@@ -63,7 +63,7 @@ __forceinline__ __host__ __device__ auto ceillog2(IType const& d)
     static constexpr auto nbits = NBits<IType>;
     int ell = 0;
     for (ell = 0; ell < nbits; ++ell)
-        if ((1U << ell) >= d)
+        if ((static_cast<IType>(1) << ell) >= d)
             break;
     return ell;
 }

--- a/legacy/src/dnn_backend/pack_unpack.cu
+++ b/legacy/src/dnn_backend/pack_unpack.cu
@@ -1,0 +1,122 @@
+#include <hip/hip_runtime.h>
+
+namespace
+{
+template <typename T, size_t ND>
+struct array
+{
+    T val[ND];
+};
+
+template <size_t ND>
+__global__
+void copy_kernel(float const alpha,
+                 float const beta,
+                 array<int, ND> const dims,
+                 array<int, ND> const src_strides,
+                 array<int, ND> const tgt_strides,
+                 array<int, ND> const packed_strides,
+                 float const* src_data,
+                 float* tgt_data)
+{
+    size_t const max_index = ((size_t) dims.val[0]) * ((size_t) packed_strides.val[0]);
+    for (size_t entry1d = threadIdx.x + blockIdx.x * blockDim.x;
+         entry1d < max_index;
+         entry1d += blockDim.x * gridDim.x)
+    {
+        size_t entry1d_tmp = entry1d;
+        size_t src_idx_1d = 0, tgt_idx_1d = 0;
+#pragma unroll
+        for (size_t i = 0; i < ND; ++i)
+        {
+            int const idx_i = (entry1d / packed_strides.val[i]);
+            src_idx_1d += idx_i * src_strides.val[i];
+            tgt_idx_1d += idx_i * tgt_strides.val[i];
+            entry1d = (entry1d % packed_strides.val[i]);
+        }
+        tgt_data[tgt_idx_1d] = alpha * src_data[src_idx_1d] + beta * tgt_data[tgt_idx_1d];
+    }
+}
+
+template <size_t ND>
+void launch_kernel(float const& alpha,
+                   float const& beta,
+                   int const* dims_in,
+                   int const* src_strides_in,
+                   int const* tgt_strides_in,
+                   int const* packed_strides_in,
+                   float const* src_data,
+                   float* tgt_data,
+                   hipStream_t stream)
+{
+  array<int, ND> dims, src_strides, tgt_strides, packed_strides;
+  std::copy_n(dims_in, ND, dims.val);
+  std::copy_n(src_strides_in, ND, src_strides.val);
+  std::copy_n(tgt_strides_in, ND, tgt_strides.val);
+  std::copy_n(packed_strides_in, ND, packed_strides.val);
+
+  size_t const N = ((size_t) dims_in[0]) * ((size_t) packed_strides_in[0]);
+  size_t const blk_size = 256;
+
+  hipLaunchKernelGGL(copy_kernel,
+                     dim3((N+blk_size-1)/blk_size),
+                     dim3(blk_size),
+                     0,
+                     stream,
+                     alpha,
+                     beta,
+                     dims,
+                     src_strides,
+                     tgt_strides,
+                     packed_strides,
+                     src_data,
+                     tgt_data);
+}
+
+}
+
+namespace distconv
+{
+namespace miopen
+{
+  // A copy with different strides
+void do_gpu_tensor_repack(
+    float const& alpha,
+    float const& beta,
+    size_t const ndims,
+    int const* dims,
+    int const* src_strides,
+    int const* tgt_strides,
+    int const* packed_strides,
+    float const* src_data,
+    float* tgt_data,
+    hipStream_t stream)
+{
+    switch (ndims)
+    {
+    case 1:
+        launch_kernel<1>(alpha, beta, dims, src_strides, tgt_strides, packed_strides, src_data, tgt_data, stream);
+        break;
+    case 2:
+        launch_kernel<2>(alpha, beta, dims, src_strides, tgt_strides, packed_strides, src_data, tgt_data, stream);
+        break;
+    case 3:
+        launch_kernel<3>(alpha, beta, dims, src_strides, tgt_strides, packed_strides, src_data, tgt_data, stream);
+        break;
+    case 4:
+        launch_kernel<4>(alpha, beta, dims, src_strides, tgt_strides, packed_strides, src_data, tgt_data, stream);
+        break;
+    case 5:
+        launch_kernel<5>(alpha, beta, dims, src_strides, tgt_strides, packed_strides, src_data, tgt_data, stream);
+        break;
+    case 6:
+        launch_kernel<6>(alpha, beta, dims, src_strides, tgt_strides, packed_strides, src_data, tgt_data, stream);
+        break;
+    case 7:
+        launch_kernel<7>(alpha, beta, dims, src_strides, tgt_strides, packed_strides, src_data, tgt_data, stream);
+    default:
+        throw std::runtime_error("Unsupported ndims.");
+    }
+}
+} // namespace miopen
+} // namespace distconv

--- a/legacy/src/dnn_backend/pack_unpack.cu
+++ b/legacy/src/dnn_backend/pack_unpack.cu
@@ -2,39 +2,186 @@
 
 namespace
 {
+template <typename T>
+struct IntegerTraits;
+
+template <>
+struct IntegerTraits<int32_t>
+{
+    using type = int32_t;
+    using signed_type = int32_t;
+    using unsigned_type = uint32_t;
+    static constexpr int nbits = 32;
+};
+
+template <>
+struct IntegerTraits<uint32_t>
+{
+    using type = uint32_t;
+    using signed_type = int32_t;
+    using unsigned_type = uint32_t;
+    static constexpr int nbits = 32;
+};
+
+template <>
+struct IntegerTraits<int64_t>
+{
+    using type = int64_t;
+    using signed_type = int64_t;
+    using unsigned_type = uint64_t;
+    static constexpr int nbits = 64;
+};
+
+template <>
+struct IntegerTraits<uint64_t>
+{
+    using type = uint64_t;
+    using signed_type = int64_t;
+    using unsigned_type = uint64_t;
+    static constexpr int nbits = 64;
+};
+
+template <typename IType>
+using SType = typename IntegerTraits<IType>::signed_type;
+
+template <typename IType>
+using UType = typename IntegerTraits<IType>::unsigned_type;
+
+template <typename IType>
+inline constexpr auto NBits = IntegerTraits<IType>::nbits;
+
+template <typename IType>
+inline constexpr bool IsSigned = std::is_same_v<SType<IType>, IType>;
+
+template <typename IType>
+inline constexpr bool IsUnsigned = std::is_same_v<UType<IType>, IType>;
+
+template <typename IType>
+__forceinline__ __host__ __device__ auto ceillog2(IType const& d)
+{
+    static_assert(IsUnsigned<IType>, "divisor should be unsigned");
+    static constexpr auto nbits = NBits<IType>;
+    int ell = 0;
+    for (ell = 0; ell < nbits; ++ell)
+        if ((1U << ell) >= d)
+            break;
+    return ell;
+}
+
+__forceinline__ __device__ uint32_t mulhi(uint32_t x, uint32_t y)
+{
+    return __umulhi(x, y);
+}
+
+__forceinline__ __device__ uint64_t mulhi(uint64_t x, uint64_t y)
+{
+    return __umul64hi(x, y);
+}
+
+// Handy container for the "l" and "m'" values in Figure 4.1 of
+// https://gmplib.org/~tege/divcnst-pldi94.pdf
+template <typename IType>
+class FastDiv
+{
+    static_assert(IsUnsigned<IType>, "FastDiv for unsigned division only");
+
+public:
+    using UInt = UType<IType>;
+
+public:
+    FastDiv() : FastDiv(1u) {}
+    FastDiv(UInt d) : div_{d}
+    {
+        int ell = ceillog2(d);
+        mprime_ =
+            static_cast<UInt>(((1ul << 32) * ((1ul << ell) - d) / d) + 1ul);
+        sh1_ = min(ell, 1);
+        sh2_ = max(ell - 1, 0);
+    }
+
+    // This lets it masquerade as a dim if needed
+    __host__ __device__ operator UInt const&() const noexcept { return div_; }
+    __forceinline__ __host__ __device__ void
+    divmod(UInt const& in, UInt& q, UInt& r) const noexcept
+    {
+        UInt const t1 = mulhi(mprime_, in);
+        // There's a warning in the paper not to compute it this way
+        // since the sum may overflow N bits. In preliminary tests,
+        // overflow was not observed, but the measurable impact on
+        // performance was negligible. So safety first and all that...
+        // But I'm leaving it here in case anyone wants to reevaluate
+        // that claim later on. One shift is better than two. (An
+        // alternative approach could be to use 2*N bits for the
+        // result of (t1+in) and cast the result of the shift back to
+        // N bits before return. I have not looked into any
+        // performance implications of this.)
+        // q = (t1 + in) >> ell_;
+        q = (t1 + ((in - t1) >> sh1_)) >> sh2_;
+        r = in - (q * div_);
+    }
+
+private:
+    UInt div_;
+    UInt mprime_;
+    int sh1_;
+    int sh2_;
+};
+
 template <typename T, size_t ND>
 struct array
 {
     T val[ND];
 };
 
-template <size_t ND>
-__global__
-void copy_kernel(float const alpha,
-                 float const beta,
-                 array<int, ND> const dims,
-                 array<int, ND> const src_strides,
-                 array<int, ND> const tgt_strides,
-                 array<int, ND> const packed_strides,
-                 float const* src_data,
-                 float* tgt_data)
+template <typename IType, size_t ND>
+__forceinline__ __host__ __device__ auto
+get_size(array<FastDiv<IType>, ND> const& dims)
 {
-    size_t const max_index = ((size_t) dims.val[0]) * ((size_t) packed_strides.val[0]);
-    for (size_t entry1d = threadIdx.x + blockIdx.x * blockDim.x;
-         entry1d < max_index;
-         entry1d += blockDim.x * gridDim.x)
-    {
-        size_t entry1d_tmp = entry1d;
-        size_t src_idx_1d = 0, tgt_idx_1d = 0;
+    IType size = 1;
 #pragma unroll
-        for (size_t i = 0; i < ND; ++i)
-        {
-            int const idx_i = (entry1d / packed_strides.val[i]);
-            src_idx_1d += idx_i * src_strides.val[i];
-            tgt_idx_1d += idx_i * tgt_strides.val[i];
-            entry1d = (entry1d % packed_strides.val[i]);
-        }
-        tgt_data[tgt_idx_1d] = alpha * src_data[src_idx_1d] + beta * tgt_data[tgt_idx_1d];
+    for (size_t i = 0; i < ND; ++i)
+        size *= dims.val[i];
+    return size;
+}
+
+template <typename IType, size_t ND>
+__forceinline__ __host__ __device__ IType
+get_real_idx(IType idx,
+             array<FastDiv<IType>, ND> const& dims,
+             array<IType, ND> const& strides)
+{
+    IType real_idx = 0;
+    IType q, r;
+#pragma unroll
+    for (size_t i = 0; i < ND; ++i)
+    {
+        dims.val[i].divmod(idx, q, r);
+        real_idx += r * strides.val[i];
+        idx = q;
+    }
+    return real_idx;
+}
+
+template <typename IType, size_t ND>
+__global__ void copy_kernel(float const alpha,
+                            float const beta,
+                            size_t const max_index,
+                            array<FastDiv<IType>, ND> const dims,
+                            array<IType, ND> const src_strides,
+                            array<IType, ND> const tgt_strides,
+                            float const* src_data,
+                            float* tgt_data)
+{
+    using UInt = UType<IType>;
+    UInt const num_thds = blockDim.x * gridDim.x;
+
+    for (UInt entry1d = threadIdx.x + blockIdx.x * blockDim.x;
+         entry1d < max_index;
+         entry1d += num_thds)
+    {
+        UInt src_idx_1d = get_real_idx(entry1d, dims, src_strides);
+        UInt tgt_idx_1d = get_real_idx(entry1d, dims, tgt_strides);
+        tgt_data[tgt_idx_1d] = src_data[src_idx_1d];
     }
 }
 
@@ -44,79 +191,130 @@ void launch_kernel(float const& alpha,
                    int const* dims_in,
                    int const* src_strides_in,
                    int const* tgt_strides_in,
-                   int const* packed_strides_in,
                    float const* src_data,
                    float* tgt_data,
                    hipStream_t stream)
 {
-  array<int, ND> dims, src_strides, tgt_strides, packed_strides;
-  std::copy_n(dims_in, ND, dims.val);
-  std::copy_n(src_strides_in, ND, src_strides.val);
-  std::copy_n(tgt_strides_in, ND, tgt_strides.val);
-  std::copy_n(packed_strides_in, ND, packed_strides.val);
+    using int_type = uint32_t;
+    using FastDivT = FastDiv<int_type>;
+    array<int_type, ND> src_strides, tgt_strides;
+    array<FastDivT, ND> dims;
+    for (size_t i = ND; i > 0; --i)
+        dims.val[ND - i] = FastDivT(dims_in[i - 1]);
+    std::reverse_copy(src_strides_in, src_strides_in + ND, src_strides.val);
+    std::reverse_copy(tgt_strides_in, tgt_strides_in + ND, tgt_strides.val);
 
-  size_t const N = ((size_t) dims_in[0]) * ((size_t) packed_strides_in[0]);
-  size_t const blk_size = 256;
+    size_t const N = get_size(dims);
+    size_t const blk_size = 256; // 64;
 
-  hipLaunchKernelGGL(copy_kernel,
-                     dim3((N+blk_size-1)/blk_size),
-                     dim3(blk_size),
-                     0,
-                     stream,
-                     alpha,
-                     beta,
-                     dims,
-                     src_strides,
-                     tgt_strides,
-                     packed_strides,
-                     src_data,
-                     tgt_data);
+    hipLaunchKernelGGL(copy_kernel,
+                       dim3((N + blk_size - 1) / blk_size),
+                       dim3(blk_size),
+                       0,
+                       stream,
+                       alpha,
+                       beta,
+                       N,
+                       dims,
+                       src_strides,
+                       tgt_strides,
+                       src_data,
+                       tgt_data);
 }
 
-}
+} // namespace
 
 namespace distconv
 {
 namespace miopen
 {
-  // A copy with different strides
-void do_gpu_tensor_repack(
-    float const& alpha,
-    float const& beta,
-    size_t const ndims,
-    int const* dims,
-    int const* src_strides,
-    int const* tgt_strides,
-    int const* packed_strides,
-    float const* src_data,
-    float* tgt_data,
-    hipStream_t stream)
+
+// A copy with different strides
+void do_gpu_tensor_repack(float const& alpha,
+                          float const& beta,
+                          size_t const ndims,
+                          int const* dims,
+                          int const* src_strides,
+                          int const* tgt_strides,
+                          float const* src_data,
+                          float* tgt_data,
+                          hipStream_t stream)
 {
     switch (ndims)
     {
     case 1:
-        launch_kernel<1>(alpha, beta, dims, src_strides, tgt_strides, packed_strides, src_data, tgt_data, stream);
+        launch_kernel<1>(alpha,
+                         beta,
+                         dims,
+                         src_strides,
+                         tgt_strides,
+                         src_data,
+                         tgt_data,
+                         stream);
         break;
     case 2:
-        launch_kernel<2>(alpha, beta, dims, src_strides, tgt_strides, packed_strides, src_data, tgt_data, stream);
+        launch_kernel<2>(alpha,
+                         beta,
+                         dims,
+                         src_strides,
+                         tgt_strides,
+                         src_data,
+                         tgt_data,
+                         stream);
         break;
     case 3:
-        launch_kernel<3>(alpha, beta, dims, src_strides, tgt_strides, packed_strides, src_data, tgt_data, stream);
+        launch_kernel<3>(alpha,
+                         beta,
+                         dims,
+                         src_strides,
+                         tgt_strides,
+                         src_data,
+                         tgt_data,
+                         stream);
         break;
     case 4:
-        launch_kernel<4>(alpha, beta, dims, src_strides, tgt_strides, packed_strides, src_data, tgt_data, stream);
+        launch_kernel<4>(alpha,
+                         beta,
+                         dims,
+                         src_strides,
+                         tgt_strides,
+                         src_data,
+                         tgt_data,
+                         stream);
         break;
     case 5:
-        launch_kernel<5>(alpha, beta, dims, src_strides, tgt_strides, packed_strides, src_data, tgt_data, stream);
+        launch_kernel<5>(alpha,
+                         beta,
+                         dims,
+                         src_strides,
+                         tgt_strides,
+                         src_data,
+                         tgt_data,
+                         stream);
         break;
     case 6:
-        launch_kernel<6>(alpha, beta, dims, src_strides, tgt_strides, packed_strides, src_data, tgt_data, stream);
+        launch_kernel<6>(alpha,
+                         beta,
+                         dims,
+                         src_strides,
+                         tgt_strides,
+                         src_data,
+                         tgt_data,
+                         stream);
         break;
     case 7:
-        launch_kernel<7>(alpha, beta, dims, src_strides, tgt_strides, packed_strides, src_data, tgt_data, stream);
-    default:
-        throw std::runtime_error("Unsupported ndims.");
+        launch_kernel<7>(alpha,
+                         beta,
+                         dims,
+                         src_strides,
+                         tgt_strides,
+                         src_data,
+                         tgt_data,
+                         stream);
+        break;
+    default: throw std::runtime_error("Unsupported ndims.");
     }
 }
+
 } // namespace miopen
 } // namespace distconv

--- a/src/gpu/memory_utils.cpp
+++ b/src/gpu/memory_utils.cpp
@@ -13,7 +13,7 @@
 #include <cuda_runtime.h>
 #elif H2_HAS_ROCM
 #include <hip/hip_runtime.h>
-#include <hipcub/hipcub.hpp>
+#include <hipcub/util_allocator.hpp>
 #endif
 
 #include <cstdlib>

--- a/test/unit_test/patterns/multimethods/unit_test_switch_dispatcher.cpp
+++ b/test/unit_test/patterns/multimethods/unit_test_switch_dispatcher.cpp
@@ -132,7 +132,7 @@ struct TestFunctorWithArgs
 using DTypes = TL<derived_one, derived_two, derived_three>;
 using DTypesNoD3 = TL<derived_one, derived_two>;
 
-TEST_CASE("Switch dispatcher", "[h2][utils][multimethods]")
+TEST_CASE("Switch dispatcher", "[utilities][multimethods]")
 {
     derived_one d1;
     derived_two d2;

--- a/test/unit_test/utils/CMakeLists.txt
+++ b/test/unit_test/utils/CMakeLists.txt
@@ -6,5 +6,6 @@
 ################################################################################
 
 target_sources(SeqCatchTests PRIVATE
+  unit_test_integer_math.cpp
   unit_test_logging.cpp
   )

--- a/test/unit_test/utils/unit_test_integer_math.cpp
+++ b/test/unit_test/utils/unit_test_integer_math.cpp
@@ -25,6 +25,8 @@ TEMPLATE_TEST_CASE("ceillog2", "[math][utilities]", uint32_t, uint64_t)
     CHECK(ceillog2(static_cast<UInt>(0)) == 0);
     CHECK(ceillog2(std::numeric_limits<UInt>::max()) == bits);
 
+    CHECK(ceillog2(static_cast<UInt>(1)) == 0);
+
     for (auto i = decltype(bits){1}; i < bits; ++i)
     {
         if (i > 1)
@@ -98,11 +100,14 @@ TEMPLATE_TEST_CASE("FastDiv", "[math][utilities]", uint32_t, uint64_t)
     using UInt = TestType;
     using FDiv = FastDiv<UInt>;
 
-    UInt const divisor = 17;
+    UInt const divisor = GENERATE(1,2,3,10,12,17,21,35,50,51,99,100,101);
+    INFO("Divisor = " << divisor);
+
     FDiv divmod = FDiv{divisor};
     UInt q, r;
     for (UInt num = 0; num < 100; ++num)
     {
+        INFO("Numerator = " << num);
         CHECK_NOTHROW(divmod.divmod(num, q, r));
         CHECK(q == num / divisor);
         CHECK(r == num % divisor);

--- a/test/unit_test/utils/unit_test_integer_math.cpp
+++ b/test/unit_test/utils/unit_test_integer_math.cpp
@@ -1,0 +1,111 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#include <catch2/catch.hpp>
+
+#include "h2/utils/IntegerMath.hpp"
+
+#include <type_traits>
+
+using namespace h2;
+
+TEMPLATE_TEST_CASE("ceillog2", "[math][utilities]", uint32_t, uint64_t)
+{
+    using UInt = TestType;
+    static constexpr auto bits = NBits<UInt>;
+    static constexpr auto one = static_cast<UInt>(1);
+
+    // 0 is special -- technically log_2(0) does not exist. But if we
+    // are looking for "the power of two that bounds the input above",
+    // the correct answer is 0.
+    CHECK(ceillog2(static_cast<UInt>(0)) == 0);
+    CHECK(ceillog2(std::numeric_limits<UInt>::max()) == bits);
+
+    for (auto i = decltype(bits){1}; i < bits; ++i)
+    {
+        if (i > 1)
+            CHECK(ceillog2((one << i) - 1) == i);
+        CHECK(ceillog2(one << i) == i);
+        CHECK(ceillog2((one << i) + 1) == i + 1);
+    }
+}
+
+TEMPLATE_TEST_CASE("ispow2", "[math][utilities]", uint32_t, uint64_t)
+{
+    using UInt = TestType;
+    static constexpr auto bits = NBits<UInt>;
+    static constexpr auto one = static_cast<UInt>(1);
+    for (int i = 0; i < bits; ++i)
+    {
+        CHECK(ispow2(one << i));
+        if (i > 0)
+            CHECK_FALSE(ispow2((one << i) + 1));
+    }
+}
+
+TEST_CASE("host mulhi - uint32_t", "[math][utilities]")
+{
+    using UInt = uint32_t;
+    SECTION("Multiplication fits into 32 bits")
+    {
+        UInt a = 7, b = 31;
+        CHECK(mulhi(a, b) == static_cast<UInt>(0));
+    }
+
+    SECTION("Multiplication requires 64 bits")
+    {
+        UInt x = 123151, y = 6235236;
+        CHECK(mulhi(x, y) == 0b10110010U);
+
+        UInt w = 1048575, z = 1048577;
+        CHECK(mulhi(w, z) == 0b11111111U);
+    }
+}
+
+TEST_CASE("host mulhi - uint64_t", "[math][utilities]")
+{
+    using UInt = uint64_t;
+    static constexpr UInt zero = static_cast<UInt>(0);
+    SECTION("Multiplication fits into 64 bits")
+    {
+        // All the uint32_t cases fit in this category now.
+        UInt a = 7, b = 31;
+        CHECK(mulhi(a, b) == zero);
+
+        UInt x = 123151, y = 6235236;
+        CHECK(mulhi(x, y) == zero);
+
+        UInt w = 1048575, z = 1048577;
+        CHECK(mulhi(w, z) == zero);
+    }
+
+    SECTION("Multiplication requires 128 bits")
+    {
+        UInt x = 923151289, y = 96235236762;
+        CHECK(mulhi(x, y) == 0b100);
+
+        UInt w = 8834007663, z = 42587299100;
+        CHECK(mulhi(w, z) == 0b10100);
+    }
+}
+
+TEMPLATE_TEST_CASE("FastDiv", "[math][utilities]", uint32_t, uint64_t)
+{
+    using UInt = TestType;
+    using FDiv = FastDiv<UInt>;
+
+    UInt const divisor = 17;
+    FDiv divmod = FDiv{divisor};
+    UInt q, r;
+    for (UInt num = 0; num < 100; ++num)
+    {
+        CHECK_NOTHROW(divmod.divmod(num, q, r));
+        CHECK(q == num / divisor);
+        CHECK(r == num % divisor);
+    }
+
+}


### PR DESCRIPTION
We are having issues on two fronts:

1. MIOpen doesn't support non-fully-packed tensors at all (despite their API suggesting otherwise).
2. cuDNN is finnicky (but well-documented) about stride compatibility of tensor data.

This PR will address both cases (though at open-time, it only solves (1) nicely (ish)).

A preliminary assessment of the performance cost of packing/unpacking tensors suggests that, for the cosmoflow model, the penalty could exceed a 2x performance loss (1.7s vs 3.9s). But this was a preliminary test and shouldn't be considered conclusive. (My guess is that the pack/unpack kernel can be greatly improved.) That said, the mechanism for handling proxies is "stupid" -- it is meant to approximate the lowest-order attempt to provide API compatibility and correctness. Namely, it constructs a new proxy object for every invocation of a backend function call (it does NOT copy the tensor data when it only needs a packed descriptor, though). A cleverer implementation might, for example, cache a proxy constructed in forward-propagation for use in back-propagation.
