### PR TITLE
Update Gitlab to test ROCm v5.5.1 and ROCm v5.6.0

### DIFF
--- a/.gitlab/build-and-test-corona.yml
+++ b/.gitlab/build-and-test-corona.yml
@@ -21,28 +21,28 @@ include:
 # "+ci+coverage".
 rocm-5-4-3:
   variables:
-    SPEC: "%rocmcc@5.4.3 +developer +rocm amdgpu_target=gfx906 ^hip@5.4.3 ^llvm-amdgpu@5.4.3 ^hsa-rocr-dev@5.4.3"
-    MODULES: "gcc/10.3.1-magic openmpi/4.1.2 rocm/5.4.3 ninja/1.11.0 python"
+    SPEC: "%rocmcc@5.5.1 +developer +rocm amdgpu_target=gfx906 ^hip@5.5.1 ^llvm-amdgpu@5.5.1 ^hsa-rocr-dev@5.5.1"
+    MODULES: "gcc/10.3.1-magic openmpi/4.1.2 rocm/5.5.1 ninja/1.11.0 python"
   extends: [.build-and-test-on-corona, .build-and-test]
 
 rocm-5-5-0:
   variables:
-    SPEC: "%rocmcc@5.5.0 +developer +rocm amdgpu_target=gfx906 ^hip@5.5.0 ^llvm-amdgpu@5.5.0 ^hsa-rocr-dev@5.5.0"
-    MODULES: "gcc/10.3.1-magic openmpi/4.1.2 rocm/5.5.0 ninja/1.11.0 python"
+    SPEC: "%rocmcc@5.6.0 +developer +rocm amdgpu_target=gfx906 ^hip@5.6.0 ^llvm-amdgpu@5.6.0 ^hsa-rocr-dev@5.6.0"
+    MODULES: "gcc/10.3.1-magic openmpi/4.1.2 rocm/5.6.0 ninja/1.11.0 python"
   extends: [.build-and-test-on-corona, .build-and-test]
 
 rocm-5-5-0-distconv:
   variables:
-    SPEC: "%rocmcc@5.5.0 +developer +distconv +rocm amdgpu_target=gfx906 ^hip@5.5.0 ^llvm-amdgpu@5.5.0 ^hsa-rocr-dev@5.5.0"
-    MODULES: "gcc/10.3.1-magic openmpi/4.1.2 rocm/5.5.0 ninja/1.11.0 python"
+    SPEC: "%rocmcc@5.6.0 +developer +distconv +rocm amdgpu_target=gfx906 ^hip@5.6.0 ^llvm-amdgpu@5.6.0 ^hsa-rocr-dev@5.6.0"
+    MODULES: "gcc/10.3.1-magic openmpi/4.1.2 rocm/5.6.0 ninja/1.11.0 python"
   extends: [.build-and-test-on-corona, .build-and-test]
   rules:
     - if: $TEST_DISTCONV_BUILD == "1"
 
 rocm-5-5-0-coverage:
   variables:
-    SPEC: "%rocmcc@5.5.0 +developer +ci +coverage +rocm amdgpu_target=gfx906 ^hip@5.5.0 ^llvm-amdgpu@5.5.0 ^hsa-rocr-dev@5.5.0"
-    MODULES: "gcc/10.3.1-magic openmpi/4.1.2 rocm/5.5.0 ninja/1.11.0 python"
+    SPEC: "%rocmcc@5.6.0 +developer +ci +coverage +rocm amdgpu_target=gfx906 ^hip@5.6.0 ^llvm-amdgpu@5.6.0 ^hsa-rocr-dev@5.6.0"
+    MODULES: "gcc/10.3.1-magic openmpi/4.1.2 rocm/5.6.0 ninja/1.11.0 python"
   extends: [.build-and-test-on-corona, .build-and-test-coverage]
 
 .build-and-test-on-corona:

--- a/.gitlab/build-and-test-corona.yml
+++ b/.gitlab/build-and-test-corona.yml
@@ -19,19 +19,19 @@ include:
 # includes/libs are setup properly under the "/usr/tce" prefix). So I
 # load a module to get a real prefix. This only matters when
 # "+ci+coverage".
