### PR TITLE
DaCe-powered JIT convolutions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,10 @@ if (H2_ENABLE_ROCM AND NOT H2_ENABLE_HIP_ROCM)
   set(H2_ENABLE_HIP_ROCM ON CACHE BOOL "Use HIP/ROCm backend." FORCE)
 endif ()
 
+option(H2_ENABLE_DACE
+  "Use the DaCe JIT compiler backend for DistConv convolutions in DiHydrogen."
+  OFF)
+
 # Sanity-check the arguments.
 if (H2_ENABLE_DISTCONV_LEGACY)
   # We need one of CUDA or ROCm
@@ -260,6 +264,11 @@ endif ()
 
 if (H2_HAS_CUDA OR H2_HAS_ROCM)
   set(H2_HAS_GPU TRUE)
+endif ()
+
+if (H2_ENABLE_DACE)
+  set(H2_HAS_DACE TRUE)
+  message(STATUS "Using DaCe JIT-capable backend")
 endif ()
 
 # DiHydrogen will use MPI-3 features extensively. Until proven

--- a/cmake/config/h2_config.hpp.in
+++ b/cmake/config/h2_config.hpp.in
@@ -26,6 +26,7 @@
 #endif
 
 #cmakedefine01 H2_HAS_MPI
+#cmakedefine01 H2_HAS_DACE
 
 // Features detected at configure time
 #define H2_PRETTY_FUNCTION @H2_PRETTY_FUNCTION@

--- a/legacy/include/distconv/dnn_backend/backend.hpp
+++ b/legacy/include/distconv/dnn_backend/backend.hpp
@@ -1,3 +1,10 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2023 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
 #pragma once
 #ifndef H2_LEGACY_INCLUDE_DISTCONV_BACKEND_HPP_INCLUDED
 #define H2_LEGACY_INCLUDE_DISTCONV_BACKEND_HPP_INCLUDED
@@ -7,10 +14,18 @@
 #include "dnn_backend.hpp"
 #include "dnn_backend_impl.hpp"
 
