### PR TITLE
Fix Batch Norm Stride Bug

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -26,6 +26,8 @@ Build system:
      -- ROC-tracer
 
 Bug fixes:
+ - Fixed a bug in kernel selection for batchnorm gradients in the case of
+   overlap/strides.
 
 Retired features:
 

--- a/legacy/src/dnn_backend/batchnorm.cu
+++ b/legacy/src/dnn_backend/batchnorm.cu
@@ -1366,14 +1366,14 @@ __global__ void backprop2_kernel(const DataType* __restrict__ input,
 }
 
 template <int ND, typename DataType, typename DataTypeV>
-__global__ void backprop2_opt_kernel(const DataTypeV* __restrict__ input,
+__global__ void backprop2_opt_kernel(const DataTypeV* input,
                                      const DataTypeV* __restrict__ d_output,
                                      const DataType* __restrict__ global_mean,
                                      const DataType* __restrict__ global_var,
                                      const DataType* __restrict__ global_scale,
                                      const DataType* __restrict__ global_dmean,
                                      const DataType* __restrict__ global_dvar,
-                                     DataTypeV* __restrict__ d_input,
+                                     DataTypeV* d_input,
                                      DataType epsilon,
                                      index_t num_per_sum,
                                      index_t spatial_size,
@@ -1495,7 +1495,9 @@ void backprop2(index_t num_samples,
     using DataType = typename TensorType::data_type;
 
     if (input.get_local_real_shape() == d_output.get_local_real_shape()
-        && input.get_local_real_shape() == d_input.get_local_real_shape())
+        && input.get_local_real_shape() == d_input.get_local_real_shape()
+        && input.get_overlap() == 0 && d_output.get_overlap() == 0
+        && d_input.get_overlap() == 0)
     {
         if (std::getenv("DISTCONV_DISABLE_BN_OPT"))
         {

--- a/legacy/src/dnn_backend/batchnorm.cu
+++ b/legacy/src/dnn_backend/batchnorm.cu
@@ -1301,14 +1301,14 @@ namespace
 {
 
 template <int ND, typename DataType>
-__global__ void backprop2_kernel(const DataType* __restrict__ input,
+__global__ void backprop2_kernel(const DataType* input,
                                  const DataType* __restrict__ d_output,
                                  const DataType* __restrict__ global_mean,
                                  const DataType* __restrict__ global_var,
                                  const DataType* __restrict__ global_scale,
                                  const DataType* __restrict__ global_dmean,
                                  const DataType* __restrict__ global_dvar,
-                                 DataType* __restrict__ d_input,
+                                 DataType* d_input,
                                  DataType epsilon,
                                  index_t num_per_sum,
                                  tensor::Array<ND> shape,

--- a/legacy/src/dnn_backend/batchnorm.cu
+++ b/legacy/src/dnn_backend/batchnorm.cu
@@ -1301,20 +1301,23 @@ namespace
 {
 
 template <int ND, typename DataType>
-__global__ void backprop2_kernel(const DataType* input,
-                                 const DataType* __restrict__ d_output,
-                                 const DataType* __restrict__ global_mean,
-                                 const DataType* __restrict__ global_var,
-                                 const DataType* __restrict__ global_scale,
-                                 const DataType* __restrict__ global_dmean,
-                                 const DataType* __restrict__ global_dvar,
-                                 DataType* d_input,
-                                 DataType epsilon,
-                                 index_t num_per_sum,
-                                 tensor::Array<ND> shape,
-                                 tensor::Array<ND> input_strides,
-                                 tensor::Array<ND> d_output_strides,
-                                 tensor::Array<ND> d_input_strides)
+__global__ void backprop2_kernel(
+    const DataType* input, // no __restrict__ so input can be reused for d_input
+                           // as a memory optimization
+    const DataType* __restrict__ d_output,
+    const DataType* __restrict__ global_mean,
+    const DataType* __restrict__ global_var,
+    const DataType* __restrict__ global_scale,
+    const DataType* __restrict__ global_dmean,
+    const DataType* __restrict__ global_dvar,
+    DataType* d_input, // no __restrict__ so input can be reused for d_input as
+                       // a memory optimization
+    DataType epsilon,
+    index_t num_per_sum,
+    tensor::Array<ND> shape,
+    tensor::Array<ND> input_strides,
+    tensor::Array<ND> d_output_strides,
+    tensor::Array<ND> d_input_strides)
 {
     const index_t gidx = threadIdx.x + blockIdx.x * blockDim.x;
     const int ch_idx = blockIdx.y;
@@ -1366,18 +1369,21 @@ __global__ void backprop2_kernel(const DataType* input,
 }
 
 template <int ND, typename DataType, typename DataTypeV>
-__global__ void backprop2_opt_kernel(const DataTypeV* input,
-                                     const DataTypeV* __restrict__ d_output,
-                                     const DataType* __restrict__ global_mean,
-                                     const DataType* __restrict__ global_var,
-                                     const DataType* __restrict__ global_scale,
-                                     const DataType* __restrict__ global_dmean,
-                                     const DataType* __restrict__ global_dvar,
-                                     DataTypeV* d_input,
-                                     DataType epsilon,
-                                     index_t num_per_sum,
-                                     index_t spatial_size,
-                                     int num_channels)
+__global__ void backprop2_opt_kernel(
+    const DataTypeV* input, // no __restrict__ so input can be reused for
+                            // d_input as a memory optimization
+    const DataTypeV* __restrict__ d_output,
+    const DataType* __restrict__ global_mean,
+    const DataType* __restrict__ global_var,
+    const DataType* __restrict__ global_scale,
+    const DataType* __restrict__ global_dmean,
+    const DataType* __restrict__ global_dvar,
+    DataTypeV* d_input, // no __restrict__ so input can be reused for d_input as
+                        // a memory optimization
+    DataType epsilon,
+    index_t num_per_sum,
+    index_t spatial_size,
+    int num_channels)
 {
     const auto ch_idx = blockIdx.y;
     const auto sample_idx = blockIdx.z;


### PR DESCRIPTION
Fixes a bug in kernel selection in backward stage 2 for the case where the tensors have strides/overlaps. Also, allow aliasing in stage 2 kernels to support the memory optimization reusing inputs as error signals.