-rocm-5-4-3:
+rocm-5-5-1:
   variables:
     SPEC: "%rocmcc@5.5.1 +developer +rocm amdgpu_target=gfx906 ^hip@5.5.1 ^llvm-amdgpu@5.5.1 ^hsa-rocr-dev@5.5.1"
     MODULES: "gcc/10.3.1-magic openmpi/4.1.2 rocm/5.5.1 ninja/1.11.0 python"
   extends: [.build-and-test-on-corona, .build-and-test]
 
-rocm-5-5-0:
+rocm-5-6-0:
   variables:
     SPEC: "%rocmcc@5.6.0 +developer +rocm amdgpu_target=gfx906 ^hip@5.6.0 ^llvm-amdgpu@5.6.0 ^hsa-rocr-dev@5.6.0"
     MODULES: "gcc/10.3.1-magic openmpi/4.1.2 rocm/5.6.0 ninja/1.11.0 python"
   extends: [.build-and-test-on-corona, .build-and-test]
 
-rocm-5-5-0-distconv:
+rocm-5-6-0-distconv:
   variables:
     SPEC: "%rocmcc@5.6.0 +developer +distconv +rocm amdgpu_target=gfx906 ^hip@5.6.0 ^llvm-amdgpu@5.6.0 ^hsa-rocr-dev@5.6.0"
     MODULES: "gcc/10.3.1-magic openmpi/4.1.2 rocm/5.6.0 ninja/1.11.0 python"
@@ -39,7 +39,7 @@ rocm-5-5-0-distconv:
   rules:
     - if: $TEST_DISTCONV_BUILD == "1"
 
-rocm-5-5-0-coverage:
+rocm-5-6-0-coverage:
   variables:
     SPEC: "%rocmcc@5.6.0 +developer +ci +coverage +rocm amdgpu_target=gfx906 ^hip@5.6.0 ^llvm-amdgpu@5.6.0 ^hsa-rocr-dev@5.6.0"
     MODULES: "gcc/10.3.1-magic openmpi/4.1.2 rocm/5.6.0 ninja/1.11.0 python"

--- a/.gitlab/build-and-test-tioga.yml
+++ b/.gitlab/build-and-test-tioga.yml
@@ -15,19 +15,19 @@ include:
 # (directly) used.
 rocm-5-4-3:
   variables:
-    SPEC: "%rocmcc@5.4.3 +developer +rocm amdgpu_target=gfx90a ^hip@5.4.3 ^llvm-amdgpu@5.4.3 ^hsa-rocr-dev@5.4.3"
-    MODULES: "PrgEnv-amd amd/5.4.3"
+    SPEC: "%rocmcc@5.5.1 +developer +rocm amdgpu_target=gfx90a ^hip@5.5.1 ^llvm-amdgpu@5.5.1 ^hsa-rocr-dev@5.5.1"
+    MODULES: "PrgEnv-amd amd/5.5.1"
   extends: .build-and-test-on-tioga
 
 rocm-5-5-0:
   variables:
-    SPEC: "%rocmcc@5.5.0 +developer +rocm amdgpu_target=gfx90a ^hip@5.5.0 ^llvm-amdgpu@5.5.0 ^hsa-rocr-dev@5.5.0"
-    MODULES: "PrgEnv-amd amd/5.5.0"
+    SPEC: "%rocmcc@5.6.0 +developer +rocm amdgpu_target=gfx90a ^hip@5.6.0 ^llvm-amdgpu@5.6.0 ^hsa-rocr-dev@5.6.0"
+    MODULES: "PrgEnv-amd amd/5.6.0"
   extends: .build-and-test-on-tioga
 
 # cray-amd-5-5-0:
 #   variables:
-#     SPEC: "%cce@amd-5.5.0 +developer +rocm amdgpu_target=gfx90a ^hip@5.5.0 ^llvm-amdgpu@5.5.0 ^hsa-rocr-dev@5.5.0"
+#     SPEC: "%cce@amd-5.6.0 +developer +rocm amdgpu_target=gfx90a ^hip@5.6.0 ^llvm-amdgpu@5.6.0 ^hsa-rocr-dev@5.6.0"
 #   extends: .build-and-test-on-tioga
 
 .build-and-test-on-tioga:

--- a/.gitlab/build-and-test-tioga.yml
+++ b/.gitlab/build-and-test-tioga.yml
@@ -13,19 +13,19 @@ include:
 
 # Note: We load gcc/10.3.1-magic to get the right MPI but it's not
 # (directly) used.
-rocm-5-4-3:
+rocm-5-5-1:
   variables:
     SPEC: "%rocmcc@5.5.1 +developer +rocm amdgpu_target=gfx90a ^hip@5.5.1 ^llvm-amdgpu@5.5.1 ^hsa-rocr-dev@5.5.1"
     MODULES: "PrgEnv-amd amd/5.5.1"
   extends: .build-and-test-on-tioga
 
-rocm-5-5-0:
+rocm-5-6-0:
   variables:
     SPEC: "%rocmcc@5.6.0 +developer +rocm amdgpu_target=gfx90a ^hip@5.6.0 ^llvm-amdgpu@5.6.0 ^hsa-rocr-dev@5.6.0"
     MODULES: "PrgEnv-amd amd/5.6.0"
   extends: .build-and-test-on-tioga
 
-# cray-amd-5-5-0:
+# cray-amd-5-6-0:
 #   variables:
 #     SPEC: "%cce@amd-5.6.0 +developer +rocm amdgpu_target=gfx90a ^hip@5.6.0 ^llvm-amdgpu@5.6.0 ^hsa-rocr-dev@5.6.0"
 #   extends: .build-and-test-on-tioga

--- a/.gitlab/spack/environments/corona/spack.yaml
+++ b/.gitlab/spack/environments/corona/spack.yaml
@@ -28,12 +28,12 @@ spack:
       environment: {}
       extra_rpaths: []
   - compiler:
-      spec: rocmcc@=5.4.3
+      spec: rocmcc@=5.5.1
       paths:
-        cc: /opt/rocm-5.4.3/bin/amdclang
-        cxx: /opt/rocm-5.4.3/bin/amdclang++
-        f77: /opt/rocm-5.4.3/bin/amdflang
-        fc: /opt/rocm-5.4.3/bin/amdflang
+        cc: /opt/rocm-5.5.1/bin/amdclang
+        cxx: /opt/rocm-5.5.1/bin/amdclang++
+        f77: /opt/rocm-5.5.1/bin/amdflang
+        fc: /opt/rocm-5.5.1/bin/amdflang
       flags: {}
       operating_system: rhel8
       target: x86_64
@@ -41,12 +41,12 @@ spack:
       environment: {}
       extra_rpaths: []
   - compiler:
-      spec: rocmcc@=5.5.0
+      spec: rocmcc@=5.6.0
       paths:
-        cc: /opt/rocm-5.5.0/bin/amdclang
-        cxx: /opt/rocm-5.5.0/bin/amdclang++
-        f77: /opt/rocm-5.5.0/bin/amdflang
-        fc: /opt/rocm-5.5.0/bin/amdflang
+        cc: /opt/rocm-5.6.0/bin/amdclang
+        cxx: /opt/rocm-5.6.0/bin/amdclang++
+        f77: /opt/rocm-5.6.0/bin/amdflang
+        fc: /opt/rocm-5.6.0/bin/amdflang
       flags: {}
       operating_system: rhel8
       target: x86_64
@@ -147,24 +147,24 @@ spack:
     hip:
       buildable: false
       externals:
-      - spec: hip@5.4.3
-        prefix: /opt/rocm-5.4.3/hip
-      - spec: hip@5.5.0
-        prefix: /opt/rocm-5.5.0/hip
+      - spec: hip@5.5.1
+        prefix: /opt/rocm-5.5.1/hip
+      - spec: hip@5.6.0
+        prefix: /opt/rocm-5.6.0/hip
     hipcub:
       buildable: false
       externals:
-      - spec: hipcub@5.4.3
-        prefix: /opt/rocm-5.4.3
-      - spec: hipcub@5.5.0
-        prefix: /opt/rocm-5.5.0
+      - spec: hipcub@5.5.1
+        prefix: /opt/rocm-5.5.1
+      - spec: hipcub@5.6.0
+        prefix: /opt/rocm-5.6.0
     hsa-rocr-dev:
       buildable: false
       externals:
-      - spec: hsa-rocr-dev@5.4.3
-        prefix: /opt/rocm-5.4.3
-      - spec: hsa-rocr-dev@5.5.0
-        prefix: /opt/rocm-5.5.0
+      - spec: hsa-rocr-dev@5.5.1
+        prefix: /opt/rocm-5.5.1
+      - spec: hsa-rocr-dev@5.6.0
+        prefix: /opt/rocm-5.6.0
     hwloc:
       externals:
       - spec: hwloc@2.9.0
@@ -188,10 +188,10 @@ spack:
     llvm-amdgpu:
       buildable: false
       externals:
-      - spec: llvm-amdgpu@5.4.3
-        prefix: /opt/rocm-5.4.3/llvm
-      - spec: llvm-amdgpu@5.5.0
-        prefix: /opt/rocm-5.5.0/llvm
+      - spec: llvm-amdgpu@5.5.1
+        prefix: /opt/rocm-5.5.1/llvm
+      - spec: llvm-amdgpu@5.6.0
+        prefix: /opt/rocm-5.6.0/llvm
     m4:
       externals:
       - spec: m4@1.4.18
@@ -199,10 +199,10 @@ spack:
     miopen-hip:
       buildable: false
       externals:
-      - spec: miopen-hip@5.4.3
-        prefix: /opt/rocm-5.4.3
-      - spec: miopen-hip@5.5.0
-        prefix: /opt/rocm-5.5.0
+      - spec: miopen-hip@5.5.1
+        prefix: /opt/rocm-5.5.1
+      - spec: miopen-hip@5.6.0
+        prefix: /opt/rocm-5.6.0
     mvapich2:
       externals:
       - spec: mvapich2@2.3.7~cuda~debug+regcache+wrapperrpath ch3_rank_bits=32 fabrics=mrail
@@ -246,17 +246,17 @@ spack:
         prefix: /usr/tce/packages/python/python-3.9.12
     rccl:
       externals:
-      - spec: rccl@5.4.3
-        prefix: /opt/rocm-5.4.3
-      - spec: rccl@5.5.0
-        prefix: /opt/rocm-5.5.0
+      - spec: rccl@5.5.1
+        prefix: /opt/rocm-5.5.1
+      - spec: rccl@5.6.0
+        prefix: /opt/rocm-5.6.0
     roctracer-dev:
       buildable: false
       externals:
-      - spec: roctracer-dev@5.4.3
-        prefix: /opt/rocm-5.4.3
-      - spec: roctracer-dev@5.5.0
-        prefix: /opt/rocm-5.5.0
+      - spec: roctracer-dev@5.5.1
+        prefix: /opt/rocm-5.5.1
+      - spec: roctracer-dev@5.6.0
+        prefix: /opt/rocm-5.6.0
     swig:
       externals:
       - spec: swig@3.0.12

--- a/.gitlab/spack/environments/tioga/spack.yaml
+++ b/.gitlab/spack/environments/tioga/spack.yaml
@@ -17,7 +17,7 @@ spack:
     unify: true
   compilers:
   # - compiler:
-  #     spec: cce@=amd-5.5.0
+  #     spec: cce@=amd-5.6.0
   #     paths:
   #       cc: cc
   #       cxx: CC
@@ -26,16 +26,16 @@ spack:
   #     flags: {}
   #     operating_system: rhel8
   #     target: x86_64
-  #     modules: [PrgEnv-amd/8.3.3, amd/5.5.0]
+  #     modules: [PrgEnv-amd/8.3.3, amd/5.6.0]
   #     environment: {}
   #     extra_rpaths: []
   - compiler:
-      spec: rocmcc@=5.5.0
+      spec: rocmcc@=5.6.0
       paths:
-        cc: /opt/rocm-5.5.0/bin/amdclang
-        cxx: /opt/rocm-5.5.0/bin/amdclang++
-        f77: /opt/rocm-5.5.0/bin/amdflang
-        fc: /opt/rocm-5.5.0/bin/amdflang
+        cc: /opt/rocm-5.6.0/bin/amdclang
+        cxx: /opt/rocm-5.6.0/bin/amdclang++
+        f77: /opt/rocm-5.6.0/bin/amdflang
+        fc: /opt/rocm-5.6.0/bin/amdflang
       flags: {}
       operating_system: rhel8
       target: x86_64