+#if H2_HAS_DACE
+#include "dace_backend.hpp"
+#endif
+
 // LBANN is looking for this in the distconv ns
 namespace distconv
 {
+#if H2_HAS_DACE
+using BackendDNNLib = DaCeDNNBackend<distconv::GPUDNNBackend>;
+#else
 using BackendDNNLib = DNNBackend<distconv::GPUDNNBackend>;
+#endif
 // FIXME trb: HACK to make LBANN compile
 namespace backend
 {

--- a/legacy/include/distconv/dnn_backend/dace_backend.hpp
+++ b/legacy/include/distconv/dnn_backend/dace_backend.hpp
@@ -156,6 +156,11 @@ public:
                    Options opts = Options{});
     virtual ~DaCeDNNBackend();
 
+    // Use the other overloads from the base class
+    using DNNBackend<VendorBackendT>::convolution_forward;
+    using DNNBackend<VendorBackendT>::convolution_bwd_data;
+    using DNNBackend<VendorBackendT>::convolution_bwd_filter;
+
     void convolution_forward(double alpha,
                              TensorDescriptor_t const& xdesc,
                              void const* x,
@@ -169,6 +174,34 @@ public:
                              TensorDescriptor_t const& ydesc,
                              void* y,
                              Stream_t s) const override;
+
+    void convolution_bwd_data(double alpha,
+                              FilterDescriptor_t const& filter_desc,
+                              void const* filter_data,
+                              TensorDescriptor_t const& dy_desc,
+                              void const* dy_data,
+                              ConvolutionDescriptor_t const& conv_desc,
+                              ConvBwdDataAlgo_t const& conv_algo,
+                              void* workspace,
+                              size_t workspace_bytes,
+                              double beta,
+                              TensorDescriptor_t const& dx_desc,
+                              void* dx_data,
+                              Stream_t s) const override;
+
+    void convolution_bwd_filter(double alpha,
+                                TensorDescriptor_t const& in_desc,
+                                void const* in_data,
+                                TensorDescriptor_t const& dy_desc,
+                                void const* dy_data,
+                                ConvolutionDescriptor_t const& conv_desc,
+                                ConvBwdFilterAlgo_t const& conv_algo,
+                                void* workspace,
+                                size_t workspace_bytes,
+                                double beta,
+                                FilterDescriptor_t const& dw_desc,
+                                void* dw_data,
+                                Stream_t s) const override;
 
 protected:
     // JIT-compiled libraries

--- a/legacy/include/distconv/dnn_backend/dace_backend.hpp
+++ b/legacy/include/distconv/dnn_backend/dace_backend.hpp
@@ -103,9 +103,9 @@ typedef void (*dynbatch_daceprogram_t)(dacehandle_t handle,
                                        void const*,
                                        void const*,
                                        void const*,
+                                       int B,
                                        float alpha,
-                                       float beta,
-                                       int B);
+                                       float beta);
 typedef size_t (*dynbatch_getworkspacesize_t)(dacehandle_t handle, int B);
 typedef void (*dynbatch_setworkspace_t)(dacehandle_t handle,
                                         void* workspace,

--- a/legacy/include/distconv/dnn_backend/dace_backend.hpp
+++ b/legacy/include/distconv/dnn_backend/dace_backend.hpp
@@ -1,0 +1,199 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2023 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <map>
+#include <tuple>
+
+#include "dnn_backend.hpp"
+
+namespace distconv
+{
+/** @brief Type of JIT-compiled convolution **/
+enum ConvType
+{
+    FORWARD = 0,
+    BACKWARD_FILTER,
+    BACKWARD_DATA
+};
+
+/** @brief Convolution parameters **/
+struct ConvParams
+{
+    int pads[3];
+    int strides[3];
+    int dilation[3];
+    int groups;
+
+    bool operator<(const ConvParams& other) const;
+    bool operator==(const ConvParams& other) const;
+};
+
+// 5D shape
+using s5d = std::tuple<int, int, int, int, int>;
+inline void set_value(s5d& shape, int d, int n)
+{
+    switch (d)
+    {
+    case 0: std::get<0>(shape) = n; break;
+    case 1: std::get<1>(shape) = n; break;
+    case 2: std::get<2>(shape) = n; break;
+    case 3: std::get<3>(shape) = n; break;
+    case 4: std::get<4>(shape) = n; break;
+    default: break;
+    }
+}
+
+/**
+ * @brief A convolution descriptor with a one-to-one correspondence to a
+ * JIT-compiled library.
+ **/
+struct ConvDescriptor
+{
+    // Tensor parameters
+    s5d x_shape, x_strides;
+    s5d w_shape;
+    s5d y_shape, y_strides;
+
+    // Convolution parameters
+    ConvType type;
+    ConvParams params;
+
+    /**
+     * Returns tensor dimensionality from convolution parameters.
+     **/
+    int get_dimensionality() const
+    {
+        if (std::get<4>(w_shape) == 0)
+        {
+            if (std::get<3>(w_shape) == 0)
+                return 1;
+            return 2;
+        }
+        return 3;
+    }
+
+    std::string hash(bool dynamic_minibatch_size = false) const;
+
+    bool operator<(const ConvDescriptor& other) const;
+};
+
+// Definition of dace types
+typedef void* dacehandle_t;
+typedef bool (*dace_setstream_t)(dacehandle_t handle, void const* stream);
+typedef void (*dace_exitfunc_t)(dacehandle_t handle);
+
+// void const* below act as catch-all pointers for data types and fwd/bwd
+typedef void (*daceprogram_t)(dacehandle_t handle,
+                              void const*,
+                              void const*,
+                              void const*,
+                              float alpha,
+                              float beta);
+// A version of the above JIT-compiled convolution with runtime minibatch size
+typedef void (*dynbatch_daceprogram_t)(dacehandle_t handle,
+                                       void const*,
+                                       void const*,
+                                       void const*,
+                                       float alpha,
+                                       float beta,
+                                       int B);
+
+/**
+ * @brief An internal DaCe-compiled function's state; contains handles and
+ * function pointers and handles.
+ **/
+struct dace_state
+{
+    void* library;
+    dacehandle_t handle;
+    dace_setstream_t setstream_func;
+    daceprogram_t func;
+    dynbatch_daceprogram_t dynbatch_func;
+    dace_exitfunc_t dtor;
+
+    dace_state()
+        : library(nullptr),
+          handle(nullptr),
+          setstream_func(nullptr),
+          func(nullptr),
+          dynbatch_func(nullptr),
+          dtor(nullptr)
+    {}
+};
+
+template <typename VendorBackendT>
+class DaCeDNNBackend : public DNNBackend<VendorBackendT>
+{
+public:
+    using VendorBackend = VendorBackendT;
+    using ActivationDescriptor_t =
+        typename VendorBackend::ActivationDescriptor_t;
+    using ConvBwdDataAlgo_t = typename VendorBackend::ConvBwdDataAlgo_t;
+    using ConvBwdFilterAlgo_t = typename VendorBackend::ConvBwdFilterAlgo_t;
+    using ConvFwdAlgo_t = typename VendorBackend::ConvFwdAlgo_t;
+    using ConvolutionDescriptor_t =
+        typename VendorBackend::ConvolutionDescriptor_t;
+    using ConvolutionMode_t = typename VendorBackend::ConvolutionMode_t;
+    using DataType_t = typename VendorBackend::DataType_t;
+    using Event_t = typename VendorBackend::Event_t;
+    using FilterDescriptor_t = typename VendorBackend::FilterDescriptor_t;
+    using Handle_t = typename VendorBackend::Handle_t;
+    using PoolingDescriptor_t = typename VendorBackend::PoolingDescriptor_t;
+    using PoolingMode_t = typename VendorBackend::PoolingMode_t;
+    using Stream_t = typename VendorBackend::Stream_t;
+    using TensorDescriptor_t = typename VendorBackend::TensorDescriptor_t;
+
+    DaCeDNNBackend(MPI_Comm comm, Handle_t handle, Options opts = Options{});
+    DaCeDNNBackend(MPI_Comm comm,
+                   Handle_t handle,
+                   Stream_t stream,
+                   Options opts = Options{});
+    virtual ~DaCeDNNBackend();
+
+    void convolution_forward(double alpha,
+                             TensorDescriptor_t const& xdesc,
+                             void const* x,
+                             FilterDescriptor_t const& filter_desc,
+                             void const* filter_data,
+                             ConvolutionDescriptor_t const& conv_desc,
+                             ConvFwdAlgo_t const& conv_algo,
+                             void* workspace,
+                             size_t workspace_bytes,
+                             double beta,
+                             TensorDescriptor_t const& ydesc,
+                             void* y,
+                             Stream_t s) const override;
+
+protected:
+    // JIT-compiled libraries
+    mutable std::map<ConvDescriptor, dace_state> m_dace_libraries;
+
+    bool descriptor_from_tensors(TensorDescriptor_t const& xdesc,
+                                 FilterDescriptor_t const& filter_desc,
+                                 ConvolutionDescriptor_t const& conv_desc,
+                                 TensorDescriptor_t const& ydesc,
+                                 ConvDescriptor& result) const;
+
+    dace_state try_load(const std::string& hash,
+                        bool dynamic_minibatch_size) const;
+
+    bool unload(dace_state library);
+
+    bool invoke(const ConvDescriptor& desc,
+                void const*,
+                void const*,
+                void const*,
+                float alpha,
+                float beta,
+                void* workspace,
+                Stream_t stream) const;
+
+}; // class DaCeDNNBackend
+
+} // namespace distconv

--- a/legacy/include/distconv/dnn_backend/dace_backend.hpp
+++ b/legacy/include/distconv/dnn_backend/dace_backend.hpp
@@ -29,9 +29,6 @@ struct ConvParams
     int strides[3];
     int dilation[3];
     int groups;
-
-    bool operator<(const ConvParams& other) const;
-    bool operator==(const ConvParams& other) const;
 };
 
 // 5D shape
