### PR TITLE
GPU tests compile separately from other tests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,7 +193,13 @@ endif ()
 
 # Required dependencies
 
+find_package(Hydrogen 1.5.0 CONFIG REQUIRED)
+
 if (H2_ENABLE_CUDA)
+  if (NOT _HYDROGEN_HAVE_CUDA)
+    message(FATAL_ERROR "Hydrogen does not have CUDA support.")
+  endif ()
+
   enable_language(CUDA)
   include(SetupCUDAToolkit)
   if (CMAKE_CUDA_COMPILER)
@@ -208,13 +214,15 @@ if (H2_ENABLE_CUDA)
   endif ()
 endif (H2_ENABLE_CUDA)
 
-find_package(Hydrogen 1.5.0 CONFIG REQUIRED)
-
 find_package(spdlog CONFIG REQUIRED)
 set(H2_HAS_SPDLOG TRUE)
 
 # This is a placeholder.
 if (H2_ENABLE_ROCM)
+  if (NOT _HYDROGEN_HAVE_ROCM)
+    message(FATAL_ERROR "Hydrogen does not have ROCm support.")
+  endif ()
+
   # Our ROCm installs generally have a common prefix. It's not clear
   # that this is a global truth, but it's global enough for me.
   if (NOT H2_ROCM_PATH)

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -43,7 +43,17 @@ set_tests_properties([==[Testing the Version String.]==] PROPERTIES
 # Add the sequential Catch2 driver.
 #
 
-add_executable(SeqCatchTests SequentialCatchMain.cpp)
+add_executable(SeqCatchTests)
+if (H2_HAS_GPU)
+  add_executable(GPUCatchTests GPUCatchMain.cpp)
+  target_link_libraries(GPUCatchTests
+    PRIVATE ${H2_LIBRARIES} Catch2::Catch2)
+  target_compile_definitions(GPUCatchTests PRIVATE H2_TEST_WITH_GPU=1)
+  set_target_properties(GPUCatchTests PROPERTIES
+    CXX_STANDARD 17
+    CXX_EXTENSIONS OFF
+    CXX_STANDARD_REQUIRED ON)
+endif ()
 
 # Add Catch2 unit tests
 add_subdirectory(patterns/factory)
@@ -52,13 +62,14 @@ add_subdirectory(utils)
 add_subdirectory(tensor)
 
 target_link_libraries(SeqCatchTests
-  PRIVATE ${H2_LIBRARIES} Catch2::Catch2)
+  PRIVATE ${H2_LIBRARIES} Catch2::Catch2WithMain)
 set_target_properties(SeqCatchTests
   PROPERTIES
   CXX_STANDARD 17
   CXX_EXTENSIONS OFF
   CXX_STANDARD_REQUIRED ON)
 
+# Not 100% sold on this
 catch_discover_tests(SeqCatchTests)
 
 if (H2_CODE_COVERAGE)
@@ -69,8 +80,4 @@ endif ()
 if (H2_EXTRA_CXX_FLAGS)
   target_compile_options(SeqCatchTests
     PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${H2_EXTRA_CXX_FLAGS}>)
-endif ()
-
-if (H2_SEQUENTIAL_CATCH_TESTS)
-  catch_discover_tests(SeqCatchTests TEST_PREFIX "Seq--")
 endif ()

--- a/test/unit_test/GPUCatchMain.cpp
+++ b/test/unit_test/GPUCatchMain.cpp
@@ -8,16 +8,25 @@
 #include <catch2/catch_session.hpp>
 
 #include <El.hpp>
+#include <h2/gpu/runtime.hpp>
 
+struct GPUEnvironment
+{
+    GPUEnvironment()
+    {
+        El::gpu::Initialize();
+        h2::gpu::init_runtime();
+    }
+
+    ~GPUEnvironment()
+    {
+        h2::gpu::finalize_runtime();
+        El::gpu::Finalize();
+    }
+};
 
 int main(int argc, char** argv)
 {
-#ifdef HYDROGEN_HAVE_GPU
-  El::gpu::Initialize();
-#endif
-  int result = Catch::Session().run(argc, argv);
-#ifdef HYDROGEN_HAVE_GPU
-  El::gpu::Finalize();
-#endif
-  return result;
+    GPUEnvironment env;
+    return Catch::Session().run(argc, argv);
 }

--- a/test/unit_test/tensor/CMakeLists.txt
+++ b/test/unit_test/tensor/CMakeLists.txt
@@ -9,4 +9,12 @@ target_sources(SeqCatchTests PRIVATE
   unit_test_raw_buffer.cpp
   unit_test_strided_memory.cpp
   unit_test_tensor.cpp
+)
+
+if (H2_HAS_GPU)
+  target_sources(GPUCatchTests PRIVATE
+    unit_test_raw_buffer.cpp
+    unit_test_strided_memory.cpp
+    unit_test_tensor.cpp
   )
+endif ()

--- a/test/unit_test/tensor/utils.hpp
+++ b/test/unit_test/tensor/utils.hpp
@@ -16,14 +16,12 @@
 // The raw CPU/GPUDev_t can be used in TEMPLATE_TEST_CASE and the
 // AllDevList can be used in TEMPLATE_LIST_TEST_CASE.
 using CPUDev_t = std::integral_constant<h2::Device, h2::Device::CPU>;
-#ifdef HYDROGEN_HAVE_GPU
+#ifdef H2_TEST_WITH_GPU
 using GPUDev_t = std::integral_constant<h2::Device, h2::Device::GPU>;
+using AllDevList = h2::meta::TL<CPUDev_t, GPUDev_t>;
+#else
+using AllDevList = h2::meta::TL<CPUDev_t>;
 #endif
-using AllDevList = h2::meta::TypeList <CPUDev_t
-#ifdef HYDROGEN_HAVE_GPU
-                                   , GPUDev_t
-#endif
-                                    >;
 
 // Standard datatype to be used when testing.
 // Note: When used with integers, floats are exact for any integer less


### PR DESCRIPTION
The CPU versions compile and run with both SeqCatchTests and GPUCatchTests. Currently, GPUCatchTests is not added to code coverage.