### PR TITLE
Fix an include path

### DIFF
--- a/test/unit_test/utils/unit_test_logging.cpp
+++ b/test/unit_test/utils/unit_test_logging.cpp
@@ -7,7 +7,7 @@
 
 #include "catch2/catch.hpp"
 #include <h2/utils/Logger.hpp>
-#include "../../src/utils/logger_internals.hpp"
+#include "../src/utils/logger_internals.hpp"
 #include <cstdlib>
 #include <iostream>
 


### PR DESCRIPTION
Not caught in testing because the build directory happened to be setup so both were valid paths.