@@ -79,8 +76,6 @@ struct ConvDescriptor
     }
 
     std::string hash(bool dynamic_minibatch_size = false) const;
-
-    bool operator<(const ConvDescriptor& other) const;
 };
 
 // Definition of dace types

--- a/legacy/include/distconv/dnn_backend/dnn_backend.hpp
+++ b/legacy/include/distconv/dnn_backend/dnn_backend.hpp
@@ -58,7 +58,7 @@ struct Options
             bool deterministic = false,
             bool enable_profiling = false,
             float ws_capacity_factor = 1.0f,
-            bool jit_verbose = true,
+            bool jit_verbose = false,
             const std::string& jit_cache_path = ".jitcache");
 }; // struct Options
 

--- a/legacy/src/dnn_backend/CMakeLists.txt
+++ b/legacy/src/dnn_backend/CMakeLists.txt
@@ -6,6 +6,10 @@ h2_set_full_path(THIS_DIR_SOURCES
   stream_manager.cpp
 )
 
+if (H2_ENABLE_DACE)
+  h2_append_full_path(THIS_DIR_SOURCES dace_backend.cpp)
+endif()
+
 h2_set_full_path(THIS_DIR_CU_SOURCES
   batchnorm.cu
   cross_entropy.cu

--- a/legacy/src/dnn_backend/dace_backend.cpp
+++ b/legacy/src/dnn_backend/dace_backend.cpp
@@ -619,7 +619,7 @@ bool DaCeDNNBackend<VendorBackendT>::invoke(const ConvDescriptor& desc,
         if (library.dynbatch_set_workspace)
             library.dynbatch_set_workspace(library.handle, workspace, B);
 
-        library.dynbatch_func(library.handle, w, x, y, alpha, beta, B);
+        library.dynbatch_func(library.handle, w, x, y, B, alpha, beta);
     }
 
     return true;

--- a/legacy/src/dnn_backend/dace_backend.cpp
+++ b/legacy/src/dnn_backend/dace_backend.cpp
@@ -70,72 +70,72 @@ std::string ConvDescriptor::hash(bool dynamic_minibatch_size) const
     return stream.str();
 }
 
-bool ConvParams::operator<(const ConvParams& other) const
+bool operator<(const ConvParams& a, const ConvParams& b)
 {
     for (int i = 0; i < 3; ++i)
     {
-        if (pads[i] < other.pads[i])
+        if (a.pads[i] < b.pads[i])
             return true;
-        if (pads[i] > other.pads[i])
+        if (a.pads[i] > b.pads[i])
             return false;
     }
     for (int i = 0; i < 3; ++i)
     {
-        if (strides[i] < other.strides[i])
+        if (a.strides[i] < b.strides[i])
             return true;
-        if (strides[i] > other.strides[i])
+        if (a.strides[i] > b.strides[i])
             return false;
     }
     for (int i = 0; i < 3; ++i)
     {
-        if (dilation[i] < other.dilation[i])
+        if (a.dilation[i] < b.dilation[i])
             return true;
-        if (dilation[i] > other.dilation[i])
+        if (a.dilation[i] > b.dilation[i])
             return false;
     }
-    return groups < other.groups;
+    return a.groups < b.groups;
 }
 
-bool ConvParams::operator==(const ConvParams& other) const
+bool operator==(const ConvParams& a, const ConvParams& b)
 {
     for (int i = 0; i < 3; ++i)
-        if (pads[i] != other.pads[i])
+        if (a.pads[i] != b.pads[i])
             return false;
     for (int i = 0; i < 3; ++i)
-        if (strides[i] != other.strides[i])
+        if (a.strides[i] != b.strides[i])
             return false;
     for (int i = 0; i < 3; ++i)
-        if (dilation[i] != other.dilation[i])
+        if (a.dilation[i] != b.dilation[i])
             return false;
-    return groups == other.groups;
+    return a.groups == b.groups;
 }
 
