### PR TITLE
DaCe-powered convolution JIT compiler backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,10 @@ if (H2_ENABLE_ROCM AND NOT H2_ENABLE_HIP_ROCM)
   set(H2_ENABLE_HIP_ROCM ON CACHE BOOL "Use HIP/ROCm backend." FORCE)
 endif ()
 
+option(H2_ENABLE_DACE
+  "Use the DaCe JIT compiler backend for DistConv convolutions in DiHydrogen."
+  OFF)
+
 # Sanity-check the arguments.
 if (H2_ENABLE_DISTCONV_LEGACY)
   # We need one of CUDA or ROCm
@@ -234,6 +238,10 @@ endif ()
 
 if (H2_HAS_CUDA OR H2_HAS_ROCM)
   set(H2_HAS_GPU TRUE)
+endif ()
+
+if (H2_ENABLE_DACE)
+  set(H2_HAS_DACE TRUE)
 endif ()
 
 # DiHydrogen will use MPI-3 features extensively. Until proven

--- a/cmake/config/h2_config.hpp.in
+++ b/cmake/config/h2_config.hpp.in
@@ -19,6 +19,7 @@
 #cmakedefine01 H2_HAS_HALF
 #cmakedefine01 H2_HAS_OPENMP
 
+#cmakedefine01 H2_HAS_DACE
 #cmakedefine01 H2_HAS_CUDA
 #cmakedefine01 H2_HAS_ROCM
 #if H2_HAS_CUDA || H2_HAS_ROCM

