### PR TITLE
Set GPU trace messages to correct level

### DIFF
--- a/include/h2/gpu/cuda/memory_utils.hpp
+++ b/include/h2/gpu/cuda/memory_utils.hpp
@@ -41,7 +41,7 @@ using RawCUBAllocType = cub::CachingDeviceAllocator;
 
 inline void mem_copy(void* dst, void const* src, size_t bytes)
 {
-    H2_GPU_INFO("cudaMemcpy(dst={}, src={}, bytes={}, kind=cudaMemcpyDefault)",
+    H2_GPU_TRACE("cudaMemcpy(dst={}, src={}, bytes={}, kind=cudaMemcpyDefault)",
                 dst,
                 src,
                 bytes);
@@ -51,7 +51,7 @@ inline void mem_copy(void* dst, void const* src, size_t bytes)
 inline void
 mem_copy(void* dst, void const* src, size_t bytes, DeviceStream stream)
 {
-    H2_GPU_INFO("cudaMemcpyAsync(dst={}, src={}, bytes={}, "
+    H2_GPU_TRACE("cudaMemcpyAsync(dst={}, src={}, bytes={}, "
                 "kind=cudaMemcpyDefault, stream={})",
                 dst,
                 src,
@@ -62,13 +62,13 @@ mem_copy(void* dst, void const* src, size_t bytes, DeviceStream stream)
 
 inline void mem_zero(void* mem, size_t bytes)
 {
-    H2_GPU_INFO("cudaMemset(mem={}, value=0x0, bytes={})", mem, bytes);
+    H2_GPU_TRACE("cudaMemset(mem={}, value=0x0, bytes={})", mem, bytes);
     H2_CHECK_CUDA(cudaMemset(mem, 0x0, bytes));
 }
 
 inline void mem_zero(void* mem, size_t bytes, DeviceStream stream)
 {
-    H2_GPU_INFO("cudaMemsetAsync(mem={}, value=0x0, bytes={}, stream={})",
+    H2_GPU_TRACE("cudaMemsetAsync(mem={}, value=0x0, bytes={}, stream={})",
                 mem,
                 bytes,
                 (void*) stream);

--- a/include/h2/gpu/logger.hpp
+++ b/include/h2/gpu/logger.hpp
@@ -23,7 +23,7 @@
 #define H2_LOG_LEVEL_OFF SPDLOG_LEVEL_OFF
 
 #ifndef H2_GPU_LOG_ACTIVE_LEVEL
-#define H2_GPU_LOG_ACTIVE_LEVEL H2_LOG_LEVEL_INFO
+#define H2_GPU_LOG_ACTIVE_LEVEL H2_LOG_LEVEL_TRACE
 #endif
 
 #define H2_GPU_LOG(level, ...)                                                 \

--- a/include/h2/gpu/rocm/memory_utils.hpp
+++ b/include/h2/gpu/rocm/memory_utils.hpp
@@ -41,7 +41,7 @@ inline MemInfo mem_info()
 
 inline void mem_copy(void* const dst, void const* const src, size_t const bytes)
 {
-    H2_GPU_INFO("hipMemcpy(dst={}, src={}, bytes={}, kind=hipMemcpyDefault)",
+    H2_GPU_TRACE("hipMemcpy(dst={}, src={}, bytes={}, kind=hipMemcpyDefault)",
                 dst,
                 src,
                 bytes);
@@ -53,7 +53,7 @@ inline void mem_copy(void* const dst,
                      size_t const bytes,
                      DeviceStream const stream)
 {
-    H2_GPU_INFO("hipMemcpyAsync(dst={}, src={}, bytes={}, "
+    H2_GPU_TRACE("hipMemcpyAsync(dst={}, src={}, bytes={}, "
                 "kind=hipMemcpyDefault, stream={})",
                 dst,
                 src,
@@ -64,13 +64,13 @@ inline void mem_copy(void* const dst,
 
 inline void mem_zero(void* mem, size_t bytes)
 {
-    H2_GPU_INFO("hipMemset(mem={}, value=0x0, bytes={})", mem, bytes);
+    H2_GPU_TRACE("hipMemset(mem={}, value=0x0, bytes={})", mem, bytes);
     H2_CHECK_HIP(hipMemset(mem, 0x0, bytes));
 }
 
 inline void mem_zero(void* mem, size_t bytes, DeviceStream stream)
 {
-    H2_GPU_INFO("hipMemsetAsync(mem={}, value=0x0, bytes={}, stream={})",
+    H2_GPU_TRACE("hipMemsetAsync(mem={}, value=0x0, bytes={}, stream={})",
                 mem,
                 bytes,
                 (void*) stream);

--- a/src/gpu/cuda/runtime.cpp
+++ b/src/gpu/cuda/runtime.cpp
@@ -205,7 +205,7 @@ int h2::gpu::current_gpu()
 
 void h2::gpu::set_gpu(int id)
 {
-    H2_GPU_INFO("setting device to id={}", id);
+    H2_GPU_TRACE("setting device to id={}", id);
     H2_CHECK_CUDA(cudaSetDevice(id));
 }
 
@@ -214,8 +214,8 @@ void h2::gpu::init_runtime()
     if (initialized_)
         return;
 
-    H2_GPU_INFO("initializing gpu runtime");
-    H2_GPU_INFO("found {} devices", num_gpus());
+    H2_GPU_TRACE("initializing gpu runtime");
+    H2_GPU_TRACE("found {} devices", num_gpus());
     set_reasonable_default_gpu();
     initialized_ = true;
 }
@@ -225,7 +225,7 @@ void h2::gpu::finalize_runtime()
     if (!initialized_)
         return;
 
-    H2_GPU_INFO("finalizing gpu runtime");
+    H2_GPU_TRACE("finalizing gpu runtime");
     initialized_ = false;
 }
 
@@ -243,7 +243,7 @@ cudaStream_t h2::gpu::make_stream()
 {
     cudaStream_t stream;
     H2_CHECK_CUDA(cudaStreamCreate(&stream));
-    H2_GPU_INFO("created stream {}", (void*) stream);
+    H2_GPU_TRACE("created stream {}", (void*) stream);
     return stream;
 }
 
@@ -251,13 +251,13 @@ cudaStream_t h2::gpu::make_stream_nonblocking()
 {
     cudaStream_t stream;
     H2_CHECK_CUDA(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
-    H2_GPU_INFO("created non-blocking stream {}", (void*) stream);
+    H2_GPU_TRACE("created non-blocking stream {}", (void*) stream);
     return stream;
 }
 
 void h2::gpu::destroy(cudaStream_t const stream)
 {
-    H2_GPU_INFO("destroy stream {}", (void*) stream);
+    H2_GPU_TRACE("destroy stream {}", (void*) stream);
     H2_CHECK_CUDA(cudaStreamDestroy(stream));
 }
 
@@ -265,7 +265,7 @@ cudaEvent_t h2::gpu::make_event()
 {
     cudaEvent_t event;
     H2_CHECK_CUDA(cudaEventCreate(&event));
-    H2_GPU_INFO("created event {}", (void*) event);
+    H2_GPU_TRACE("created event {}", (void*) event);
     return event;
 }
 
@@ -273,30 +273,30 @@ cudaEvent_t h2::gpu::make_event_notiming()
 {
     cudaEvent_t event;
     H2_CHECK_CUDA(cudaEventCreateWithFlags(&event, cudaEventDisableTiming));
-    H2_GPU_INFO("created non-timing event {}", (void*) event);
+    H2_GPU_TRACE("created non-timing event {}", (void*) event);
     return event;
 }
 
 void h2::gpu::destroy(cudaEvent_t const event)
 {
-    H2_GPU_INFO("destroy event {}", (void*) event);
+    H2_GPU_TRACE("destroy event {}", (void*) event);
     H2_CHECK_CUDA(cudaEventDestroy(event));
 }
 
 void h2::gpu::sync()
 {
-    H2_GPU_INFO("synchronizing gpu");
+    H2_GPU_TRACE("synchronizing gpu");
     H2_CHECK_CUDA(cudaDeviceSynchronize());
 }
 
 void h2::gpu::sync(cudaEvent_t event)
 {
-    H2_GPU_INFO("synchronizing event {}", (void*) event);
+    H2_GPU_TRACE("synchronizing event {}", (void*) event);
     H2_CHECK_CUDA(cudaEventSynchronize(event));
 }
 
 void h2::gpu::sync(cudaStream_t stream)
 {
-    H2_GPU_INFO("synchronizing stream {}", (void*) stream);
+    H2_GPU_TRACE("synchronizing stream {}", (void*) stream);
     H2_CHECK_CUDA(cudaStreamSynchronize(stream));
 }

--- a/src/gpu/memory_utils.cpp
+++ b/src/gpu/memory_utils.cpp
@@ -82,7 +82,7 @@ h2::gpu::RawCUBAllocType make_allocator(unsigned int const gf,
                                         size_t const max_cached,
                                         bool const debug)
 {
-    H2_GPU_INFO("hipcub allocator"
+    H2_GPU_TRACE("hipcub allocator"
                 "(gf={}, min={}, max={}, max_cached={}, debug={})",
                 gf,
                 min,

--- a/src/gpu/rocm/runtime.cpp
+++ b/src/gpu/rocm/runtime.cpp
@@ -303,13 +303,13 @@ static void log_gpu_info(int const gpu_id)
     {
         H2_CHECK_RSMI(rsmi_init(0));
         auto const name = get_device_name_by_pci_bus(pci);
-        H2_GPU_INFO("GPU ID {}: name=\"{}\", pci={:#04x}", gpu_id, name, pci);
+        H2_GPU_TRACE("GPU ID {}: name=\"{}\", pci={:#04x}", gpu_id, name, pci);
     }
     catch (std::runtime_error const& e)
     {
         // Report the error; just log the PCI bus and move on.
         H2_GPU_ERROR("Non-fatal ROCm-SMI error: {}", e.what());
-        H2_GPU_INFO("GPU ID {}: pci={:#04x}", gpu_id, pci);
+        H2_GPU_TRACE("GPU ID {}: pci={:#04x}", gpu_id, pci);
     }
 
     // Ignoring the error code here because we're done with RSMI
@@ -341,7 +341,7 @@ int h2::gpu::current_gpu()
 
 void h2::gpu::set_gpu(int id)
 {
-    H2_GPU_INFO("setting device to id={}", id);
+    H2_GPU_TRACE("setting device to id={}", id);
     H2_CHECK_HIP(hipSetDevice(id));
 }
 
@@ -349,15 +349,15 @@ void h2::gpu::init_runtime()
 {
     if (!initialized_)
     {
-        H2_GPU_INFO("initializing gpu runtime");
+        H2_GPU_TRACE("initializing gpu runtime");
         H2_CHECK_HIP(hipInit(0));
-        H2_GPU_INFO("found {} devices", num_gpus());
+        H2_GPU_TRACE("found {} devices", num_gpus());
         set_reasonable_default_gpu();
         initialized_ = true;
     }
     else
     {
-        H2_GPU_INFO("H2 GPU already initialized; current gpu={}", current_gpu());
+        H2_GPU_TRACE("H2 GPU already initialized; current gpu={}", current_gpu());
     }
     log_gpu_info(current_gpu());
 }
@@ -367,7 +367,7 @@ void h2::gpu::finalize_runtime()
     if (!initialized_)
         return;
 
-    H2_GPU_INFO("finalizing gpu runtime");
+    H2_GPU_TRACE("finalizing gpu runtime");
     initialized_ = false;
 }
 
@@ -385,7 +385,7 @@ hipStream_t h2::gpu::make_stream()
 {
     hipStream_t stream;
     H2_CHECK_HIP(hipStreamCreate(&stream));
-    H2_GPU_INFO("created stream {}", (void*) stream);
+    H2_GPU_TRACE("created stream {}", (void*) stream);
     return stream;
 }
 
@@ -393,13 +393,13 @@ hipStream_t h2::gpu::make_stream_nonblocking()
 {
     hipStream_t stream;
     H2_CHECK_HIP(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
-    H2_GPU_INFO("created non-blocking stream {}", (void*) stream);
+    H2_GPU_TRACE("created non-blocking stream {}", (void*) stream);
     return stream;
 }
 
 void h2::gpu::destroy(hipStream_t stream)
 {
-    H2_GPU_INFO("destroy stream {}", (void*) stream);
+    H2_GPU_TRACE("destroy stream {}", (void*) stream);
     H2_CHECK_HIP(hipStreamDestroy(stream));
 }
 
@@ -407,7 +407,7 @@ hipEvent_t h2::gpu::make_event()
 {
     hipEvent_t event;
     H2_CHECK_HIP(hipEventCreate(&event));
-    H2_GPU_INFO("created event {}", (void*) event);
+    H2_GPU_TRACE("created event {}", (void*) event);
     return event;
 }
 
@@ -415,30 +415,30 @@ hipEvent_t h2::gpu::make_event_notiming()
 {
     hipEvent_t event;
     H2_CHECK_HIP(hipEventCreateWithFlags(&event, hipEventDisableTiming));
-    H2_GPU_INFO("created non-timing event {}", (void*) event);
+    H2_GPU_TRACE("created non-timing event {}", (void*) event);
     return event;
 }
 
 void h2::gpu::destroy(hipEvent_t const event)
 {
-    H2_GPU_INFO("destroy event {}", (void*) event);
+    H2_GPU_TRACE("destroy event {}", (void*) event);
     H2_CHECK_HIP(hipEventDestroy(event));
 }
 
 void h2::gpu::sync()
 {
-    H2_GPU_INFO("synchronizing gpu");
+    H2_GPU_TRACE("synchronizing gpu");
     H2_CHECK_HIP(hipDeviceSynchronize());
 }
 
 void h2::gpu::sync(hipEvent_t event)
 {
-    H2_GPU_INFO("synchronizing event {}", (void*) event);
+    H2_GPU_TRACE("synchronizing event {}", (void*) event);
     H2_CHECK_HIP(hipEventSynchronize(event));
 }
 
 void h2::gpu::sync(hipStream_t stream)
 {
-    H2_GPU_INFO("synchronizing stream {}", (void*) stream);
+    H2_GPU_TRACE("synchronizing stream {}", (void*) stream);
     H2_CHECK_HIP(hipStreamSynchronize(stream));
 }


### PR DESCRIPTION
I had these set to "INFO" to make my life easier while debugging and then forgot to correct it before committing. This fixes that. The messages are all set to `TRACE` now.