### PR TITLE
[DistConv] Replace every use of HostTransferBackend with the NCCL backend.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,6 +278,10 @@ if (H2_ENABLE_ALUMINUM)
   if (NOT Aluminum_FOUND)
     message(FATAL_ERROR "Aluminum support required but not found.")
   endif ()
+  if (H2_ENABLE_DISTCONV_LEGACY AND NOT AL_HAS_NCCL)
+    message(FATAL_ERROR
+      "DistConv requires Aluminum with at least the NCCLBackend enabled.")
+  endif ()
 endif ()
 
 if (MPI_FOUND AND H2_HAS_ROCM)

--- a/legacy/benchmarks/shuffle_benchmark.cpp
+++ b/legacy/benchmarks/shuffle_benchmark.cpp
@@ -28,7 +28,7 @@
 using DataType = float;
 using namespace distconv;
 using distconv::tensor::Shape;
-using AlBackend = Al::HostTransferBackend;
+using AlBackend = Al::NCCLBackend;
 
 namespace distconv_benchmark {
 

--- a/legacy/include/distconv/dnn_backend/backend_cudnn.hpp
+++ b/legacy/include/distconv/dnn_backend/backend_cudnn.hpp
@@ -798,7 +798,7 @@ public:
 
     MPI_Comm get_comm() { return m_comm; }
 
-    std::shared_ptr<Al::HostTransferBackend::comm_type> get_al_mpi_cuda_comm()
+    std::shared_ptr<Al::NCCLBackend::comm_type> get_al_mpi_cuda_comm()
     {
         return m_al_mpi_cuda_comm;
     }
@@ -847,7 +847,7 @@ public:
         return m_internal_streams_pr[idx];
     }
 
