### PR TITLE
[DistConv] Cleanup inclusion of backend implementations.

### DIFF
--- a/legacy/benchmarks/distconv_benchmark_common.hpp
+++ b/legacy/benchmarks/distconv_benchmark_common.hpp
@@ -12,6 +12,15 @@
 #include "distconv/util/stopwatch.h"
 #include "distconv/util/util.hpp"
 
+#include "distconv/dnn_backend/batchnorm.hpp"
+#include "distconv/dnn_backend/convolution.hpp"
+#include "distconv/dnn_backend/cross_entropy.hpp"
+#include "distconv/dnn_backend/leaky_relu.hpp"
+#include "distconv/dnn_backend/mean_squared_error.hpp"
+#include "distconv/dnn_backend/pooling.hpp"
+#include "distconv/dnn_backend/relu.hpp"
+#include "distconv/dnn_backend/softmax.hpp"
+
 /*
   Miscellaneous structures and functions that should be only used for
   benchmarks using Distconv. cudnn_benchmark, e.g., should not used

--- a/legacy/include/distconv/dnn_backend/backend.hpp
+++ b/legacy/include/distconv/dnn_backend/backend.hpp
@@ -30,13 +30,4 @@ namespace backend = dnn_lib;
 
 #endif
 
-#include "distconv/dnn_backend/batchnorm.hpp"
-#include "distconv/dnn_backend/convolution.hpp"
-#include "distconv/dnn_backend/cross_entropy.hpp"
-#include "distconv/dnn_backend/leaky_relu.hpp"
-#include "distconv/dnn_backend/mean_squared_error.hpp"
-#include "distconv/dnn_backend/pooling.hpp"
-#include "distconv/dnn_backend/relu.hpp"
-#include "distconv/dnn_backend/softmax.hpp"
-
 #endif // H2_LEGACY_INCLUDE_DISTCONV_CUDNN_BACKEND_HPP_INCLUDED

--- a/legacy/tests/test_common.hpp
+++ b/legacy/tests/test_common.hpp
@@ -13,6 +13,15 @@
 #endif
 #include "distconv/util/cxxopts.hpp"
 
+#include "distconv/dnn_backend/batchnorm.hpp"
+#include "distconv/dnn_backend/convolution.hpp"
+#include "distconv/dnn_backend/cross_entropy.hpp"
+#include "distconv/dnn_backend/leaky_relu.hpp"
+#include "distconv/dnn_backend/mean_squared_error.hpp"
+#include "distconv/dnn_backend/pooling.hpp"
+#include "distconv/dnn_backend/relu.hpp"
+#include "distconv/dnn_backend/softmax.hpp"
+
 namespace test {
 
 using namespace distconv;


### PR DESCRIPTION
Removed inclusion of all known backend layer implementations in the
backend.hpp header.  This should enable a more IWYU paradigm and 
reduce intra-class recomplilation cross-talk.