@@ -43,12 +43,12 @@ spack:
       environment: {}
       extra_rpaths: []
   - compiler:
-      spec: rocmcc@=5.4.3
+      spec: rocmcc@=5.5.1
       paths:
-        cc: /opt/rocm-5.4.3/bin/amdclang
-        cxx: /opt/rocm-5.4.3/bin/amdclang++
-        f77: /opt/rocm-5.4.3/bin/amdflang
-        fc: /opt/rocm-5.4.3/bin/amdflang
+        cc: /opt/rocm-5.5.1/bin/amdclang
+        cxx: /opt/rocm-5.5.1/bin/amdclang++
+        f77: /opt/rocm-5.5.1/bin/amdflang
+        fc: /opt/rocm-5.5.1/bin/amdflang
       flags: {}
       operating_system: rhel8
       target: x86_64
@@ -134,22 +134,22 @@ spack:
         prefix: /usr
     hip:
       externals:
-      - spec: hip@5.4.3
-        prefix: /opt/rocm-5.4.3
-      - spec: hip@5.5.0
-        prefix: /opt/rocm-5.5.0
+      - spec: hip@5.5.1
+        prefix: /opt/rocm-5.5.1
+      - spec: hip@5.6.0
+        prefix: /opt/rocm-5.6.0
     hipcub:
       externals:
-      - spec: hip@5.4.3
-        prefix: /opt/rocm-5.4.3
-      - spec: hip@5.5.0
-        prefix: /opt/rocm-5.5.0
+      - spec: hip@5.5.1
+        prefix: /opt/rocm-5.5.1
+      - spec: hip@5.6.0
+        prefix: /opt/rocm-5.6.0
     hsa-rocr-dev:
       externals:
-      - spec: hsa-rocr-dev@5.4.3
-        prefix: /opt/rocm-5.4.3
-      - spec: hsa-rocr-dev@5.5.0
-        prefix: /opt/rocm-5.5.0
+      - spec: hsa-rocr-dev@5.5.1
+        prefix: /opt/rocm-5.5.1
+      - spec: hsa-rocr-dev@5.6.0
+        prefix: /opt/rocm-5.6.0
     hwloc:
       externals:
       - spec: hwloc@2.9.0
@@ -168,20 +168,20 @@ spack:
         prefix: /usr
     llvm-amdgpu:
       externals:
-      - spec: llvm-amdgpu@5.4.3
-        prefix: /opt/rocm-5.4.3/llvm
-      - spec: llvm-amdgpu@5.5.0
-        prefix: /opt/rocm-5.5.0/llvm
+      - spec: llvm-amdgpu@5.5.1
+        prefix: /opt/rocm-5.5.1/llvm
+      - spec: llvm-amdgpu@5.6.0
+        prefix: /opt/rocm-5.6.0/llvm
     m4:
       externals:
       - spec: m4@1.4.18
         prefix: /usr
     miopen-hip:
       externals:
-      - spec: miopen-hip@5.4.3
-        prefix: /opt/rocm-5.4.3
-      - spec: miopen-hip@5.5.0
-        prefix: /opt/rocm-5.5.0
+      - spec: miopen-hip@5.5.1
+        prefix: /opt/rocm-5.5.1
+      - spec: miopen-hip@5.6.0
+        prefix: /opt/rocm-5.6.0
     mpich:
       externals:
       - spec: mpich@3.4a2~hydra device=ch4 netmod=ofi
@@ -209,10 +209,10 @@ spack:
         prefix: /usr/tce/packages/python/python-3.9.12
     rccl:
       externals:
-      - spec: rccl@5.4.3
-        prefix: /opt/rocm-5.4.3
-      - spec: rccl@5.5.0
-        prefix: /opt/rocm-5.5.0
+      - spec: rccl@5.5.1
+        prefix: /opt/rocm-5.5.1
+      - spec: rccl@5.6.0
+        prefix: /opt/rocm-5.6.0
     subversion:
       externals:
       - spec: subversion@1.10.2


### PR DESCRIPTION
This is to reflect new versions available on the test clusters. Instead of 5.4.3 and 5.5.0, this tests 5.5.1 and 5.6.0. These versions include important bugfixes and reflect the new minimum supported ROCm versions.