-bool ConvDescriptor::operator<(const ConvDescriptor& other) const
+bool operator<(const ConvDescriptor& a, const ConvDescriptor& b)
 {
-    if (type < other.type)
+    if (a.type < b.type)
         return true;
-    if (type == other.type)
+    if (a.type == b.type)
     {
-        if (params < other.params)
+        if (a.params < b.params)
             return true;
-        if (params == other.params)
+        if (a.params == b.params)
         {
-            if (x_shape < other.x_shape)
+            if (a.x_shape < b.x_shape)
                 return true;
-            if (x_shape == other.x_shape)
+            if (a.x_shape == b.x_shape)
             {
-                if (x_strides < other.x_strides)
+                if (a.x_strides < b.x_strides)
                     return true;
-                if (x_strides == other.x_strides)
+                if (a.x_strides == b.x_strides)
                 {
-                    if (w_shape < other.w_shape)
+                    if (a.w_shape < b.w_shape)
                         return true;
-                    if (w_shape == other.w_shape)
+                    if (a.w_shape == b.w_shape)
                     {
-                        if (y_shape < other.y_shape)
+                        if (a.y_shape < b.y_shape)
                             return true;
-                        if (y_shape == other.y_shape)
-                            return y_strides < other.y_strides;
+                        if (a.y_shape == b.y_shape)
+                            return a.y_strides < b.y_strides;
                     }
                 }
             }

--- a/legacy/src/dnn_backend/dace_backend.cpp
+++ b/legacy/src/dnn_backend/dace_backend.cpp
@@ -1,0 +1,411 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2023 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#include "distconv/dnn_backend/dace_backend.hpp"
+
+#include "distconv/util/util_mpi.hpp" // For printouts
+
+#include <dlfcn.h>
+
+#include <sstream>
+#include <string>
+
+namespace distconv
+{
+///////////////////////////////////////////////////////////////////////////
+// Descriptor functionality
+
+// DaCe-generated internal function types
+typedef dacehandle_t (*initfunc_t)();
+
+template <class C, class T>
+std::basic_ostream<C, T>&
+write_s5d(std::basic_ostream<C, T>& os, const s5d& s, bool ignore_first = false)
+{
+    if (ignore_first)
+    {
+        return os << "B_" << std::get<1>(s) << '_' << std::get<2>(s) << '_'
+                  << std::get<3>(s) << '_' << std::get<4>(s);
+    }
+
+    return os << std::get<0>(s) << '_' << std::get<1>(s) << '_'
+              << std::get<2>(s) << '_' << std::get<3>(s) << '_'
+              << std::get<4>(s);
+}
+
+template <class C, class T>
+std::basic_ostream<C, T>& write_convparams(std::basic_ostream<C, T>& os,
+                                           const ConvParams& p)
+{
+    return os << p.pads[0] << '_' << p.pads[1] << '_' << p.pads[2] << '_'
+              << p.strides[0] << '_' << p.strides[1] << '_' << p.strides[2]
+              << '_' << p.dilation[0] << '_' << p.dilation[1] << '_'
+              << p.dilation[2] << '_' << p.groups;
+}
+
+std::string ConvDescriptor::hash(bool dynamic_minibatch_size) const
+{
+    std::stringstream stream;
+    const char* ctype =
+        (this->type == FORWARD
+             ? "fwd"
+             : (this->type == BACKWARD_FILTER ? "bwdfilt" : "bwddata"));
+    stream << "conv" << this->get_dimensionality() << "d_";
+    write_s5d(stream, this->x_shape, dynamic_minibatch_size);
+    stream << '_';
+    write_s5d(stream, this->x_strides);
+    stream << '_';
+    write_s5d(stream, this->w_shape);
+    stream << '_';
+    write_s5d(stream, this->y_shape, dynamic_minibatch_size);
+    stream << '_';
+    write_s5d(stream, this->y_strides);
+    stream << '_';
+    write_convparams(stream, this->params);
+    stream << '_' << ctype;
+    return stream.str();
+}
+
+bool ConvParams::operator<(const ConvParams& other) const
+{
+    for (int i = 0; i < 3; ++i)
+    {
+        if (pads[i] < other.pads[i])
+            return true;
+        if (pads[i] > other.pads[i])
+            return false;
+    }
+    for (int i = 0; i < 3; ++i)
+    {
+        if (strides[i] < other.strides[i])
+            return true;
+        if (strides[i] > other.strides[i])
+            return false;
+    }
+    for (int i = 0; i < 3; ++i)
+    {
+        if (dilation[i] < other.dilation[i])
+            return true;
+        if (dilation[i] > other.dilation[i])
+            return false;
+    }
+    return groups < other.groups;
+}
+
+bool ConvParams::operator==(const ConvParams& other) const
+{
+    for (int i = 0; i < 3; ++i)
+        if (pads[i] != other.pads[i])
+            return false;
+    for (int i = 0; i < 3; ++i)
+        if (strides[i] != other.strides[i])
+            return false;
+    for (int i = 0; i < 3; ++i)
+        if (dilation[i] != other.dilation[i])
+            return false;
+    return groups == other.groups;
+}
+
+bool ConvDescriptor::operator<(const ConvDescriptor& other) const
+{
+    if (type < other.type)
+        return true;
+    if (type == other.type)
+    {
+        if (params < other.params)
+            return true;
+        if (params == other.params)
+        {
+            if (x_shape < other.x_shape)
+                return true;
+            if (x_shape == other.x_shape)
+            {
+                if (x_strides < other.x_strides)
+                    return true;
+                if (x_strides == other.x_strides)
+                {
+                    if (w_shape < other.w_shape)
+                        return true;
+                    if (w_shape == other.w_shape)
+                    {
+                        if (y_shape < other.y_shape)
+                            return true;
+                        if (y_shape == other.y_shape)
+                            return y_strides < other.y_strides;
+                    }
+                }
+            }
+        }
+    }
+    return false;
+}
+
+///////////////////////////////////////////////////////////////////////////
+
+template <typename VendorBackendT>
+DaCeDNNBackend<VendorBackendT>::DaCeDNNBackend(MPI_Comm comm,
+                                               Handle_t handle,
+                                               Options opts)
+    : DNNBackend<VendorBackendT>(comm, handle, opts)
+{}
+
+template <typename VendorBackendT>
+DaCeDNNBackend<VendorBackendT>::DaCeDNNBackend(MPI_Comm comm,
+                                               Handle_t handle,
+                                               Stream_t stream,
+                                               Options opts)
+    : DNNBackend<VendorBackendT>(comm, handle, stream, opts)
+{}
+
+template <typename VendorBackendT>
+DaCeDNNBackend<VendorBackendT>::~DaCeDNNBackend()
+{
+    // Loop over libraries and unload them
+    for (const auto& iter : m_dace_libraries)
+    {
+        if (!unload(iter.second))
+            util::MPIPrintStreamWarning()
+                << "Unable to unload library: " << iter.first.hash();
+    }
+}
+
+template <typename VendorBackendT>
+void DaCeDNNBackend<VendorBackendT>::convolution_forward(
+    double alpha,
+    TensorDescriptor_t const& xdesc,
+    void const* x,
+    FilterDescriptor_t const& filter_desc,
+    void const* filter_data,
+    ConvolutionDescriptor_t const& conv_desc,
+    ConvFwdAlgo_t const& conv_algo,
+    void* workspace,
+    size_t workspace_bytes,
+    double beta,
+    TensorDescriptor_t const& ydesc,
+    void* y,
+    Stream_t s) const
+{
+    ConvDescriptor desc;
+    desc.type = FORWARD;
+    if (descriptor_from_tensors(xdesc, filter_desc, conv_desc, ydesc, desc))
+    {
+        // Try to invoke a JIT-compiled convolution
+        bool jit_compiled =
+            invoke(desc, x, filter_data, y, alpha, beta, workspace, s);
+        if (jit_compiled)
+            return;
+    }
+
+    // Fallback to vendor backend
+    DNNBackend<VendorBackendT>::convolution_forward(alpha,
+                                                    xdesc,
+                                                    x,
+                                                    filter_desc,
+                                                    filter_data,
+                                                    conv_desc,
+                                                    conv_algo,
+                                                    workspace,
+                                                    workspace_bytes,
+                                                    beta,
+                                                    ydesc,
+                                                    y,
+                                                    s);
+}
+
+template <typename VendorBackendT>
+bool DaCeDNNBackend<VendorBackendT>::descriptor_from_tensors(
+    TensorDescriptor_t const& xdesc,
+    FilterDescriptor_t const& filter_desc,
+    ConvolutionDescriptor_t const& conv_desc,
+    TensorDescriptor_t const& ydesc,
+    ConvDescriptor& result) const
+{
+    int ndims = VendorBackendT::get_tensor_rank(xdesc);
+    if (ndims > 5)
+    {
+        if (this->m_opts.jit_verbose)
+        {
+            util::MPIPrintStreamInfo() << "Unsupported number of dimensions in "
+                                       << "convolution: " << ndims;
+        }
+        return false;
+    }
+    int xshape[5] = {0}, xstrides[5] = {0}, wshape[5] = {0}, yshape[5] = {0},
+        ystrides[5] = {0};
+    ConvolutionMode_t unused_mode;
+    DataType_t unused_datatype; // TODO: Use
+
+    VendorBackendT::get_tensor_descriptor(
+        xdesc, unused_datatype, ndims, xshape, xstrides);
+    VendorBackendT::get_filter_descriptor(
+        filter_desc, unused_datatype, ndims, wshape);
+    VendorBackendT::get_tensor_descriptor(
+        ydesc, unused_datatype, ndims, yshape, ystrides);
+
+    // Set tuples according to arrays
+    result.x_shape = s5d{xshape[0], xshape[1], xshape[2], xshape[3], xshape[4]};
+    result.x_strides =
+        s5d{xstrides[0], xstrides[1], xstrides[2], xstrides[3], xstrides[4]};
+    result.w_shape = s5d{wshape[0], wshape[1], wshape[2], wshape[3], wshape[4]};
+    result.y_shape = s5d{yshape[0], yshape[1], yshape[2], yshape[3], yshape[4]};
+    result.y_strides =
+        s5d{ystrides[0], ystrides[1], ystrides[2], ystrides[3], ystrides[4]};
+
+    VendorBackendT::get_convolution_descriptor(conv_desc,
+                                               ndims - 2,
+                                               result.params.pads,
+                                               result.params.strides,
+                                               result.params.dilation,
+                                               result.params.groups,
+                                               unused_mode,
+                                               unused_datatype);
+    return true;
+}
+
+template <typename VendorBackendT>
+dace_state
+DaCeDNNBackend<VendorBackendT>::try_load(const std::string& hash,
+                                         bool dynamic_minibatch_size) const
+{
+    dace_state result;
+    const std::string& path = this->m_opts.jit_cache_path;
+    if (path.size() == 0)
+    {
+        util::MPIPrintStreamError()
+            << "ERROR finding build path. Please "
+            << "set the DISTCONV_JIT_CACHEPATH environment variable.";
+        std::abort();
+    }
+
+    std::stringstream fname, initname, exitname, funcname;
+    fname << path << "/.dacecache/" << hash << "/build/lib" << hash << ".so";
+    initname << "__dace_init_" << hash;
+    exitname << "__dace_exit_" << hash;
+    funcname << "__program_" << hash;
+    void* handle = dlopen(fname.str().c_str(), RTLD_LAZY);
+    if (handle)
+    {
+        initfunc_t initfunc =
+            (initfunc_t) dlsym(handle, initname.str().c_str());
+        result.library = handle;
+        if (!initfunc) // No initializer
+        {
+            util::MPIPrintStreamError() << "Initializer not found.";
+            std::abort();
+        }
+
+        dace_exitfunc_t exitfunc =
+            (dace_exitfunc_t) dlsym(result.library, exitname.str().c_str());
+        if (!exitfunc) // No destructor
+        {
+            util::MPIPrintStreamError() << "Destructor not found.";
+            std::abort();
+        }
+        result.dtor = exitfunc;
+
+        // Initialize handle
+        dacehandle_t dacehandle = initfunc();
+        result.handle = dacehandle;
+
+        // Set the current stream
+        dace_setstream_t setstreamfunc =
+            (dace_setstream_t) dlsym(handle, "__dace_gpu_set_all_streams");
+        if (!setstreamfunc)
+        { // No external stream setter
+            util::MPIPrintStreamError()
+                << "Set stream function not found, please regenerate the code.";
+            std::abort();
+        }
+        result.setstream_func = setstreamfunc;
+
+        void* func = dlsym(handle, funcname.str().c_str());
+        if (dynamic_minibatch_size)
+            result.dynbatch_func = (dynbatch_daceprogram_t) func;
+        else
+            result.func = (daceprogram_t) func;
+    }
+    return result;
+}
+
+template <typename VendorBackendT>
+bool DaCeDNNBackend<VendorBackendT>::unload(dace_state library)
+{
+    // Malformed library state
+    if (!library.dtor || !library.handle)
+    {
+        dlclose(library.library);
+        return false;
+    }
+    library.dtor(library.handle);
+    if (dlclose(library.library))
+        return false;
+    return true;
+}
+
+template <typename VendorBackendT>
+bool DaCeDNNBackend<VendorBackendT>::invoke(const ConvDescriptor& desc,
+                                            void const* x,
+                                            void const* w,
+                                            void const* y,
+                                            float alpha,
+                                            float beta,
+                                            void* workspace,
+                                            Stream_t stream) const
+{
+    dace_state library;
+    auto iter = m_dace_libraries.find(desc);
+
+    // First encounter of descriptor: need to try to find a JITted library
+    if (iter == m_dace_libraries.end())
+    {
+        // First, try to load the library with a specialized minibatch size
+        std::string hash = desc.hash();
+        library = try_load(hash, false);
+
+        // If failed, try to load the library with a dynamic minibatch size
+        if (!library.library)
+        {
+            hash = desc.hash(true);
+            library = try_load(hash, true);
+        }
+
+        if (!library.library && this->m_opts.jit_verbose)
+        {
+            util::MPIPrintStreamInfo()
+                << "JIT-compiled convolution not found for " << hash;
+        }
+
+        m_dace_libraries[desc] = library;
+    }
+    else
+    {
+        library = iter->second;
+    }
+
+    // No library found - fall back to vendor implementation
+    if (!library.library)
+        return false;
+
+    // Set stream
+    library.setstream_func(library.handle, stream);
+
+    // Call library
+    if (!library.dynbatch_func)
+        library.func(library.handle, w, x, y, alpha, beta);
+    else
+        library.dynbatch_func(
+            library.handle, w, x, y, alpha, beta, std::get<0>(desc.x_shape));
+
+    return true;
+}
+
+///////////////////////////////////////////////////////////////////////////
+
+// Instantiate class with GPU backend
+template class DaCeDNNBackend<GPUDNNBackend>;
+
+} // namespace distconv

--- a/legacy/src/dnn_backend/dnn_backend.cpp
+++ b/legacy/src/dnn_backend/dnn_backend.cpp
@@ -51,7 +51,6 @@
 
 namespace distconv
 {
-
 namespace
 {
 size_t getenv_num_streams(size_t default_nstreams = 8)
@@ -82,6 +81,10 @@ DNNBackend<VendorBackendT>::DNNBackend(MPI_Comm comm,
       m_handle{handle},
       m_stream_mgr{getenv_num_streams(/*default_nstreams=*/8UL), stream},
       m_comms{comm, m_stream_mgr}
+{}
+
+template <typename VendorBackendT>
+DNNBackend<VendorBackendT>::~DNNBackend()
 {}
 
 template <typename VendorBackendT>

--- a/legacy/src/dnn_backend/dnn_backend_cudnn.cpp.inc
+++ b/legacy/src/dnn_backend/dnn_backend_cudnn.cpp.inc
@@ -203,6 +203,7 @@ void GPUDNNBackend::copy_convolution_descriptor(
     int pads[arrayLengthRequested];
     int strides[arrayLengthRequested];
     int dilations[arrayLengthRequested];
+    int ngrps = 1;
     ConvolutionMode_t mode;
     DataType_t dt;
     DISTCONV_CHECK_CUDNN(cudnnGetConvolutionNdDescriptor(src,
@@ -213,8 +214,32 @@ void GPUDNNBackend::copy_convolution_descriptor(
                                                          dilations,
                                                          &mode,
                                                          &dt));
+    DISTCONV_CHECK_CUDNN(cudnnGetConvolutionGroupCount(src, &ngrps));
     DISTCONV_CHECK_CUDNN(cudnnSetConvolutionNdDescriptor(
         dst, array_length, pads, strides, dilations, mode, dt));
+    DISTCONV_CHECK_CUDNN(cudnnSetConvolutionGroupCount(dst, ngrps));
+}
+
+void GPUDNNBackend::get_convolution_descriptor(
+                                           ConvolutionDescriptor_t const& conv_desc,
+                                           int array_len,
+                                           int* const pad,
+                                           int* const stride,
+                                           int* const dilation,
+                                           int& ngrps,
+                                           ConvolutionMode_t& mode,
+                                           DataType_t& data_type)
+{
+    int ndim;
+    DISTCONV_CHECK_CUDNN(cudnnGetConvolutionNdDescriptor(conv_desc,
+                                                         array_len,
+                                                         &ndim,
+                                                         pad,
+                                                         stride,
+                                                         dilation,
+                                                         &mode,
+                                                         &data_type));
+    DISTCONV_CHECK_CUDNN(cudnnGetConvolutionGroupCount(conv_desc, &ngrps));
 }
 
 void GPUDNNBackend::convolution_forward(
@@ -1006,6 +1031,17 @@ void GPUDNNBackend::destroy_filter_descriptor(FilterDescriptor_t const& desc)
     DISTCONV_CHECK_CUDNN(cudnnDestroyFilterDescriptor(desc));
 }
 
+void GPUDNNBackend::get_filter_descriptor(FilterDescriptor_t const& desc,
+                                          DataType_t& dt,
+                                          size_t ndims,
+                                          int* dims)
+{
+    int nbdims;
+    cudnnTensorFormat_t format;
+    DISTCONV_CHECK_CUDNN(cudnnGetFilterNdDescriptor(
+        desc, ndims, &dt, &format, &nbdims, dims));
+}
+
 void GPUDNNBackend::set_filter_descriptor(FilterDescriptor_t const& desc,
                                           DataType_t const& dt,
                                           size_t ndims,
@@ -1034,11 +1070,22 @@ void GPUDNNBackend::destroy_tensor_descriptor(TensorDescriptor_t const& desc)
     DISTCONV_CHECK_CUDNN(cudnnDestroyTensorDescriptor(desc));
 }
 
-void GPUDNNBackend::set_tensor_descriptor(TensorDescriptor_t const& desc,
-                                          DataType_t const& dt,
+void GPUDNNBackend::get_tensor_descriptor(TensorDescriptor_t const& desc,
+                                          DataType_t& dt,
                                           size_t ndims,
                                           int* dims,
                                           int* strides)
+{
+    int nbdims;
+    DISTCONV_CHECK_CUDNN(cudnnGetTensorNdDescriptor(
+        desc, ndims, &dt, &nbdims, dims, strides));
+}
+
+void GPUDNNBackend::set_tensor_descriptor(TensorDescriptor_t const& desc,
+                                          DataType_t const& dt,
+                                          size_t ndims,
+                                          int const* dims,
+                                          int const* strides)
 {
     DISTCONV_CHECK_CUDNN(
         cudnnSetTensorNdDescriptor(desc, dt, ndims, dims, strides));

--- a/legacy/src/dnn_backend/dnn_backend_miopen.cpp.inc
+++ b/legacy/src/dnn_backend/dnn_backend_miopen.cpp.inc
@@ -405,6 +405,33 @@ void GPUDNNBackend::copy_convolution_descriptor(
         src, spatial_dims, &spatial_dims, pads, strides, dilations, &mode));
     DISTCONV_CHECK_MIOPEN(miopenInitConvolutionNdDescriptor(
         dst, spatial_dims, pads, strides, dilations, mode));
+
+    // miopenGetConvolutionGroupCount is not in the MIOpen API, so we're
+    // skipping copying groups
+    /*
+    int ngrps = 1;
+    DISTCONV_CHECK_MIOPEN(miopenGetConvolutionGroupCount(src, &ngrps));
+    DISTCONV_CHECK_MIOPEN(miopenSetConvolutionGroupCount(dst, ngrps));
+    */
+}
+
+void GPUDNNBackend::get_convolution_descriptor(
+                                           ConvolutionDescriptor_t const& conv_desc,
+                                           int array_len,
+                                           int* const pad,
+                                           int* const stride,
+                                           int* const dilation,
+                                           int& ngrps,
+                                           ConvolutionMode_t& mode,
+                                           DataType_t& /*data_type*/)
+{
+    int ndim;
+    DISTCONV_CHECK_MIOPEN(miopenGetConvolutionNdDescriptor(
+        conv_desc, array_len, &ndim, pad, stride, dilation, &mode));
+    // miopenGetConvolutionGroupCount is not in the MIOpen API, so we're
+    // ignoring groups for now.
+    //DISTCONV_CHECK_MIOPEN(miopenGetConvolutionGroupCount(conv_desc, &ngrps));
+    ngrps = 1;
 }
 
 void GPUDNNBackend::convolution_forward(
@@ -1067,11 +1094,21 @@ void GPUDNNBackend::destroy_tensor_descriptor(TensorDescriptor_t const& desc)
     DISTCONV_CHECK_MIOPEN(miopenDestroyTensorDescriptor(desc));
 }
 
-void GPUDNNBackend::set_tensor_descriptor(TensorDescriptor_t const& desc,
-                                          DataType_t const& dt,
+void GPUDNNBackend::get_tensor_descriptor(TensorDescriptor_t const& desc,
+                                          DataType_t& dt,
                                           size_t ndims,
                                           int* dims,
                                           int* strides)
+{
+    DISTCONV_CHECK_MIOPEN(
+        miopenGetTensorDescriptor(desc, &dt, dims, strides));
+}
+
+void GPUDNNBackend::set_tensor_descriptor(TensorDescriptor_t const& desc,
+                                          DataType_t const& dt,
+                                          size_t ndims,
+                                          int const* dims,
+                                          int const* strides)
 {
     DISTCONV_CHECK_MIOPEN(
         miopenSetTensorDescriptor(desc, dt, ndims, dims, strides));
@@ -1098,6 +1135,14 @@ auto GPUDNNBackend::make_filter_descriptor() -> TensorDescriptor_t
 void GPUDNNBackend::destroy_filter_descriptor(TensorDescriptor_t const& desc)
 {
     destroy_tensor_descriptor(desc);
+}
+
+void GPUDNNBackend::get_filter_descriptor(FilterDescriptor_t const& desc,
+                                          DataType_t& dt,
+                                          size_t ndims,
+                                          int* dims)
+{
+    get_tensor_descriptor(desc, dt, ndims, dims, nullptr);
 }
 
 void GPUDNNBackend::set_filter_descriptor(FilterDescriptor_t const& desc,

--- a/legacy/src/dnn_backend/options.cpp
+++ b/legacy/src/dnn_backend/options.cpp
@@ -10,15 +10,18 @@
 
 namespace distconv
 {
-
 Options::Options(bool overlap_halo_exchange_in,
                  bool deterministic_in,
                  bool enable_profiling_in,
-                 float ws_capacity_factor_in)
+                 float ws_capacity_factor_in,
+                 bool jit_verbose_in,
+                 const std::string& jit_cache_path_in)
     : overlap_halo_exchange{overlap_halo_exchange_in},
       m_deterministic{deterministic_in},
       enable_profiling{enable_profiling_in},
-      ws_capacity_factor{ws_capacity_factor_in}
+      ws_capacity_factor{ws_capacity_factor_in},
+      jit_verbose{jit_verbose_in},
+      jit_cache_path{jit_cache_path_in}
 {
     // FIXME (trb): This carries over the previous logic, which is
     // BAD. `DISTCONV_OVERLAP_HALO_EXCHANGE=0` is still "detected", so
@@ -51,6 +54,20 @@ Options::Options(bool overlap_halo_exchange_in,
                                         << "DISTCONV_WS_CAPACITY_FACTOR"
                                         << " detected";
         ws_capacity_factor = atof(std::getenv("DISTCONV_WS_CAPACITY_FACTOR"));
+    }
+    if (std::getenv("DISTCONV_JIT_VERBOSE"))
+    {
+        util::MPIRootPrintStreamDebug() << "Environment variable: "
+                                        << "DISTCONV_JIT_VERBOSE"
+                                        << " detected";
+        jit_verbose = true;
+    }
+    if (std::getenv("DISTCONV_JIT_CACHEPATH"))
+    {
+        util::MPIRootPrintStreamDebug() << "Environment variable: "
+                                        << "DISTCONV_JIT_CACHEPATH"
+                                        << " detected";
+        jit_cache_path = std::getenv("DISTCONV_JIT_CACHEPATH");
     }
 }
 


### PR DESCRIPTION
Iteration 2 of the DaCe backend. If a precompiled library exists, it will be reused instead of running the vendor-provided convolution. First, it searches for a precompiled library with a fixed/specialized minibatch size. If not found, it will search for a symbolic minibatch size. If no such file exists, the backend will fall back to the current vendor implementation.

TODO:
- [x] Forward convolutions
- [x] Backward data/filter support
- [x] Better workspace integration
- [x] Make JIT verbose mode disabled by default