-    std::shared_ptr<Al::HostTransferBackend::comm_type>&
+    std::shared_ptr<Al::NCCLBackend::comm_type>&
     get_internal_al_mpi_cuda_comm(int idx)
     {
         assert_always(idx < (int) m_internal_streams_pr.size());
@@ -979,7 +979,7 @@ public:
 
 protected:
     MPI_Comm m_comm;
-    std::shared_ptr<Al::HostTransferBackend::comm_type> m_al_mpi_cuda_comm;
+    std::shared_ptr<Al::NCCLBackend::comm_type> m_al_mpi_cuda_comm;
     // Keeps a heap object as copying a NCCLCommunicator destroys
     // ncclComm_t
     std::unique_ptr<Al::NCCLBackend::comm_type> m_al_nccl_comm;
@@ -996,10 +996,10 @@ protected:
     std::vector<cudaStream_t> m_internal_streams;
     static constexpr int m_num_internal_streams_pr = 8;
     std::vector<cudaStream_t> m_internal_streams_pr;
-    // The communicator of HostTransferBackend creates new MPI communicators
+    // The communicator of NCCLBackend creates new MPI communicators
     // when constructed even without no argument. Having them as heap
     // objects prevent that.
-    std::vector<std::shared_ptr<Al::HostTransferBackend::comm_type>>
+    std::vector<std::shared_ptr<Al::NCCLBackend::comm_type>>
         m_internal_al_mpi_cuda_comms;
     Options m_opts;
 
@@ -1018,7 +1018,7 @@ protected:
     {
         DISTCONV_CHECK_MPI(MPI_Comm_dup(comm, &m_comm));
         m_al_mpi_cuda_comm =
-            std::make_shared<Al::HostTransferBackend::comm_type>(m_comm,
+            std::make_shared<Al::NCCLBackend::comm_type>(m_comm,
                                                                  m_stream);
         m_al_nccl_comm.reset(new Al::NCCLBackend::comm_type(m_comm, m_stream));
         DISTCONV_CHECK_CUDNN(cudnnSetStream(m_cudnn_h, m_stream));
@@ -1046,7 +1046,7 @@ protected:
         for (int i = 0; i < m_num_internal_streams_pr; ++i)
         {
             m_internal_al_mpi_cuda_comms.push_back(
-                std::make_shared<Al::HostTransferBackend::comm_type>(
+                std::make_shared<Al::NCCLBackend::comm_type>(
                     m_comm, m_internal_streams_pr[i]));
         }
     }

--- a/legacy/include/distconv/dnn_backend/backend_miopen.hpp
+++ b/legacy/include/distconv/dnn_backend/backend_miopen.hpp
@@ -853,7 +853,7 @@ public:
 
     MPI_Comm get_comm() { return m_comm; }
 
-    std::shared_ptr<Al::HostTransferBackend::comm_type> get_al_mpi_cuda_comm()
+    std::shared_ptr<Al::NCCLBackend::comm_type> get_al_mpi_cuda_comm()
     {
         return m_al_mpi_cuda_comm;
     }
@@ -900,7 +900,7 @@ public:
         return m_internal_streams_pr[idx];
     }
 
-    std::shared_ptr<Al::HostTransferBackend::comm_type>&
+    std::shared_ptr<Al::NCCLBackend::comm_type>&
     get_internal_al_mpi_cuda_comm(int idx)
     {
         assert_always(idx < (int) m_internal_streams_pr.size());
@@ -1032,7 +1032,7 @@ public:
 
 protected:
     MPI_Comm m_comm;
-    std::shared_ptr<Al::HostTransferBackend::comm_type> m_al_mpi_cuda_comm;
+    std::shared_ptr<Al::NCCLBackend::comm_type> m_al_mpi_cuda_comm;
     // Keeps a heap object as copying a NCCLCommunicator destroys
     // ncclComm_t
     std::unique_ptr<Al::NCCLBackend::comm_type> m_al_nccl_comm;
@@ -1049,10 +1049,10 @@ protected:
     std::vector<hipStream_t> m_internal_streams;
     static constexpr int m_num_internal_streams_pr = 8;
     std::vector<hipStream_t> m_internal_streams_pr;
-    // The communicator of HostTransferBackend creates new MPI communicators
+    // The communicator of NCCLBackend creates new MPI communicators
     // when constructed even without no argument. Having them as heap
     // objects prevent that.
-    std::vector<std::shared_ptr<Al::HostTransferBackend::comm_type>>
+    std::vector<std::shared_ptr<Al::NCCLBackend::comm_type>>
         m_internal_al_mpi_cuda_comms;
     Options m_opts;
 
@@ -1071,7 +1071,7 @@ protected:
     {
         DISTCONV_CHECK_MPI(MPI_Comm_dup(comm, &m_comm));
         m_al_mpi_cuda_comm =
-            std::make_shared<Al::HostTransferBackend::comm_type>(m_comm,
+            std::make_shared<Al::NCCLBackend::comm_type>(m_comm,
                                                                  m_stream);
         m_al_nccl_comm.reset(new Al::NCCLBackend::comm_type(m_comm, m_stream));
         DISTCONV_CHECK_MIOPEN(miopenSetStream(m_miopen_h, m_stream));
@@ -1096,7 +1096,7 @@ protected:
         for (int i = 0; i < m_num_internal_streams_pr; ++i)
         {
             m_internal_al_mpi_cuda_comms.push_back(
-                std::make_shared<Al::HostTransferBackend::comm_type>(
+                std::make_shared<Al::NCCLBackend::comm_type>(
                     m_comm, m_internal_streams_pr[i]));
         }
     }

--- a/legacy/include/distconv/dnn_backend/convolution.hpp
+++ b/legacy/include/distconv/dnn_backend/convolution.hpp
@@ -1376,41 +1376,41 @@ protected:
 
     HaloExchangeMethod m_halo_xch_method;
     using HaloExchange = tensor::
-        HaloExchange<DataType, tensor::CUDAAllocator, Al::HostTransferBackend>;
+        HaloExchange<DataType, tensor::CUDAAllocator, Al::NCCLBackend>;
     using HaloExchangeMPI = tensor::HaloExchangeMPI<DataType,
                                                     tensor::CUDAAllocator,
-                                                    Al::HostTransferBackend>;
+                                                    Al::NCCLBackend>;
     using HaloExchangeAL = tensor::HaloExchangeAL<DataType,
                                                   tensor::CUDAAllocator,
-                                                  Al::HostTransferBackend>;
+                                                  Al::NCCLBackend>;
 #ifdef DISTCONV_HAS_P2P
     using HaloExchangeP2P = tensor::HaloExchangeP2P<DataType,
                                                     tensor::CUDAAllocator,
-                                                    Al::HostTransferBackend>;
+                                                    Al::NCCLBackend>;
     using HaloExchangeHybrid =
         tensor::HaloExchangeHybrid<DataType,
                                    tensor::CUDAAllocator,
-                                   Al::HostTransferBackend>;
+                                   Al::NCCLBackend>;
 #endif // DISTCONV_HAS_P2P
 #ifdef DISTCONV_HAS_NVSHMEM
     using HaloExchangeNVSHMEM =
         tensor::HaloExchangeNVSHMEM<DataType,
                                     tensor::CUDAAllocator,
-                                    Al::HostTransferBackend>;
+                                    Al::NCCLBackend>;
 #ifdef DISTCONV_HAS_CUDA_GRAPH
     using HaloExchangeNVSHMEMGraph =
         tensor::HaloExchangeNVSHMEMGraph<DataType,
                                          tensor::CUDAAllocator,
-                                         Al::HostTransferBackend>;
+                                         Al::NCCLBackend>;
 #endif // DISTCONV_HAS_CUDA_GRAPH
     using HaloExchangeNVSHMEMDirect =
         tensor::HaloExchangeNVSHMEMDirect<DataType,
                                           tensor::CUDAAllocator,
-                                          Al::HostTransferBackend>;
+                                          Al::NCCLBackend>;
     using HaloExchangeNVSHMEMFusedNotify =
         tensor::HaloExchangeNVSHMEMFusedNotify<DataType,
                                                tensor::CUDAAllocator,
-                                               Al::HostTransferBackend>;
+                                               Al::NCCLBackend>;
 #endif // DISTCONV_HAS_NVSHMEM
     std::unique_ptr<HaloExchange> m_halo_xch_input;
     std::unique_ptr<HaloExchange> m_halo_xch_d_output;
@@ -1429,7 +1429,7 @@ protected:
     BoundaryAttributesV<index_t> m_input_boundary_offsets = 0;
     BoundaryAttributesV<index_t> m_output_boundary_offsets = 0;
     BoundaryAttributesV<h2::gpu::DeviceStream> m_boundary_streams;
-    BoundaryAttributesV<std::shared_ptr<Al::HostTransferBackend::comm_type>>
+    BoundaryAttributesV<std::shared_ptr<Al::NCCLBackend::comm_type>>
         m_boundary_comms;
 
     bool m_enable_profiling;

--- a/legacy/include/distconv/dnn_backend/pooling.hpp
+++ b/legacy/include/distconv/dnn_backend/pooling.hpp
@@ -358,45 +358,45 @@ private:
 
     HaloExchangeMethod m_halo_xch_method;
     using HaloExchange = tensor::
-        HaloExchange<DataType, tensor::CUDAAllocator, Al::HostTransferBackend>;
+        HaloExchange<DataType, tensor::CUDAAllocator, Al::NCCLBackend>;
     using HaloExchangeMPI = tensor::HaloExchangeMPI<DataType,
                                                     tensor::CUDAAllocator,
-                                                    Al::HostTransferBackend>;
+                                                    Al::NCCLBackend>;
     using HaloExchangeAL = tensor::HaloExchangeAL<DataType,
                                                   tensor::CUDAAllocator,
-                                                  Al::HostTransferBackend>;
+                                                  Al::NCCLBackend>;
 #ifdef DISTCONV_HAS_P2P
     using HaloExchangeP2P = tensor::HaloExchangeP2P<DataType,
                                                     tensor::CUDAAllocator,
-                                                    Al::HostTransferBackend>;
+                                                    Al::NCCLBackend>;
     using HaloExchangeHybrid =
         tensor::HaloExchangeHybrid<DataType,
                                    tensor::CUDAAllocator,
-                                   Al::HostTransferBackend>;
+                                   Al::NCCLBackend>;
 #endif // DISTCONV_HAS_P2P
 #ifdef DISTCONV_HAS_NVSHMEM
     using HaloExchangeNVSHMEM =
         tensor::HaloExchangeNVSHMEM<DataType,
                                     tensor::CUDAAllocator,
-                                    Al::HostTransferBackend>;
+                                    Al::NCCLBackend>;
 #ifdef DISTCONV_HAS_CUDA_GRAPH
     using HaloExchangeNVSHMEMGraph =
         tensor::HaloExchangeNVSHMEMGraph<DataType,
                                          tensor::CUDAAllocator,
-                                         Al::HostTransferBackend>;
+                                         Al::NCCLBackend>;
 #endif // DISTCONV_HAS_CUDA_GRAPH
     using HaloExchangeNVSHMEMDirect =
         tensor::HaloExchangeNVSHMEMDirect<DataType,
                                           tensor::CUDAAllocator,
-                                          Al::HostTransferBackend>;
+                                          Al::NCCLBackend>;
     using HaloExchangeNVSHMEMFusedNotify =
         tensor::HaloExchangeNVSHMEMFusedNotify<DataType,
                                                tensor::CUDAAllocator,
-                                               Al::HostTransferBackend>;
+                                               Al::NCCLBackend>;
 #endif // DISTCONV_HAS_NVSHMEM
     std::unique_ptr<HaloExchange> m_halo_xch_input;
     std::unique_ptr<HaloExchange> m_halo_xch_d_input;
-    BoundaryAttributesV<std::shared_ptr<Al::HostTransferBackend::comm_type>>
+    BoundaryAttributesV<std::shared_ptr<Al::NCCLBackend::comm_type>>
         m_boundary_comms;
 
     template <typename Tensor>

--- a/legacy/include/distconv/tensor/shuffle_mpi_cuda_al.hpp
+++ b/legacy/include/distconv/tensor/shuffle_mpi_cuda_al.hpp
@@ -16,7 +16,7 @@ class TensorMPICUDAShufflerAL:
  public:
   TensorMPICUDAShufflerAL(const TensorType &src_tensor,
                           const TensorType &dst_tensor,
-                          Al::HostTransferBackend::comm_type &al_comm,
+                          Al::NCCLBackend::comm_type &al_comm,
                           DataType *src_buf=nullptr,
                           DataType *dst_buf=nullptr):
       TensorMPICUDAShuffler<DataType>(src_tensor, dst_tensor, src_buf, dst_buf),
@@ -26,7 +26,7 @@ class TensorMPICUDAShufflerAL:
   virtual ~TensorMPICUDAShufflerAL() = default;
 
  protected:
-  Al::HostTransferBackend::comm_type &m_al_comm;
+  Al::NCCLBackend::comm_type &m_al_comm;
 
   void transfer(const DataType* send_buf,
                 size_t send_buffer_size,
@@ -36,13 +36,13 @@ class TensorMPICUDAShufflerAL:
                 h2::gpu::DeviceStream stream) override
   {
       // Assumes stream is the same as m_al_comm.get_stream()
-      std::vector<Al::HostTransferBackend::req_type> requests;
+      std::vector<Al::NCCLBackend::req_type> requests;
       for (int i = 0; i < this->get_num_peers(); ++i)
       {
-          requests.push_back(Al::HostTransferBackend::null_req);
+          requests.push_back(Al::NCCLBackend::null_req);
           auto& req = requests.back();
           auto peer = this->m_peers[i];
-          Al::NonblockingSendRecv<Al::HostTransferBackend, DataType>(
+          Al::NonblockingSendRecv<Al::NCCLBackend, DataType>(
               send_buf + this->get_send_displs_h(is_forward)[peer],
               this->get_send_counts(is_forward)[peer],
               peer,
@@ -54,7 +54,7 @@ class TensorMPICUDAShufflerAL:
       }
       for (auto& req : requests)
       {
-          Al::Wait<Al::HostTransferBackend>(req);
+          Al::Wait<Al::NCCLBackend>(req);
       }
   }
 };

--- a/legacy/src/tensor/halo_exchange_cuda.cu
+++ b/legacy/src/tensor/halo_exchange_cuda.cu
@@ -9,7 +9,7 @@ namespace distconv {
 namespace tensor {
 
 template <>
-void HaloExchange<float, CUDAAllocator, Al::HostTransferBackend>::
+void HaloExchange<float, CUDAAllocator, Al::NCCLBackend>::
     pack_or_unpack(int dim,
                    Side side,
                    int width,
@@ -24,7 +24,7 @@ void HaloExchange<float, CUDAAllocator, Al::HostTransferBackend>::
 }
 
 template <>
-void HaloExchange<double, CUDAAllocator, Al::HostTransferBackend>::
+void HaloExchange<double, CUDAAllocator, Al::NCCLBackend>::
     pack_or_unpack(int dim,
                    Side side,
                    int width,

--- a/legacy/src/tensor/halo_exchange_cuda_nvshmem.cu
+++ b/legacy/src/tensor/halo_exchange_cuda_nvshmem.cu
@@ -12,7 +12,7 @@ namespace tensor {
 
 #define DEFINE_FUNC(TYPE)                                               \
   template <>                                                           \
-  void HaloExchangeNVSHMEMDirect<TYPE, CUDAAllocator, Al::HostTransferBackend>::pack_and_put( \
+  void HaloExchangeNVSHMEMDirect<TYPE, CUDAAllocator, Al::NCCLBackend>::pack_and_put( \
       int dim, Side side, int width, cudaStream_t stream,               \
       void *buf, bool is_reverse,                                       \
       void *dst, int peer) {                                            \
@@ -26,7 +26,7 @@ LIST_OF_TYPES
 
 #define DEFINE_FUNC(TYPE)                                               \
   template <>                                                           \
-  void HaloExchangeNVSHMEMFusedNotify<TYPE, CUDAAllocator, Al::HostTransferBackend>:: \
+  void HaloExchangeNVSHMEMFusedNotify<TYPE, CUDAAllocator, Al::NCCLBackend>:: \
   pack_put_notify(                                                      \
       int dim, Side side, int width, cudaStream_t stream,               \
       void *buf, bool is_reverse,                                       \
@@ -43,7 +43,7 @@ LIST_OF_TYPES
 
 #define DEFINE_FUNC(TYPE)                                               \
   template <>                                                           \
-  void HaloExchangeNVSHMEMFusedNotify<TYPE, CUDAAllocator, Al::HostTransferBackend>:: \
+  void HaloExchangeNVSHMEMFusedNotify<TYPE, CUDAAllocator, Al::NCCLBackend>:: \
   wait_and_unpack(                                                      \
       int dim, Side side, int width, cudaStream_t stream,               \
       void *buf, bool is_reverse, HaloExchangeAccumOp op) {             \

--- a/legacy/tests/tensor/test_halo_exchange_cuda.cu
+++ b/legacy/tests/tensor/test_halo_exchange_cuda.cu
@@ -508,11 +508,11 @@ int test_halo_exchange(const Array<ND> &shape,
   for(int i = 0; i < ND - 2; ++i)
     dims.push_back(i);
   DeviceStream stream_main = make_stream();
-  BoundaryAttributesV<std::shared_ptr<Al::HostTransferBackend::comm_type>> comms;
+  BoundaryAttributesV<std::shared_ptr<Al::NCCLBackend::comm_type>> comms;
   apply_to_spatial_sides(ND, [&](int i, Side side) {
       DeviceStream stream = make_stream_nonblocking();
       comms(i, side) =
-          std::make_shared<Al::HostTransferBackend::comm_type>(
+          std::make_shared<Al::NCCLBackend::comm_type>(
               tensor.get_locale().get_comm(), stream);
   });
   for (int i = 0; i < ND - 2; ++i) {
@@ -521,7 +521,7 @@ int test_halo_exchange(const Array<ND> &shape,
     }
   }
 
-  HaloExchange<DataType, CUDAAllocator, Al::HostTransferBackend> *halo_exc = nullptr;
+  HaloExchange<DataType, CUDAAllocator, Al::NCCLBackend> *halo_exc = nullptr;
 #ifdef DISTCONV_HAS_P2P
   p2p::P2P p2p(MPI_COMM_WORLD);
 #endif
@@ -529,47 +529,47 @@ int test_halo_exchange(const Array<ND> &shape,
   switch (method) {
     case HaloExchangeMethod::MPI:
       halo_exc = new HaloExchangeMPI<
-        DataType, CUDAAllocator, Al::HostTransferBackend>(tensor);
+        DataType, CUDAAllocator, Al::NCCLBackend>(tensor);
       util::MPIRootPrintStreamInfo() << "HaloExchangeMPI created";
       break;
     case HaloExchangeMethod::AL:
       halo_exc = new HaloExchangeAL<DataType, CUDAAllocator,
-                                    Al::HostTransferBackend>(tensor);
+                                    Al::NCCLBackend>(tensor);
       util::MPIRootPrintStreamInfo() << "HaloExchangeAL created";
       break;
 #ifdef DISTCONV_HAS_P2P
     case HaloExchangeMethod::P2P:
       halo_exc = new HaloExchangeP2P<
-        DataType, CUDAAllocator, Al::HostTransferBackend>(tensor, p2p);
+        DataType, CUDAAllocator, Al::NCCLBackend>(tensor, p2p);
       util::MPIRootPrintStreamInfo() << "HaloExchangeP2P created";
       break;
     case HaloExchangeMethod::HYBRID:
       halo_exc = new HaloExchangeHybrid<DataType, CUDAAllocator,
-                                        Al::HostTransferBackend>(tensor, p2p);
+                                        Al::NCCLBackend>(tensor, p2p);
       util::MPIRootPrintStreamInfo() << "HaloExchangeHybrid created";
       break;
 #endif // DISTCONV_HAS_P2P
 #ifdef DISTCONV_HAS_NVSHMEM
     case HaloExchangeMethod::NVSHMEM:
       halo_exc = new HaloExchangeNVSHMEM<DataType, CUDAAllocator,
-                                         Al::HostTransferBackend>(tensor);
+                                         Al::NCCLBackend>(tensor);
       util::MPIRootPrintStreamInfo() << "HaloExchangeNVSHMEM created";
       break;
 #ifdef DISTCONV_HAS_CUDA_GRAPH
     case HaloExchangeMethod::NVSHMEM_GRAPH:
       halo_exc = new HaloExchangeNVSHMEMGraph<DataType, CUDAAllocator,
-                                              Al::HostTransferBackend>(tensor);
+                                              Al::NCCLBackend>(tensor);
       util::MPIRootPrintStreamInfo() << "HaloExchangeNVSHMEMGraph created";
       break;
 #endif // DISTCONV_HAS_CUDA_GRAPH
     case HaloExchangeMethod::NVSHMEM_DIRECT:
       halo_exc = new HaloExchangeNVSHMEMDirect<DataType, CUDAAllocator,
-                                               Al::HostTransferBackend>(tensor);
+                                               Al::NCCLBackend>(tensor);
       util::MPIRootPrintStreamInfo() << "HaloExchangeNVSHMEMDirect created";
       break;
     case HaloExchangeMethod::NVSHMEM_FUSED_NOTIFY:
       halo_exc = new HaloExchangeNVSHMEMFusedNotify<DataType, CUDAAllocator,
-                                                    Al::HostTransferBackend>(tensor);
+                                                    Al::NCCLBackend>(tensor);
       util::MPIRootPrintStreamInfo() << "HaloExchangeNVSHMEMFusedNotify created";
       break;
 #endif // DISTCONV_HAS_NVSHMEM
@@ -675,11 +675,11 @@ int test_halo_exchange_reverse(const Array<ND> &shape,
   for(int i = 0; i < ND - 2; ++i)
     dims.push_back(i);
   DeviceStream stream_main = make_stream();
-  SpatialAttributes<ND, std::shared_ptr<Al::HostTransferBackend::comm_type>> comms;
+  SpatialAttributes<ND, std::shared_ptr<Al::NCCLBackend::comm_type>> comms;
   apply_to_spatial_sides<ND>([&](int i, Side side) {
       DeviceStream stream = make_stream();
       comms(i, side) =
-          std::make_shared<Al::HostTransferBackend::comm_type>(
+          std::make_shared<Al::NCCLBackend::comm_type>(
               tensor.get_locale().get_comm(), stream);
   });
   for (int i = 0; i < ND - 2; ++i) {
@@ -688,7 +688,7 @@ int test_halo_exchange_reverse(const Array<ND> &shape,
     }
   }
 
-  HaloExchange<DataType, CUDAAllocator, Al::HostTransferBackend> *halo_exc = nullptr;
+  HaloExchange<DataType, CUDAAllocator, Al::NCCLBackend> *halo_exc = nullptr;
 #ifdef DISTCONV_HAS_P2P
   p2p::P2P p2p(MPI_COMM_WORLD);
 #endif // DISTCONV_HAS_P2P
@@ -696,47 +696,47 @@ int test_halo_exchange_reverse(const Array<ND> &shape,
   switch (method) {
     case HaloExchangeMethod::MPI:
       halo_exc = new HaloExchangeMPI<DataType, CUDAAllocator,
-                                     Al::HostTransferBackend>(tensor);
+                                     Al::NCCLBackend>(tensor);
       util::MPIRootPrintStreamInfo() << "HaloExchangeMPI created";
       break;
     case HaloExchangeMethod::AL:
       halo_exc = new HaloExchangeAL<DataType, CUDAAllocator,
-                                    Al::HostTransferBackend>(tensor);
+                                    Al::NCCLBackend>(tensor);
       util::MPIRootPrintStreamInfo() << "HaloExchangeAL created";
       break;
 #ifdef DISTCONV_HAS_P2P
     case HaloExchangeMethod::P2P:
       halo_exc = new HaloExchangeP2P<DataType, CUDAAllocator,
-                                     Al::HostTransferBackend>(tensor, p2p);
+                                     Al::NCCLBackend>(tensor, p2p);
       util::MPIRootPrintStreamInfo() << "HaloExchangeP2P created";
       break;
     case HaloExchangeMethod::HYBRID:
       halo_exc = new HaloExchangeHybrid<DataType, CUDAAllocator,
-                                        Al::HostTransferBackend>(tensor, p2p);
+                                        Al::NCCLBackend>(tensor, p2p);
       util::MPIRootPrintStreamInfo() << "HaloExchangeHybrid created";
       break;
 #endif // DISTCONV_HAS_P2P
 #ifdef DISTCONV_HAS_NVSHMEM
     case HaloExchangeMethod::NVSHMEM:
       halo_exc = new HaloExchangeNVSHMEM<DataType, CUDAAllocator,
-                                         Al::HostTransferBackend>(tensor);
+                                         Al::NCCLBackend>(tensor);
       util::MPIRootPrintStreamInfo() << "HaloExchangeNVSHMEM created";
       break;
 #ifdef DISTCONV_HAS_CUDA_GRAPH
     case HaloExchangeMethod::NVSHMEM_GRAPH:
       halo_exc = new HaloExchangeNVSHMEMGraph<DataType, CUDAAllocator,
-                                              Al::HostTransferBackend>(tensor);
+                                              Al::NCCLBackend>(tensor);
       util::MPIRootPrintStreamInfo() << "HaloExchangeNVSHMEMGraph created";
       break;
 #endif // DISTCONV_HAS_CUDA_GRAPH
     case HaloExchangeMethod::NVSHMEM_DIRECT:
       halo_exc = new HaloExchangeNVSHMEMDirect<DataType, CUDAAllocator,
-                                               Al::HostTransferBackend>(tensor);
+                                               Al::NCCLBackend>(tensor);
       util::MPIRootPrintStreamInfo() << "HaloExchangeNVSHMEMDirect created";
       break;
     case HaloExchangeMethod::NVSHMEM_FUSED_NOTIFY:
       halo_exc = new HaloExchangeNVSHMEMFusedNotify<DataType, CUDAAllocator,
-                                                    Al::HostTransferBackend>(tensor);
+                                                    Al::NCCLBackend>(tensor);
       util::MPIRootPrintStreamInfo() << "HaloExchangeNVSHMEMFusedNotify created";
       break;
 #endif // DISTCONV_HAS_NVSHMEM

--- a/legacy/tests/tensor/test_tensor_mpi_cuda_shuffle.cu
+++ b/legacy/tests/tensor/test_tensor_mpi_cuda_shuffle.cu
@@ -26,7 +26,7 @@ using DataType = float;
 using namespace distconv;
 using namespace distconv::tensor;
 using namespace h2::gpu;
-using AlBackend = Al::HostTransferBackend;
+using AlBackend = Al::NCCLBackend;
 
 MPI_Comm local_comm;
 int local_comm_size;


### PR DESCRIPTION
Aluminum must be built with NCCL, but it no longer requires HostTransfer. This is now checked in the CMake configuration script.

I think we should generalize this further so that DistConv will run with NCCL if NCCL is available and fallback on HostTransfer if NCCL is not available.

Replaces #62.

Co-authored-by: Nikoli Dryden <ndryden@users.noreply.github.com>