### PR TITLE
Move to Catch2 v3

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+## Copyright 2019-2023 Lawrence Livermore National Security, LLC and other
 ## DiHydrogen Project Developers. See the top-level LICENSE file for details.
 ##
 ## SPDX-License-Identifier: Apache-2.0
@@ -7,15 +7,12 @@
 
 if (H2_ENABLE_TESTS)
   # Setup the Catch2 stuff.
-  find_package(Catch2 2.0.0 CONFIG QUIET
-    HINTS ${CATCH2_DIR} $ENV{CATCH2_DIR} ${CATCH_DIR} $ENV{CATCH_DIR}
-    PATH_SUFFIXES lib64/cmake/Catch2 lib/cmake/Catch2
-    NO_DEFAULT_PATH)
   if (NOT Catch2_FOUND)
-    find_package(Catch2 2.0.0 CONFIG QUIET REQUIRED)
+    find_package(Catch2 3.0.0 CONFIG QUIET REQUIRED)
   endif ()
 
   message(STATUS "Found Catch2: ${Catch2_DIR}")
+  message(STATUS "Catch2 Version: ${Catch2_VERSION}")
   include(Catch)
 
   # Add the actual drivers

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,9 +7,7 @@
 
 if (H2_ENABLE_TESTS)
   # Setup the Catch2 stuff.
-  if (NOT Catch2_FOUND)
-    find_package(Catch2 3.0.0 CONFIG QUIET REQUIRED)
-  endif ()
+  find_package(Catch2 3.0.0 CONFIG REQUIRED)
 
   message(STATUS "Found Catch2: ${Catch2_DIR}")
   message(STATUS "Catch2 Version: ${Catch2_VERSION}")

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+## Copyright 2019-2023 Lawrence Livermore National Security, LLC and other
 ## DiHydrogen Project Developers. See the top-level LICENSE file for details.
 ##
 ## SPDX-License-Identifier: Apache-2.0
@@ -48,15 +48,16 @@ set_tests_properties("[==[Testing the Version String.]==]" PROPERTIES
 # Add the sequential Catch2 driver.
 #
 
-add_executable(SeqCatchTests SequentialCatchMain.cpp)
+add_executable(SeqCatchTests)
 
 # Add Catch2 unit tests
 add_subdirectory(patterns/factory)
 add_subdirectory(patterns/multimethods)
 add_subdirectory(utils)
 
+# These tests use the default Catch2 main().
 target_link_libraries(SeqCatchTests
-  PRIVATE ${H2_LIBRARIES} Catch2::Catch2)
+  PRIVATE ${H2_LIBRARIES} Catch2::Catch2WithMain)
 set_target_properties(SeqCatchTests
   PROPERTIES
   CXX_STANDARD 17

--- a/test/unit_test/patterns/factory/unit_test_copy_factory.cpp
+++ b/test/unit_test/patterns/factory/unit_test_copy_factory.cpp
@@ -1,13 +1,13 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2023 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
-#include <h2/patterns/factory/CopyFactory.hpp>
+#include "h2/patterns/factory/CopyFactory.hpp"
 
 #include <memory>
 #include <typeinfo>

--- a/test/unit_test/patterns/factory/unit_test_object_factory.cpp
+++ b/test/unit_test/patterns/factory/unit_test_object_factory.cpp
@@ -1,11 +1,12 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2023 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
 
 #include <h2/patterns/factory/ObjectFactory.hpp>
 

--- a/test/unit_test/patterns/factory/unit_test_prototype_factory.cpp
+++ b/test/unit_test/patterns/factory/unit_test_prototype_factory.cpp
@@ -1,11 +1,11 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2023 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <h2/patterns/factory/PrototypeFactory.hpp>
 

--- a/test/unit_test/patterns/multimethods/unit_test_switch_dispatcher.cpp
+++ b/test/unit_test/patterns/multimethods/unit_test_switch_dispatcher.cpp
@@ -1,11 +1,11 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2023 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include "h2/meta/TypeList.hpp"
 #include "h2/patterns/multimethods/SwitchDispatcher.hpp"

--- a/test/unit_test/utils/unit_test_integer_math.cpp
+++ b/test/unit_test/utils/unit_test_integer_math.cpp
@@ -1,11 +1,12 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2023 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
 
 #include "h2/utils/IntegerMath.hpp"
 

--- a/test/unit_test/utils/unit_test_logging.cpp
+++ b/test/unit_test/utils/unit_test_logging.cpp
@@ -1,16 +1,18 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2023 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0
 ////////////////////////////////////////////////////////////////////////////////
 
-#include "catch2/catch.hpp"
-#include <h2/utils/Logger.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+
+#include "h2/utils/Logger.hpp"
 #include "../src/utils/logger_internals.hpp"
+
 #include <cstdlib>
 #include <iostream>
-
 
 TEST_CASE("Testing the internal functions used by the logging class",
           "[logging][utilities]")


### PR DESCRIPTION
This moves unilaterally to Catch2 v3 without backward compatibility to v2.x.