--- a/legacy/benchmarks/distconv_benchmark.cpp
+++ b/legacy/benchmarks/distconv_benchmark.cpp
@@ -655,20 +655,20 @@ struct ConvolutionTester<NSD, ref::Backend, DataType> {
 
 #ifdef DISTCONV_HAS_CUDNN
 template <int NSD, typename DataType>
-struct ConvolutionTester<NSD, cudnn::BackendCUDNN, DataType> {
+struct ConvolutionTester<NSD, BackendDNNLib, DataType> {
   ConvolutionTester() {}
-  int operator()(Data<NSD, cudnn::BackendCUDNN, DataType> &d,
+  int operator()(Data<NSD, BackendDNNLib, DataType> &d,
                  const BenchmarkConfig<NSD> &cfg, MPI_Comm comm,
                  Profile<NSD> &prof) {
     int pid;
     DISTCONV_CHECK_MPI(MPI_Comm_rank(MPI_COMM_WORLD, &pid));
     cudnnHandle_t cudnn_h;
     DISTCONV_CHECK_CUDNN(cudnnCreate(&cudnn_h));
-    cudnn::Options be_opts(cfg.overlap_halo_exchange,
+    BackendOptions be_opts(cfg.overlap_halo_exchange,
                            cfg.deterministic,
                            cfg.profiling);
-    cudnn::BackendCUDNN be(comm, cudnn_h, be_opts);
-    Convolution<cudnn::BackendCUDNN, DataType> conv(
+    BackendDNNLib be(comm, cudnn_h, be_opts);
+    Convolution<BackendDNNLib, DataType> conv(
         be, 2 + NSD, cfg.halo_exchange_method, cfg.chanfilt_algo);
     conv.setup(d.input, d.filter, d.output,
                d.d_input, d.d_filter, d.d_output,
@@ -702,25 +702,25 @@ struct ConvolutionTester<NSD, cudnn::BackendCUDNN, DataType> {
         cfg.conv_bwd_filter_algo == "AUTOTUNE") {
       d.initialize();
     }
-    start_profiler<cudnn::BackendCUDNN>();
+    start_profiler<BackendDNNLib>();
     if (cfg.nvtx_marking) {
       be.enable_nvtx_marking();
     }
-    test_convolution_forward<NSD, cudnn::BackendCUDNN, DataType>(
+    test_convolution_forward<NSD, BackendDNNLib, DataType>(
       d, cfg, comm, be, conv, prof);
     // These individual tests are mostly redundant as they are also
     // executed as prt of test_convolution_backward.
 #if 0
-    test_convolution_backward_filter<NSD, cudnn::BackendCUDNN, DataType>(
+    test_convolution_backward_filter<NSD, BackendDNNLib, DataType>(
         d, cfg, comm, be, conv, prof);
-    test_convolution_backward_data<NSD, cudnn::BackendCUDNN, DataType>(
+    test_convolution_backward_data<NSD, BackendDNNLib, DataType>(
         d, cfg, comm, be, conv, prof);
     if (cfg.use_bias) {
-      test_convolution_backward_bias<NSD, cudnn::BackendCUDNN, DataType>(
+      test_convolution_backward_bias<NSD, BackendDNNLib, DataType>(
           d, cfg, comm, be, conv, prof);
     }
 #endif
-    test_convolution_backward<NSD, cudnn::BackendCUDNN, DataType>(
+    test_convolution_backward<NSD, BackendDNNLib, DataType>(
       d, cfg, comm, be, conv, prof);
     // This seems necessary to avoid hang using NVSHMEM v0.3.3
     DISTCONV_CHECK_CUDA(cudaDeviceSynchronize());

--- a/legacy/benchmarks/distconv_benchmark_bn.cpp
+++ b/legacy/benchmarks/distconv_benchmark_bn.cpp
@@ -397,23 +397,23 @@ struct BNTester<NSD, ref::Backend, DataType> {
 
 #ifdef DISTCONV_HAS_CUDNN
 template <int NSD, typename DataType>
-struct BNTester<NSD, cudnn::BackendCUDNN, DataType> {
+struct BNTester<NSD, BackendDNNLib, DataType> {
   BNTester() {}
-  int operator()(Data<NSD, cudnn::BackendCUDNN, DataType> &d,
+  int operator()(Data<NSD, BackendDNNLib, DataType> &d,
                  const BenchmarkConfig<NSD> &cfg, MPI_Comm comm,
                  Profile<NSD> &prof) {
     int pid;
     DISTCONV_CHECK_MPI(MPI_Comm_rank(MPI_COMM_WORLD, &pid));
     cudnnHandle_t cudnn_h;
     DISTCONV_CHECK_CUDNN(cudnnCreate(&cudnn_h));
-    cudnn::Options be_opts(cfg.overlap_halo_exchange,
+    BackendOptions be_opts(cfg.overlap_halo_exchange,
                            cfg.deterministic,
                            cfg.profiling);
-    cudnn::BackendCUDNN be(comm, cudnn_h, be_opts);
-    BatchNormalization<cudnn::BackendCUDNN, DataType> bn(
+    BackendDNNLib be(comm, cudnn_h, be_opts);
+    BatchNormalization<BackendDNNLib, DataType> bn(
         be, 2 + NSD, 0.9, 1e-5, cfg.global_stat, cfg.batchnorm_impl);
     bn.set_num_samples(d.input.get_shape()[-1]);
-    start_profiler<cudnn::BackendCUDNN>();
+    start_profiler<BackendDNNLib>();
     if (cfg.nvtx_marking) {
       be.enable_nvtx_marking();
     }
@@ -454,9 +454,9 @@ struct BNTester<NSD, cudnn::BackendCUDNN, DataType> {
     }
 #endif // DISTCONV_HAS_NVSHMEM
 
-    test_forward<NSD, cudnn::BackendCUDNN, DataType>(
+    test_forward<NSD, BackendDNNLib, DataType>(
         d, cfg, comm, be, bn, prof);
-    test_backward<NSD, cudnn::BackendCUDNN, DataType>(
+    test_backward<NSD, BackendDNNLib, DataType>(
         d, cfg, comm, be, bn, prof);
     return 0;
   }

--- a/legacy/benchmarks/distconv_benchmark_common.hpp
+++ b/legacy/benchmarks/distconv_benchmark_common.hpp
@@ -39,7 +39,7 @@ struct TensorType;
 
 #ifdef DISTCONV_HAS_CUDNN
 template <typename DataType>
-struct TensorType<distconv::cudnn::BackendCUDNN, DataType> {
+struct TensorType<distconv::BackendDNNLib, DataType> {
   using type =
       distconv::tensor::Tensor<DataType,
                                distconv::tensor::LocaleMPI,
@@ -216,11 +216,11 @@ struct Clock<ref::Backend> {
 
 #ifdef DISTCONV_HAS_CUDNN
 template <>
-struct Clock<cudnn::BackendCUDNN> {
-  cudnn::BackendCUDNN &m_be;
+struct Clock<BackendDNNLib> {
+  BackendDNNLib &m_be;
   cudaEvent_t m_ev1;
   cudaEvent_t m_ev2;
-  Clock(cudnn::BackendCUDNN &be):
+  Clock(BackendDNNLib &be):
       m_be(be) {
     DISTCONV_CHECK_CUDA(cudaEventCreate(&m_ev1));
     DISTCONV_CHECK_CUDA(cudaEventCreate(&m_ev2));
@@ -245,7 +245,7 @@ inline void complete_async() {}
 
 #ifdef DISTCONV_HAS_CUDNN
 template <>
-inline void complete_async<cudnn::BackendCUDNN>() {
+inline void complete_async<BackendDNNLib>() {
   DISTCONV_CHECK_CUDA(cudaDeviceSynchronize());
 }
 #endif
@@ -255,8 +255,8 @@ inline void spin_async_device(int ms, Backend &be) {}
 
 #ifdef DISTCONV_HAS_CUDNN
 template <>
-inline void spin_async_device<cudnn::BackendCUDNN>(int ms,
-                                                   cudnn::BackendCUDNN &be) {
+inline void spin_async_device<BackendDNNLib>(int ms,
+                                             BackendDNNLib &be) {
   spin_gpu(ms, 0);
 }
 #endif
@@ -268,11 +268,11 @@ inline void stop_profiler() {}
 
 #ifdef DISTCONV_HAS_CUDNN
 template <>
-inline void start_profiler<cudnn::BackendCUDNN>() {
+inline void start_profiler<BackendDNNLib>() {
   DISTCONV_CHECK_CUDA(cudaProfilerStart());
 }
 template <>
-inline void stop_profiler<cudnn::BackendCUDNN>() {
+inline void stop_profiler<BackendDNNLib>() {
   DISTCONV_CHECK_CUDA(cudaProfilerStop());
 }
 #endif
@@ -359,7 +359,7 @@ inline int run_test(const BenchmarkConfig<NSD> &cfg, MPI_Comm comm) {
   } else if (cfg.backend == "CUDNN") {
     util::MPIRootPrintStreamInfo() << "Using " <<
         util::get_cudnn_version_number_string();
-    return run_test_with_backend<NSD, cudnn::BackendCUDNN, Data, Profile, Tester>(
+    return run_test_with_backend<NSD, BackendDNNLib, Data, Profile, Tester>(
         cfg, MPI_COMM_WORLD);
 #endif
   } else {

--- a/legacy/benchmarks/distconv_benchmark_pooling.cpp
+++ b/legacy/benchmarks/distconv_benchmark_pooling.cpp
@@ -266,24 +266,24 @@ int test_backward(Data<NSD, Backend, DataType> &d,
 
 #ifdef DISTCONV_HAS_CUDNN
 template <int NSD, typename DataType>
-struct PoolingTester<NSD, cudnn::BackendCUDNN, DataType> {
+struct PoolingTester<NSD, BackendDNNLib, DataType> {
   PoolingTester() {}
-  int operator()(Data<NSD, cudnn::BackendCUDNN, DataType> &d,
+  int operator()(Data<NSD, BackendDNNLib, DataType> &d,
                  const BenchmarkConfig<NSD> &cfg, MPI_Comm comm,
                  Profile<NSD> &prof) {
     int pid;
     DISTCONV_CHECK_MPI(MPI_Comm_rank(MPI_COMM_WORLD, &pid));
     cudnnHandle_t cudnn_h;
     DISTCONV_CHECK_CUDNN(cudnnCreate(&cudnn_h));
-    cudnn::Options be_opts(cfg.overlap_halo_exchange,
+    BackendOptions be_opts(cfg.overlap_halo_exchange,
                            cfg.deterministic);
-    cudnn::BackendCUDNN be(comm, cudnn_h, be_opts);
+    BackendDNNLib be(comm, cudnn_h, be_opts);
     if (cfg.nvtx_marking) {
       be.enable_nvtx_marking();
     }
-    test_forward<NSD, cudnn::BackendCUDNN, DataType>(
+    test_forward<NSD, BackendDNNLib, DataType>(
         d, cfg, comm, be, prof);
-    test_backward<NSD, cudnn::BackendCUDNN, DataType>(
+    test_backward<NSD, BackendDNNLib, DataType>(
         d, cfg, comm, be, prof);
     return 0;
   }

--- a/legacy/include/distconv/dnn_backend/backend.hpp
+++ b/legacy/include/distconv/dnn_backend/backend.hpp
@@ -33,7 +33,7 @@ namespace backend = dnn_lib;
 #endif
 
 // DaCe JIT compiler wrapper backend
-#ifdef H2_HAS_DACE
+#if H2_HAS_DACE
 #include "backend_dace.hpp"
 
 namespace distconv

--- a/legacy/include/distconv/dnn_backend/backend.hpp
+++ b/legacy/include/distconv/dnn_backend/backend.hpp
@@ -10,7 +10,7 @@
 #include "backend_cudnn.hpp"
 namespace distconv
 {
-using BackendDNNLib = cudnn::BackendCUDNN;
+using BackendDNNLib_ = cudnn::BackendCUDNN;
 namespace dnn_lib = cudnn;
 namespace backend = dnn_lib;
 } // namespace distconv
@@ -22,7 +22,7 @@ namespace backend = dnn_lib;
 #include "backend_miopen.hpp"
 namespace distconv
 {
-using BackendDNNLib = miopen::BackendMIOpen;
+using BackendDNNLib_ = miopen::BackendMIOpen;
 namespace dnn_lib = miopen;
 namespace backend = dnn_lib;
 } // namespace distconv
@@ -30,6 +30,23 @@ namespace backend = dnn_lib;
 #define GPU_PROFILE_RANGE_POP roctxRangePop
 #define GPU_PROFILE_RANGE_PUSH roctxRangePushA
 
+#endif
+
+// DaCe JIT compiler wrapper backend
+#ifdef H2_HAS_DACE
+#include "backend_dace.hpp"
+
+namespace distconv
+{
+using BackendDNNLib = BackendDaCe;
+using BackendOptions = DaCeOptions;
+} // namespace distconv
+#else
+namespace distconv
+{
+using BackendDNNLib = BackendDNNLib_;
+using BackendOptions = backend::Options;
+} // namespace distconv
 #endif
 
 #endif // H2_LEGACY_INCLUDE_DISTCONV_CUDNN_BACKEND_HPP_INCLUDED

--- a/legacy/include/distconv/dnn_backend/backend_cudnn.hpp
+++ b/legacy/include/distconv/dnn_backend/backend_cudnn.hpp
@@ -634,6 +634,19 @@ public:
                                        util::reverse(shape).data()));
     }
 
+    virtual void
+    setup_tensor_descriptor_internal(TensorDescriptor_t& desc,
+                                     DataType_t dt,
+                                     const std::vector<int>& shape,
+                                     const std::vector<int>& strides)
+    {
+        if (shape.size() == 0)
+            return;
+
+        DISTCONV_CHECK_CUDNN(cudnnSetTensorNdDescriptor(
+            desc, dt, shape.size(), shape.data(), strides.data()));
+    }
+
     template <typename Tensor, typename ShapeType>
     inline void setup_tensor_descriptor(cudnnTensorDescriptor_t& desc,
                                         const Tensor& tensor,
@@ -641,9 +654,6 @@ public:
     {
         cudnnDataType_t dt = util::get_cudnn_type<typename Tensor::data_type>();
         assert_eq(tensor.get_num_dims(), shape.num_dims());
-
-        if (shape.get_size() == 0)
-            return;
 
         // set descriptor for input tensor
         // The size should include halo regions. Convolution will not be
@@ -658,12 +668,11 @@ public:
             << ", shape: " << util::join_array(shape, ", ")
             << ", strides: " << util::join_array(strides, ", ") << "\n";
 
-        DISTCONV_CHECK_CUDNN(cudnnSetTensorNdDescriptor(
+        setup_tensor_descriptor_internal(
             desc,
             dt,
-            shape.num_dims(),
-            util::reverse(IntVector(shape)).data(),
-            util::reverse(strides).get_vector<int>().data()));
+            util::reverse(IntVector(shape)).get_vector<int>(),
+            util::reverse(strides).get_vector<int>());
     }
 
     template <typename Tensor>

--- a/legacy/include/distconv/dnn_backend/backend_dace.hpp
+++ b/legacy/include/distconv/dnn_backend/backend_dace.hpp
@@ -1,0 +1,221 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2023 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include "distconv/util/util_mpi.hpp"
+
+#include <Al.hpp>
+
+#include <map>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <type_traits>
+
+namespace distconv
+{
+enum ConvType
+{
+    FORWARD = 0,
+    BACKWARD_FILTER,
+    BACKWARD_DATA
+};
+
+struct ConvParams
+{
+    int pads[3];
+    int strides[3];
+    int dilation[3];
+};
+
+// 5D shape
+using s5d = std::tuple<int, int, int, int, int>;
+
+struct ConvDescriptor
+{
+    // Tensor parameters
+    s5d x_shape, x_strides;
+    s5d w_shape;
+    s5d y_shape, y_strides;
+
+    // Convolution parameters
+    ConvType type;
+    ConvParams params;
+
+    /**
+     * Returns tensor dimensionality from convolution parameters.
+     **/
+    int get_dimensionality() const
+    {
+        if (std::get<4>(w_shape) == 0)
+        {
+            if (std::get<3>(w_shape) == 0)
+                return 1;
+            return 2;
+        }
+        return 3;
+    }
+
+    std::string hash() const;
+};
+
+using state_and_func = std::tuple<void*, void*>;
+
+struct DaCeOptions : public backend::Options
+{
+    bool m_verbose;
+    std::string m_cachepath;
+
+    DaCeOptions(bool overlap_halo_exchange = false,
+                bool deterministic = false,
+                bool enable_profiling = false,
+                bool ws_capacity_factor = 1.0,
+                bool verbose = true,
+                const char* cachepath = ".jitcache")
+        : Options(overlap_halo_exchange,
+                  deterministic,
+                  enable_profiling,
+                  ws_capacity_factor),
+          m_verbose(verbose),
+          m_cachepath(cachepath)
+    {
+        set_by_environment_variables();
+    }
+    void set_by_environment_variables()
+    {
+        if (std::getenv("DACEDCONV_VERBOSE"))
+        {
+            util::MPIRootPrintStreamDebug() << "Environment variable: "
+                                            << "DACEDCONV_VERBOSE"
+                                            << " detected";
+            m_verbose = true;
+        }
+        if (std::getenv("DACEDCONV_CACHEPATH"))
+        {
+            util::MPIRootPrintStreamDebug() << "Environment variable: "
+                                            << "DACEDCONV_CACHEPATH"
+                                            << " detected";
+            m_cachepath = std::getenv("DACEDCONV_CACHEPATH");
+        }
+    }
+};
+
+// Backend context
+class BackendDaCe : public BackendDNNLib_
+{
+public:
+    BackendDaCe(MPI_Comm comm,
+                backend::Handle_t handle,
+                const DaCeOptions& opts = DaCeOptions())
+        : BackendDNNLib_(comm, handle, opts),
+          m_daceopts(opts),
+          m_curstream(nullptr)
+    {}
+
+    BackendDaCe(MPI_Comm comm,
+                backend::Handle_t handle,
+                backend::Stream_t stream,
+                const DaCeOptions& opts = DaCeOptions())
+        : BackendDNNLib_(comm, handle, stream, opts),
+          m_daceopts(opts),
+          m_curstream(nullptr)
+    {}
+
+    virtual ~BackendDaCe()
+    {
+        // Loop over libraries and unload them
+        for (const auto& iter : m_dace_libraries)
+        {
+            std::string hash = iter.first.hash();
+            if (!unload(hash, iter.second))
+                util::MPIPrintStreamWarning()
+                    << "Unable to unload library: " << hash;
+        }
+    }
+
+    std::string get_name() const
+    {
+        return BackendDNNLib_::get_name() + std::string("_DaCe");
+    }
+
+    state_and_func try_load(const std::string& hash);
+    bool unload(const std::string& hash, state_and_func library);
+
+    void set_stream(backend::Handle_t handle, backend::Stream_t stream);
+
+    template <typename T>
+    void convolution_forward(backend::Handle_t handle,
+                             T const& alpha,
+                             backend::TensorDescriptor_t const& in_desc,
+                             void const* in_data,
+                             backend::FilterDescriptor_t const& filter_desc,
+                             void const* filter_data,
+                             backend::ConvolutionDescriptor_t const& conv_desc,
+                             backend::ConvFwdAlgo_t const& conv_algo,
+                             void* work_data,
+                             size_t work_data_size,
+                             T const& beta,
+                             backend::TensorDescriptor_t const& out_desc,
+                             void* out_data)
+    {
+        printf("FWD\n");
+    }
+
+    template <typename T>
+    void convolution_bwd_data(backend::Handle_t handle,
+                              T const& alpha,
+                              backend::FilterDescriptor_t const& filter_desc,
+                              void const* filter_data,
+                              backend::TensorDescriptor_t const& dy_desc,
+                              void const* dy_data,
+                              backend::ConvolutionDescriptor_t const& conv_desc,
+                              backend::ConvBwdDataAlgo_t const& conv_algo,
+                              void* work_data,
+                              size_t work_data_size,
+                              T const& beta,
+                              backend::TensorDescriptor_t const& dx_desc,
+                              void* dx_data)
+    {
+        printf("BWD-D\n");
+    }
+
+    template <typename T>
+    void
+    convolution_bwd_filter(backend::Handle_t handle,
+                           T const& alpha,
+                           backend::TensorDescriptor_t const& in_desc,
+                           void const* in_data,
+                           backend::TensorDescriptor_t const& dy_desc,
+                           void const* dy_data,
+                           backend::ConvolutionDescriptor_t const& conv_desc,
+                           backend::ConvBwdFilterAlgo_t const& conv_algo,
+                           void* work_data,
+                           size_t work_data_size,
+                           T const& beta,
+                           backend::FilterDescriptor_t const& dw_desc,
+                           void* dw_data)
+    {
+        printf("BWD-F\n");
+    }
+
+protected:
+    DaCeOptions m_daceopts;
+
+    // Data descriptor repository
+    std::map<backend::TensorDescriptor_t, s5d> m_shapes;
+    std::map<backend::TensorDescriptor_t, s5d> m_strides;
+
+    // Convolution descriptor repository
+    std::map<backend::ConvolutionDescriptor_t, ConvParams> m_convs;
+
+    // JIT-compiled libraries
+    std::map<ConvDescriptor, state_and_func> m_dace_libraries;
+
+    backend::Stream_t m_curstream;
+};
+
+} // namespace distconv

--- a/legacy/include/distconv/dnn_backend/backend_miopen.hpp
+++ b/legacy/include/distconv/dnn_backend/backend_miopen.hpp
@@ -358,6 +358,16 @@ public:
                                       strides.data()));
     }
 
+    virtual void
+    setup_tensor_descriptor_internal(TensorDescriptor_t& desc,
+                                     DataType_t dt,
+                                     const std::vector<int>& shape,
+                                     const std::vector<int>& strides)
+    {
+        DISTCONV_CHECK_MIOPEN(miopenSetTensorDescriptor(
+            desc, dt, shape.size(), shape.data(), strides.data()));
+    }
+
     template <typename Tensor, typename ShapeType>
     inline void setup_tensor_descriptor(miopenTensorDescriptor_t& desc,
                                         Tensor const& tensor,
@@ -383,12 +393,11 @@ public:
             << ", shape: " << util::join_array(shape, ", ")
             << ", strides: " << util::join_array(strides, ", ") << "\n";
 
-        DISTCONV_CHECK_MIOPEN(miopenSetTensorDescriptor(
+        setup_tensor_descriptor_internal(
             desc,
             dt,
-            shape.num_dims(),
-            util::reverse(IntVector(shape)).data(),
-            util::reverse(strides).get_vector<int>().data()));
+            util::reverse(IntVector(shape)).get_vector<int>(),
+            util::reverse(strides).get_vector<int>());
     }
 
     template <typename Tensor>

--- a/legacy/include/distconv/dnn_backend/convolution.hpp
+++ b/legacy/include/distconv/dnn_backend/convolution.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "distconv/dnn_backend/backend.hpp"
 #include "distconv/distconv.hpp"
+#include "distconv/dnn_backend/backend.hpp"
 #include "distconv/runtime_gpu.hpp"
 #include "distconv/tensor/halo_exchange_cuda.hpp"
 #include "distconv/tensor/halo_exchange_cuda_al.hpp"
@@ -561,7 +561,7 @@ public:
                     m_output_all_filters_d,
                     m_output_all_filters_t.get_base_ptr(),
                     beta);
-                backend::convolution_forward(
+                m_be.convolution_forward(
                     handle,
                     alpha,
                     input_proxy.desc(),
@@ -592,7 +592,7 @@ public:
                                                 m_output_d,
                                                 output.get_base_ptr(),
                                                 beta);
-                backend::convolution_forward(handle,
+                m_be.convolution_forward(handle,
                                              alpha,
                                              input_proxy.desc(),
                                              input_proxy.ptr(),
@@ -625,7 +625,7 @@ public:
                     m_output_all_filters_d,
                     m_output_all_filters_t.get_base_ptr(),
                     beta);
-                backend::convolution_forward(
+                m_be.convolution_forward(
                     handle,
                     alpha,
                     input_proxy.desc(),
@@ -654,7 +654,7 @@ public:
                         m_output_d,
                         output.get_base_ptr(),
                         beta);
-                    backend::convolution_forward(handle,
+                    m_be.convolution_forward(handle,
                                                  alpha,
                                                  input_proxy.desc(),
                                                  input_proxy.ptr(),
@@ -676,7 +676,7 @@ public:
                         m_output_d,
                         output.get_base_ptr(),
                         beta);
-                    backend::convolution_bwd_data(handle,
+                    m_be.convolution_bwd_data(handle,
                                                   alpha,
                                                   m_filter_d,
                                                   filter.get_const_base_ptr(),
@@ -710,7 +710,7 @@ public:
                     m_output_interior_d,
                     output_interior_ptr,
                     beta);
-                backend::convolution_forward(handle,
+                m_be.convolution_forward(handle,
                                              alpha,
                                              input_proxy.desc(),
                                              input_proxy.ptr(),
@@ -742,7 +742,7 @@ public:
                     << "Launching convolution of boundary at dimension " << i
                     << ", side: " << side;
                 record_start_boundary(i, side);
-                backend::set_stream(handle, st_boundary);
+                m_be.set_stream(handle, st_boundary);
 
                 auto input_proxy = dnn_lib::read_proxy(
                     handle,
@@ -753,7 +753,7 @@ public:
                     m_output_boundaries_d(i, side),
                     boundary_output_ptr,
                     beta);
-                backend::convolution_forward(handle,
+                m_be.convolution_forward(handle,
                                              alpha,
                                              input_proxy.desc(),
                                              input_proxy.ptr(),
@@ -771,7 +771,7 @@ public:
                     ws_boundary);
                 util::wait_stream(st_boundary, m_be.get_stream());
             });
-            backend::set_stream(handle, m_be.get_stream());
+            m_be.set_stream(handle, m_be.get_stream());
         }
 
         if (!skip_chanfilt_comm
@@ -825,7 +825,7 @@ public:
 
         set_num_samples(output.get_local_shape()[-1]);
 
-        backend::apply_fwd_bias(m_be.get_handle(),
+        m_be.apply_fwd_bias(m_be.get_handle(),
                                 alpha,
                                 m_bias_d,
                                 bias.get_const_base_ptr(),
@@ -938,7 +938,7 @@ public:
                 m_d_input_d,
                 d_input_ptr,
                 beta);
-            backend::convolution_bwd_data(
+            m_be.convolution_bwd_data(
                 m_be.get_handle(),
                 alpha,
                 m_filter_d,
@@ -973,7 +973,7 @@ public:
                 m_d_input_all_channels_d,
                 m_d_input_all_channels_t.get_base_ptr(),
                 beta);
-            backend::convolution_bwd_data(
+            m_be.convolution_bwd_data(
                 m_be.get_handle(),
                 alpha,
                 m_filter_d,
@@ -1009,7 +1009,7 @@ public:
                 m_d_input_all_channels_d,
                 m_d_input_all_channels_t.get_base_ptr(),
                 beta);
-            backend::convolution_bwd_data(
+            m_be.convolution_bwd_data(
                 m_be.get_handle(),
                 alpha,
                 m_filter_d,
@@ -1041,7 +1041,7 @@ public:
                     m_d_input_d,
                     d_input_ptr,
                     beta);
-                backend::convolution_bwd_data(m_be.get_handle(),
+                m_be.convolution_bwd_data(m_be.get_handle(),
                                               alpha,
                                               m_filter_d,
                                               filter.get_const_base_ptr(),
@@ -1066,7 +1066,7 @@ public:
                     m_d_input_d,
                     d_input_ptr,
                     beta);
-                backend::convolution_forward(m_be.get_handle(),
+                m_be.convolution_forward(m_be.get_handle(),
                                              alpha,
                                              dy_proxy.desc(),
                                              dy_proxy.ptr(),
@@ -1222,7 +1222,7 @@ public:
                 // against cuDNN anyway, we are already guaranteed
                 // that we have a fully-packed tensor for the filters
                 // and thus we don't need to ever proxy them.
-                backend::convolution_bwd_filter(
+                m_be.convolution_bwd_filter(
                     m_be.get_handle(),
                     alpha,
                     x_proxy.desc(),
@@ -1256,7 +1256,7 @@ public:
                     handle,
                     m_d_output_d,
                     d_output.get_const_buffer());
-                backend::convolution_bwd_filter(
+                m_be.convolution_bwd_filter(
                     m_be.get_handle(),
                     alpha,
                     x_proxy.desc(),
@@ -1290,7 +1290,7 @@ public:
                     handle,
                     m_d_output_gathered_d,
                     m_d_output_gathered_t.get_const_buffer());
-                backend::convolution_bwd_filter(
+                m_be.convolution_bwd_filter(
                     m_be.get_handle(),
                     alpha,
                     x_proxy.desc(),
@@ -1321,7 +1321,7 @@ public:
                         handle,
                         m_d_output_d,
                         d_output.get_const_buffer());
-                    backend::convolution_bwd_filter(m_be.get_handle(),
+                    m_be.convolution_bwd_filter(m_be.get_handle(),
                                                     alpha,
                                                     x_proxy.desc(),
                                                     x_proxy.ptr(),
@@ -1345,7 +1345,7 @@ public:
                         handle,
                         m_input_d,
                         input_ptr);
-                    backend::convolution_bwd_filter(m_be.get_handle(),
+                    m_be.convolution_bwd_filter(m_be.get_handle(),
                                                     alpha,
                                                     x_proxy.desc(),
                                                     x_proxy.ptr(),
@@ -1402,7 +1402,7 @@ public:
 
         set_num_samples(d_output.get_local_shape()[-1]);
         record_start_comp();
-        backend::apply_bwd_bias(m_be.get_handle(),
+        m_be.apply_bwd_bias(m_be.get_handle(),
                                 alpha,
                                 m_d_output_no_halo_d,
                                 d_output.get_const_base_ptr(),

--- a/legacy/include/distconv/dnn_backend/relu.hpp
+++ b/legacy/include/distconv/dnn_backend/relu.hpp
@@ -5,37 +5,36 @@
 
 namespace distconv
 {
-
 template <>
 class ReLU<BackendDNNLib>
 {
 public:
     ReLU(BackendDNNLib& backend)
         : m_be(backend),
-          m_activation_d{backend::make_activation_descriptor()},
-          m_input_d{backend::make_tensor_descriptor()},
-          m_output_d{backend::make_tensor_descriptor()},
-          m_d_input_d{backend::make_tensor_descriptor()},
-          m_d_output_d{backend::make_tensor_descriptor()}
+          m_activation_d{backend.make_activation_descriptor()},
+          m_input_d{backend.make_tensor_descriptor()},
+          m_output_d{backend.make_tensor_descriptor()},
+          m_d_input_d{backend.make_tensor_descriptor()},
+          m_d_output_d{backend.make_tensor_descriptor()}
     {}
 
     ~ReLU()
     {
-        backend::destroy_tensor_descriptor(m_d_output_d);
-        backend::destroy_tensor_descriptor(m_d_input_d);
-        backend::destroy_tensor_descriptor(m_output_d);
-        backend::destroy_tensor_descriptor(m_input_d);
-        backend::destroy_activation_descriptor(m_activation_d);
+        m_be.destroy_tensor_descriptor(m_d_output_d);
+        m_be.destroy_tensor_descriptor(m_d_input_d);
+        m_be.destroy_tensor_descriptor(m_output_d);
+        m_be.destroy_tensor_descriptor(m_input_d);
+        m_be.destroy_activation_descriptor(m_activation_d);
     }
 
     ReLU<BackendDNNLib> operator=(const ReLU<BackendDNNLib>& x)
     {
         assert_always(&m_be == &x.m_be);
-        backend::copy_tensor_descriptor(m_input_d, x.m_input_d);
-        backend::copy_tensor_descriptor(m_output_d, x.m_output_d);
-        backend::copy_tensor_descriptor(m_d_input_d, x.m_d_input_d);
-        backend::copy_tensor_descriptor(m_d_output_d, x.m_d_output_d);
-        backend::copy_activation_descriptor(m_activation_d, x.m_activation_d);
+        m_be.copy_tensor_descriptor(m_input_d, x.m_input_d);
+        m_be.copy_tensor_descriptor(m_output_d, x.m_output_d);
+        m_be.copy_tensor_descriptor(m_d_input_d, x.m_d_input_d);
+        m_be.copy_tensor_descriptor(m_d_output_d, x.m_d_output_d);
+        m_be.copy_activation_descriptor(m_activation_d, x.m_activation_d);
         return *this;
     }
 
@@ -45,11 +44,11 @@ public:
                const Tensor& d_input,
                const ConstTensor& d_output)
     {
-        backend::setup_tensor_descriptor(m_input_d, input, false);
-        backend::setup_tensor_descriptor(m_output_d, output, false);
-        backend::setup_tensor_descriptor(m_d_input_d, d_input, false);
-        backend::setup_tensor_descriptor(m_d_output_d, d_output, false);
-        backend::setup_relu_activation_descriptor(m_activation_d);
+        m_be.setup_tensor_descriptor(m_input_d, input, false);
+        m_be.setup_tensor_descriptor(m_output_d, output, false);
+        m_be.setup_tensor_descriptor(m_d_input_d, d_input, false);
+        m_be.setup_tensor_descriptor(m_d_output_d, d_output, false);
+        m_be.setup_relu_activation_descriptor(m_activation_d);
     }
 
     template <typename Tensor>
@@ -75,14 +74,14 @@ public:
             dnn_lib::read_proxy(handle, m_input_d, input.get_const_base_ptr());
         auto output_proxy = dnn_lib::write_proxy(
             handle, m_output_d, output.get_base_ptr(), beta);
-        backend::activation_forward(m_be.get_handle(),
-                                    m_activation_d,
-                                    alpha,
-                                    input_proxy.desc(),
-                                    input_proxy.ptr(),
-                                    beta,
-                                    output_proxy.desc(),
-                                    output_proxy.ptr());
+        m_be.activation_forward(m_be.get_handle(),
+                                m_activation_d,
+                                alpha,
+                                input_proxy.desc(),
+                                input_proxy.ptr(),
+                                beta,
+                                output_proxy.desc(),
+                                output_proxy.ptr());
         return 0;
     }
 
@@ -116,29 +115,29 @@ public:
             handle, m_input_d, input.get_const_base_ptr());
         auto dx_proxy = dnn_lib::force_write_proxy(
             handle, m_d_input_d, d_input.get_base_ptr(), beta);
-        backend::activation_backward(handle,
-                                     m_activation_d,
-                                     alpha,
-                                     y_proxy.desc(),
-                                     y_proxy.ptr(),
-                                     dy_proxy.desc(),
-                                     dy_proxy.ptr(),
-                                     x_proxy.desc(),
-                                     x_proxy.ptr(),
-                                     beta,
-                                     dx_proxy.desc(),
-                                     dx_proxy.ptr());
+        m_be.activation_backward(handle,
+                                 m_activation_d,
+                                 alpha,
+                                 y_proxy.desc(),
+                                 y_proxy.ptr(),
+                                 dy_proxy.desc(),
+                                 dy_proxy.ptr(),
+                                 x_proxy.desc(),
+                                 x_proxy.ptr(),
+                                 beta,
+                                 dx_proxy.desc(),
+                                 dx_proxy.ptr());
         return 0;
     }
 
     void set_num_samples(int n)
     {
-        if (n != backend::get_tensor_num_samples(m_input_d))
+        if (n != m_be.get_tensor_num_samples(m_input_d))
         {
-            backend::set_tensor_num_samples(m_input_d, n);
-            backend::set_tensor_num_samples(m_output_d, n);
-            backend::set_tensor_num_samples(m_d_input_d, n);
-            backend::set_tensor_num_samples(m_d_output_d, n);
+            m_be.set_tensor_num_samples(m_input_d, n);
+            m_be.set_tensor_num_samples(m_output_d, n);
+            m_be.set_tensor_num_samples(m_d_input_d, n);
+            m_be.set_tensor_num_samples(m_d_output_d, n);
         }
     }
 

--- a/legacy/src/dnn_backend/CMakeLists.txt
+++ b/legacy/src/dnn_backend/CMakeLists.txt
@@ -4,6 +4,10 @@ elseif (H2_HAS_ROCM)
   h2_set_full_path(THIS_DIR_SOURCES backend_miopen.cpp pack_unpack.cpp)
 endif ()
 
+if (H2_HAS_DACE)
+  h2_set_full_path(THIS_DIR_DACE_SOURCES backend_dace.cpp)
+endif ()
+
 h2_set_full_path(THIS_DIR_CU_SOURCES
   pooling.cu
   batchnorm.cu
@@ -19,5 +23,5 @@ if (H2_HAS_ROCM)
 endif ()
 
 set(HEADERS "${HEADERS}" "${THIS_DIR_HEADERS}" PARENT_SCOPE)
-set(SOURCES "${SOURCES}" "${THIS_DIR_SOURCES}" PARENT_SCOPE)
+set(SOURCES "${SOURCES}" "${THIS_DIR_SOURCES}" "${THIS_DIR_DACE_SOURCES}" PARENT_SCOPE)
 set(CUDA_SOURCES "${CUDA_SOURCES}" "${THIS_DIR_CU_SOURCES}" PARENT_SCOPE)

--- a/legacy/src/dnn_backend/backend_dace.cpp
+++ b/legacy/src/dnn_backend/backend_dace.cpp
@@ -1,0 +1,122 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2023 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#include "distconv/dnn_backend/backend.hpp"
+#include "distconv/dnn_backend/backend_dace.hpp"
+
+#include <dlfcn.h>
+
+#include <sstream>
+#include <string>
+
+namespace distconv
+{
+// DaCe-generated function types
+typedef void* (*initfunc_t)();
+typedef void (*exitfunc_t)(void* handle);
+typedef bool (*setstream_t)(void* handle, backend::Stream_t stream);
+typedef void (*daceprogram_fwd_t)(void* handle, float* w, float* x, float* y);
+typedef void (*daceprogram_bwdfilt_t)(void* handle,
+                                      float* dw,
+                                      float* dy,
+                                      float* x);
+typedef void (*daceprogram_bwddata_t)(void* handle,
+                                      float* dx,
+                                      float* dy,
+                                      float* w);
+
+template <class C, class T>
+std::basic_ostream<C, T>& write_s5d(std::basic_ostream<C, T>& os, const s5d& s)
+{
+    return os << std::get<0>(s) << '_' << std::get<1>(s) << '_'
+              << std::get<2>(s) << '_' << std::get<3>(s) << '_'
+              << std::get<4>(s);
+}
+
+std::string ConvDescriptor::hash() const
+{
+    std::stringstream stream;
+    const char* ctype =
+        (this->type == FORWARD
+             ? "fwd"
+             : (this->type == BACKWARD_FILTER ? "bwdfilt" : "bwddata"));
+    stream << "conv" << this->get_dimensionality() << "d_";
+    write_s5d(stream, this->x_shape);
+    write_s5d(stream, this->x_strides);
+    write_s5d(stream, this->w_shape);
+    write_s5d(stream, this->y_shape);
+    write_s5d(stream, this->y_strides);
+    stream << ctype;
+    return stream.str();
+}
+
+state_and_func BackendDaCe::try_load(const std::string& hash)
+{
+    const std::string& path = m_daceopts.m_cachepath;
+    if (path.size() == 0)
+    {
+        util::MPIPrintStreamError()
+            << "ERROR finding build path. Please "
+            << "set the DACEDCONV_CACHEPATH environment variable.";
+        std::abort();
+    }
+
+    std::stringstream fname, initname, funcname;
+    fname << path << "/.dacecache/" << hash << "/build/lib" << hash << ".so";
+    initname << "__dace_init_" << hash;
+    funcname << "__program_" << hash;
+    void* handle = dlopen(fname.str().c_str(), RTLD_LAZY);
+    if (handle)
+    {
+        initfunc_t initfunc =
+            (initfunc_t) dlsym(handle, initname.str().c_str());
+        if (!initfunc)
+        { // No initializer
+            util::MPIPrintStreamError() << "Initializer not found.";
+            std::abort();
+        }
+        void* dacehandle = initfunc();
+
+        // Set the current stream
+        setstream_t setstreamfunc =
+            (setstream_t) dlsym(handle, "__dace_gpu_set_all_streams");
+        if (!setstreamfunc)
+        { // No external stream setter
+            util::MPIPrintStreamError()
+                << "Set stream function not found, please regenerate the code.";
+            std::abort();
+        }
+        if (m_curstream)
+            setstreamfunc(dacehandle, m_curstream);
+        else
+            setstreamfunc(dacehandle, m_stream);
+
+        void* func = dlsym(handle, funcname.str().c_str());
+        if (func)
+            return std::make_tuple(dacehandle, func);
+    }
+    return std::make_tuple(nullptr, nullptr);
+}
+
+bool BackendDaCe::unload(const std::string& hash, state_and_func library)
+{
+    std::stringstream exitname;
+    exitname << "__dace_exit_" << hash;
+    exitfunc_t exitfunc =
+        (exitfunc_t) dlsym(std::get<0>(library), exitname.str().c_str());
+    if (!exitfunc) // Exit function not found
+        return false;
+    exitfunc(std::get<1>(library));
+    return true;
+}
+
+void BackendDaCe::set_stream(backend::Handle_t handle, backend::Stream_t stream)
+{
+    this->m_curstream = stream;
+}
+
+} // namespace distconv

--- a/legacy/src/dnn_backend/backend_dace.cpp
+++ b/legacy/src/dnn_backend/backend_dace.cpp
@@ -37,11 +37,15 @@ std::string ConvDescriptor::hash() const
              : (this->type == BACKWARD_FILTER ? "bwdfilt" : "bwddata"));
     stream << "conv" << this->get_dimensionality() << "d_";
     write_s5d(stream, this->x_shape);
+    stream << '_';
     write_s5d(stream, this->x_strides);
+    stream << '_';
     write_s5d(stream, this->w_shape);
+    stream << '_';
     write_s5d(stream, this->y_shape);
+    stream << '_';
     write_s5d(stream, this->y_strides);
-    stream << ctype;
+    stream << '_' << ctype;
     return stream.str();
 }
 

--- a/legacy/src/dnn_backend/backend_dace.cpp
+++ b/legacy/src/dnn_backend/backend_dace.cpp
@@ -16,18 +16,9 @@
 namespace distconv
 {
 // DaCe-generated function types
-typedef void* (*initfunc_t)();
-typedef void (*exitfunc_t)(void* handle);
-typedef bool (*setstream_t)(void* handle, backend::Stream_t stream);
-typedef void (*daceprogram_fwd_t)(void* handle, float* w, float* x, float* y);
-typedef void (*daceprogram_bwdfilt_t)(void* handle,
-                                      float* dw,
-                                      float* dy,
-                                      float* x);
-typedef void (*daceprogram_bwddata_t)(void* handle,
-                                      float* dx,
-                                      float* dy,
-                                      float* w);
+typedef dacehandle_t (*initfunc_t)();
+typedef void (*exitfunc_t)(dacehandle_t handle);
+typedef bool (*setstream_t)(dacehandle_t handle, backend::Stream_t stream);
 
 template <class C, class T>
 std::basic_ostream<C, T>& write_s5d(std::basic_ostream<C, T>& os, const s5d& s)
@@ -54,8 +45,83 @@ std::string ConvDescriptor::hash() const
     return stream.str();
 }
 
-state_and_func BackendDaCe::try_load(const std::string& hash)
+bool ConvParams::operator<(const ConvParams& other) const
 {
+    for (int i = 0; i < 3; ++i)
+    {
+        if (pads[i] < other.pads[i])
+            return true;
+        if (pads[i] > other.pads[i])
+            return false;
+    }
+    for (int i = 0; i < 3; ++i)
+    {
+        if (strides[i] < other.strides[i])
+            return true;
+        if (strides[i] > other.strides[i])
+            return false;
+    }
+    for (int i = 0; i < 3; ++i)
+    {
+        if (dilation[i] < other.dilation[i])
+            return true;
+        if (dilation[i] > other.dilation[i])
+            return false;
+    }
+    return groups < other.groups;
+}
+
+bool ConvParams::operator==(const ConvParams& other) const
+{
+    for (int i = 0; i < 3; ++i)
+        if (pads[i] != other.pads[i])
+            return false;
+    for (int i = 0; i < 3; ++i)
+        if (strides[i] != other.strides[i])
+            return false;
+    for (int i = 0; i < 3; ++i)
+        if (dilation[i] != other.dilation[i])
+            return false;
+    return groups == other.groups;
+}
+
+bool ConvDescriptor::operator<(const ConvDescriptor& other) const
+{
+    if (type < other.type)
+        return true;
+    if (type == other.type)
+    {
+        if (params < other.params)
+            return true;
+        if (params == other.params)
+        {
+            if (x_shape < other.x_shape)
+                return true;
+            if (x_shape == other.x_shape)
+            {
+                if (x_strides < other.x_strides)
+                    return true;
+                if (x_strides == other.x_strides)
+                {
+                    if (w_shape < other.w_shape)
+                        return true;
+                    if (w_shape == other.w_shape)
+                    {
+                        if (y_shape < other.y_shape)
+                            return true;
+                        if (y_shape == other.y_shape)
+                            return y_strides < other.y_strides;
+                    }
+                }
+            }
+        }
+    }
+    return false;
+}
+
+dace_state BackendDaCe::try_load(const std::string& hash)
+{
+    dace_state result{nullptr, nullptr, nullptr};
     const std::string& path = m_daceopts.m_cachepath;
     if (path.size() == 0)
     {
@@ -74,12 +140,14 @@ state_and_func BackendDaCe::try_load(const std::string& hash)
     {
         initfunc_t initfunc =
             (initfunc_t) dlsym(handle, initname.str().c_str());
+        result.library = handle;
         if (!initfunc)
         { // No initializer
             util::MPIPrintStreamError() << "Initializer not found.";
             std::abort();
         }
-        void* dacehandle = initfunc();
+        dacehandle_t dacehandle = initfunc();
+        result.handle = dacehandle;
 
         // Set the current stream
         setstream_t setstreamfunc =
@@ -95,28 +163,90 @@ state_and_func BackendDaCe::try_load(const std::string& hash)
         else
             setstreamfunc(dacehandle, m_stream);
 
-        void* func = dlsym(handle, funcname.str().c_str());
-        if (func)
-            return std::make_tuple(dacehandle, func);
+        result.func = (daceprogram_t) dlsym(handle, funcname.str().c_str());
     }
-    return std::make_tuple(nullptr, nullptr);
+    return result;
 }
 
-bool BackendDaCe::unload(const std::string& hash, state_and_func library)
+bool BackendDaCe::unload(const std::string& hash, dace_state library)
 {
     std::stringstream exitname;
     exitname << "__dace_exit_" << hash;
     exitfunc_t exitfunc =
-        (exitfunc_t) dlsym(std::get<0>(library), exitname.str().c_str());
-    if (!exitfunc) // Exit function not found
+        (exitfunc_t) dlsym(library.library, exitname.str().c_str());
+    // Exit function not found
+    if (!exitfunc)
+    {
+        dlclose(library.library);
         return false;
-    exitfunc(std::get<1>(library));
+    }
+    exitfunc(library.handle);
+    if (dlclose(library.library))
+        return false;
     return true;
 }
 
 void BackendDaCe::set_stream(backend::Handle_t handle, backend::Stream_t stream)
 {
     this->m_curstream = stream;
+}
+
+dace_state BackendDaCe::compile(const ConvDescriptor& desc, const std::string& hash)
+{
+    dace_state result{nullptr, nullptr, nullptr};
+    std::string script =
+        std::string("python3 -m lbann.jit.generate_conv ") + hash;
+    int res = system(script.c_str());
+    if (res)
+    {
+        util::MPIPrintStreamError()
+            << "Error running JIT compiler script: " << res;
+        // Do not rerun
+        return result;
+    }
+
+    // Try loading library after compiling
+    result = try_load(hash);
+    if (!result.func)
+    {
+        util::MPIPrintStreamError()
+            << "Could not load JIT-compiled library after compilation: "
+            << dlerror();
+        std::abort();
+    }
+    return result;
+}
+
+bool BackendDaCe::invoke(const ConvDescriptor& desc,
+                         void const* x,
+                         void const* w,
+                         void const* y,
+                         float alpha,
+                         float beta,
+                         void* workspace)
+{
+    dace_state library;
+    auto iter = m_dace_libraries.find(desc);
+
+    // Need to JIT compile/load
+    if (iter == m_dace_libraries.end())
+    {
+        std::string hash = desc.hash();
+        library = try_load(hash);
+        // Library does not already exist, compile and reload
+        if (!library.library)
+            library = compile(desc, hash);
+        m_dace_libraries[desc] = library;
+    }
+    else
+    {
+        library = iter->second;
+    }
+
+    if (!library.library)
+        return false; // Fall back to original implementation
+    library.func(library.handle, w, x, y, alpha, beta);
+    return true;
 }
 
 } // namespace distconv

--- a/legacy/tests/dnn_backend/test_leaky_relu.cpp
+++ b/legacy/tests/dnn_backend/test_leaky_relu.cpp
@@ -150,7 +150,7 @@ int test_all<BackendDNNLib>(Data<BackendDNNLib>& d,
     int pid;
     DISTCONV_CHECK_MPI(MPI_Comm_rank(MPI_COMM_WORLD, &pid));
     auto handle = dnn_lib::make_handle();
-    BackendDNNLib be(comm, handle);
+    BackendDNNLib be (comm, handle);
     test_forward<BackendDNNLib>(d, cfg, comm, be);
     test_backward<BackendDNNLib>(d, cfg, comm, be);
     be.wait();

--- a/legacy/tests/test_batchnorm.cpp
+++ b/legacy/tests/test_batchnorm.cpp
@@ -30,7 +30,7 @@ struct TensorType;
 
 #ifdef DISTCONV_HAS_CUDNN
 template <>
-struct TensorType<cudnn::BackendCUDNN> {
+struct TensorType<BackendDNNLib> {
   using type =
       tensor::Tensor<DataType, tensor::LocaleMPI,
                      tensor::CUDAAllocator>;
@@ -200,16 +200,16 @@ int test_all(Data<Backend> &d, const test::Config &cfg,
 
 #ifdef DISTCONV_HAS_CUDNN
 template <>
-int test_all<cudnn::BackendCUDNN>(Data<cudnn::BackendCUDNN> &d,
-                                  const test::Config &cfg,
-                                  MPI_Comm comm) {
+int test_all<BackendDNNLib>(Data<BackendDNNLib> &d,
+                            const test::Config &cfg,
+                            MPI_Comm comm) {
   int pid;
   DISTCONV_CHECK_MPI(MPI_Comm_rank(MPI_COMM_WORLD, &pid));
   cudnnHandle_t cudnn_h;
   DISTCONV_CHECK_CUDNN(cudnnCreate(&cudnn_h));
-  cudnn::BackendCUDNN be(comm, cudnn_h);
-  test_forward<cudnn::BackendCUDNN>(d, cfg, comm, be);
-  test_backward<cudnn::BackendCUDNN>(d, cfg, comm, be);
+  BackendDNNLib be(comm, cudnn_h);
+  test_forward<BackendDNNLib>(d, cfg, comm, be);
+  test_backward<BackendDNNLib>(d, cfg, comm, be);
   be.wait();
   return 0;
 }
@@ -296,7 +296,7 @@ int main(int argc, char *argv[]) {
     int dev = util::choose_gpu();
     util::MPIPrintStreamDebug() << "Using GPU " << dev;
     DISTCONV_CHECK_CUDA(cudaSetDevice(dev));
-    run<cudnn::BackendCUDNN>(cfg, MPI_COMM_WORLD);
+    run<BackendDNNLib>(cfg, MPI_COMM_WORLD);
 #endif
   } else {
     util::MPIRootPrintStreamError() << "Unknown backend name";


### PR DESCRIPTION
This PR adds a light backend that replaces convolutions with JIT compiled convolutions.
It also refactors some of the code in DiHydrogen to use the generic backend classes.