### PR TITLE
Use the default H2 cub allocator in distconv

### DIFF
--- a/include/h2/gpu/memory_utils.hpp
+++ b/include/h2/gpu/memory_utils.hpp
@@ -78,7 +78,57 @@ namespace h2
 namespace gpu
 {
 
+/** @brief The default CUB allocator used in H2.
+ *
+ *  Currently, this borrows the CUB allocator used in Hydrogen.
+ */
 RawCUBAllocType& default_cub_allocator();
+
+/** @brief The default growth factor for a new CUB allocator.
+ *
+ *  Environment variable: H2_CUB_BIN_GROWTH
+ *  Default value: 2U
+ */
+unsigned int cub_growth_factor() noexcept
+
+/** @brief The default smallest bin size for a new CUB allocator.
+ *
+ *  Environment variable: H2_CUB_MIN_BIN
+ *  Default value: 1U
+ */
+unsigned int cub_min_bin() noexcept
+
+/** @brief The default largest bin size for a new CUB allocator.
+ *
+ *  Environment variable: H2_CUB_MAX_BIN
+ *  Default value: no limit
+ */
+unsigned int cub_max_bin() noexcept
+
+/** @brief The default maximum size of a new CUB allocator.
+ *
+ *  Environment variable: H2_CUB_MAX_CACHED_SIZE
+ *  Default value: no limit
+ */
+size_t cub_max_cached_size() noexcept
+
+/** @brief The default debugging flag for a new CUB allocator.
+ *
+ *  Environment variable: H2_CUB_DEBUG
+ *  Default value: false
+ */
+bool cub_debug() noexcept;
+
+/** @brief Create a new CUB allocator.
+ *
+ *  At this time, users are recommended to just use the default CUB
+ *  allocator. This helps with consistency and debugging.
+ */
+RawCUBAllocType make_allocator(unsigned int const gf = cub_growth_factor(),
+                               unsigned int const min = cub_min_bin(),
+                               unsigned int const max = cub_max_bin(),
+                               size_t const max_cached = cub_max_cached_size(),
+                               bool const debug = cub_debug());
 
 template <typename T>
 inline void mem_copy(T* dst, T const* src)

--- a/include/h2/gpu/memory_utils.hpp
+++ b/include/h2/gpu/memory_utils.hpp
@@ -91,28 +91,28 @@ RawCUBAllocType& default_cub_allocator();
  *  Environment variable: H2_CUB_BIN_GROWTH
  *  Default value: 2U
  */
-unsigned int cub_growth_factor() noexcept
+unsigned int cub_growth_factor() noexcept;
 
 /** @brief The default smallest bin size for a new CUB allocator.
  *
  *  Environment variable: H2_CUB_MIN_BIN
  *  Default value: 1U
  */
-unsigned int cub_min_bin() noexcept
+unsigned int cub_min_bin() noexcept;
 
 /** @brief The default largest bin size for a new CUB allocator.
  *
  *  Environment variable: H2_CUB_MAX_BIN
  *  Default value: no limit
  */
-unsigned int cub_max_bin() noexcept
+unsigned int cub_max_bin() noexcept;
 
 /** @brief The default maximum size of a new CUB allocator.
  *
  *  Environment variable: H2_CUB_MAX_CACHED_SIZE
  *  Default value: no limit
  */
-size_t cub_max_cached_size() noexcept
+size_t cub_max_cached_size() noexcept;
 
 /** @brief The default debugging flag for a new CUB allocator.
  *

--- a/include/h2/gpu/memory_utils.hpp
+++ b/include/h2/gpu/memory_utils.hpp
@@ -80,7 +80,9 @@ namespace gpu
 
 /** @brief The default CUB allocator used in H2.
  *
- *  Currently, this borrows the CUB allocator used in Hydrogen.
+ *  If H2_INTERNAL_CUB_POOL=1, then this constructs a new CUB
+ *  allocator for H2 use. Otherwise, this borrows the CUB allocator
+ *  used in Hydrogen.
  */
 RawCUBAllocType& default_cub_allocator();
 

--- a/legacy/include/distconv/runtime_cuda.hpp
+++ b/legacy/include/distconv/runtime_cuda.hpp
@@ -13,23 +13,20 @@ class CUDADeviceMemoryPool {
   void *get(size_t size, cudaStream_t st);
   void release(void *p);
   size_t get_max_allocatable_size(size_t limit);
-  
- protected:
-  cub::CachingDeviceAllocator m_allocator;
 };
 
 class RuntimeCUDA {
  public:
   static CUDADeviceMemoryPool &get_device_memory_pool();
   static cudaEvent_t &get_event(int idx=0);
-  
+
  protected:
   static RuntimeCUDA *m_instance;
   //PinnedMemoryPool m_pmp;
   CUDADeviceMemoryPool m_dmp;
   static constexpr int m_num_events = 2;
   cudaEvent_t m_events[m_num_events];
-  
+
   RuntimeCUDA();
   static RuntimeCUDA &get_instance();
 };

--- a/legacy/include/distconv/runtime_rocm.hpp
+++ b/legacy/include/distconv/runtime_rocm.hpp
@@ -24,9 +24,6 @@ public:
     void* get(size_t size, hipStream_t st);
     void release(void* p);
     size_t get_max_allocatable_size(size_t limit);
-
-private:
-    hipcub::CachingDeviceAllocator m_allocator;
 };
 
 class RuntimeHIP

--- a/legacy/src/runtime_cuda.cpp
+++ b/legacy/src/runtime_cuda.cpp
@@ -9,12 +9,14 @@
 namespace distconv {
 namespace internal {
 
-CUDADeviceMemoryPool::CUDADeviceMemoryPool() {}
+CUDADeviceMemoryPool::CUDADeviceMemoryPool()
+{}
 CUDADeviceMemoryPool::~CUDADeviceMemoryPool() {}
 
 void *CUDADeviceMemoryPool::get(size_t size, cudaStream_t st) {
   void *p = nullptr;
-  cudaError_t err = h2::gpu::default_cub_allocator().DeviceAllocate(&p, size, st);
+  cudaError_t err =
+      h2::gpu::default_cub_allocator().DeviceAllocate(&p, size, st);
   if (err != cudaSuccess) {
     size_t available;
     size_t total;

--- a/legacy/src/runtime_cuda.cpp
+++ b/legacy/src/runtime_cuda.cpp
@@ -9,20 +9,12 @@
 namespace distconv {
 namespace internal {
 
-CUDADeviceMemoryPool::CUDADeviceMemoryPool():
-    m_allocator(4, 8, cub::CachingDeviceAllocator::INVALID_BIN,
-                cub::CachingDeviceAllocator::INVALID_SIZE, false,
-#ifdef DISTCONV_DEBUG
-                true
-#else
-                false
-#endif
-                ) {}
+CUDADeviceMemoryPool::CUDADeviceMemoryPool() {}
 CUDADeviceMemoryPool::~CUDADeviceMemoryPool() {}
 
 void *CUDADeviceMemoryPool::get(size_t size, cudaStream_t st) {
   void *p = nullptr;
-  cudaError_t err = m_allocator.DeviceAllocate(&p, size, st);
+  cudaError_t err = h2::gpu::default_cub_allocator().DeviceAllocate(&p, size, st);
   if (err != cudaSuccess) {
     size_t available;
     size_t total;
@@ -40,11 +32,11 @@ void *CUDADeviceMemoryPool::get(size_t size, cudaStream_t st) {
 }
 
 void CUDADeviceMemoryPool::release(void *p) {
-  DISTCONV_CHECK_CUDA(m_allocator.DeviceFree(p));
+  DISTCONV_CHECK_CUDA(h2::gpu::default_cub_allocator().DeviceFree(p));
 }
 
 size_t CUDADeviceMemoryPool::get_max_allocatable_size(size_t limit) {
-  size_t bin_growth = m_allocator.bin_growth;
+  size_t bin_growth = h2::gpu::default_cub_allocator().bin_growth;
   size_t x = std::log(limit) / std::log(bin_growth);
   size_t max_allowed_size = std::pow(bin_growth, x);
   return max_allowed_size;
@@ -81,4 +73,3 @@ cudaEvent_t &RuntimeCUDA::get_event(int idx) {
 
 } // namespace internal
 } // namespace distconv
-

--- a/legacy/src/runtime_rocm.cpp
+++ b/legacy/src/runtime_rocm.cpp
@@ -31,8 +31,8 @@ HIPDeviceMemoryPool::~HIPDeviceMemoryPool()
 void* HIPDeviceMemoryPool::get(size_t size, hipStream_t st)
 {
     void* p = nullptr;
-    auto const err
-      = h2::gpu::default_cub_allocator().DeviceAllocate(&p, size, st);
+    auto const err =
+        h2::gpu::default_cub_allocator().DeviceAllocate(&p, size, st);
     if (err != hipSuccess)
     {
         auto [available, total] = h2::gpu::mem_info();

--- a/src/gpu/memory_utils.cpp
+++ b/src/gpu/memory_utils.cpp
@@ -63,9 +63,8 @@ unsigned int h2::gpu::cub_min_bin() noexcept
 unsigned int h2::gpu::cub_max_bin() noexcept
 {
     char const* env = std::getenv("H2_CUB_MAX_BIN");
-    return (env
-            ? static_cast<unsigned int>(std::atoi(env))
-            : h2::gpu::RawCUBAllocType::INVALID_BIN);
+    return (env ? static_cast<unsigned int>(std::atoi(env))
+                : h2::gpu::RawCUBAllocType::INVALID_BIN);
 }
 
 size_t h2::gpu::cub_max_cached_size() noexcept
@@ -88,12 +87,12 @@ h2::gpu::RawCUBAllocType h2::gpu::make_allocator(unsigned int const gf,
                                                  bool const debug)
 {
     H2_GPU_TRACE("H2 created CUB allocator"
-                "(gf={}, min={}, max={}, max_cached={}, debug={})",
-                gf,
-                min,
-                max,
-                max_cached,
-                debug);
+                 "(gf={}, min={}, max={}, max_cached={}, debug={})",
+                 gf,
+                 min,
+                 max,
+                 max_cached,
+                 debug);
     return h2::gpu::RawCUBAllocType{/*bin_growth=*/gf,
                                     /*min_bin=*/min,
                                     /*max_bin=*/max,
@@ -129,8 +128,8 @@ static h2::gpu::RawCUBAllocType& get_internal_cub_allocator()
 
 h2::gpu::RawCUBAllocType& h2::gpu::default_cub_allocator()
 {
-    static auto& alloc = (use_internal_pool()
-                          ? get_internal_cub_allocator()
-                          : borrow_hydrogen_cub_allocator());
+    static auto& alloc =
+        (use_internal_pool() ? get_internal_cub_allocator()
+                             : borrow_hydrogen_cub_allocator());
     return alloc;
 }

--- a/src/gpu/memory_utils.cpp
+++ b/src/gpu/memory_utils.cpp
@@ -81,11 +81,11 @@ bool h2::gpu::cub_debug() noexcept
     return (env && std::strlen(env) && env[0] != '0');
 }
 
-h2::gpu::RawCUBAllocType make_allocator(unsigned int const gf,
-                                        unsigned int const min,
-                                        unsigned int const max,
-                                        size_t const max_cached,
-                                        bool const debug)
+h2::gpu::RawCUBAllocType h2::gpu::make_allocator(unsigned int const gf,
+                                                 unsigned int const min,
+                                                 unsigned int const max,
+                                                 size_t const max_cached,
+                                                 bool const debug)
 {
     H2_GPU_TRACE("H2 created CUB allocator"
                 "(gf={}, min={}, max={}, max_cached={}, debug={})",
@@ -123,7 +123,7 @@ static h2::gpu::RawCUBAllocType& borrow_hydrogen_cub_allocator()
 
 static h2::gpu::RawCUBAllocType& get_internal_cub_allocator()
 {
-    static auto alloc = make_allocator();
+    static auto alloc = h2::gpu::make_allocator();
     return alloc;
 }
 
@@ -131,6 +131,6 @@ h2::gpu::RawCUBAllocType& h2::gpu::default_cub_allocator()
 {
     static auto& alloc = (use_internal_pool()
                           ? get_internal_cub_allocator()
-                          : borrow_hydrogen_cub_allocator();
+                          : borrow_hydrogen_cub_allocator());
     return alloc;
 }

--- a/src/gpu/memory_utils.cpp
+++ b/src/gpu/memory_utils.cpp
@@ -8,6 +8,8 @@
 
 #include "h2_config.hpp"
 
+#include <hydrogen/device/gpu/CUB.hpp>
+
 #if H2_HAS_CUDA
 #include <cub/util_allocator.cuh>
 #include <cuda_runtime.h>
@@ -46,31 +48,34 @@
 // match '[^0].*'. The behavior is undefined if the value of the H2_*
 // variables differs across processes in one MPI universe.
 
-namespace
+unsigned int h2::gpu::cub_growth_factor() noexcept
 {
+    char const* env = std::getenv("H2_CUB_BIN_GROWTH");
+    return (env ? static_cast<unsigned int>(std::atoi(env)) : 2);
+}
 
-#define H2_GET_UINT_ENV_FUNC(FUNC_NAME, VAR, DEFAULT_VAL)                      \
-    static unsigned int FUNC_NAME() noexcept                                   \
-    {                                                                          \
-        char const* env = std::getenv(VAR);                                    \
-        return (env ? static_cast<unsigned int>(std::atoi(env))                \
-                    : DEFAULT_VAL);                                            \
-    }
-H2_GET_UINT_ENV_FUNC(growth_factor, "H2_CUB_BIN_GROWTH", 2)
-H2_GET_UINT_ENV_FUNC(min_bin, "H2_CUB_MIN_BIN", 1)
-H2_GET_UINT_ENV_FUNC(max_bin,
-                     "H2_CUB_MAX_BIN",
-                     h2::gpu::RawCUBAllocType::INVALID_BIN)
-#undef H2_GET_UINT_ENV_FUNC
+unsigned int h2::gpu::cub_min_bin() noexcept
+{
+    char const* env = std::getenv("H2_CUB_MIN_BIN");
+    return (env ? static_cast<unsigned int>(std::atoi(env)) : 1);
+}
 
-static size_t max_cached_size() noexcept
+unsigned int h2::gpu::cub_max_bin() noexcept
+{
+    char const* env = std::getenv("H2_CUB_MAX_BIN");
+    return (env
+            ? static_cast<unsigned int>(std::atoi(env))
+            : h2::gpu::RawCUBAllocType::INVALID_BIN);
+}
+
+size_t h2::gpu::cub_max_cached_size() noexcept
 {
     char const* env = std::getenv("H2_CUB_MAX_CACHED_SIZE");
     return (env ? static_cast<size_t>(std::atoll(env))
                 : h2::gpu::RawCUBAllocType::INVALID_SIZE);
 }
 
-static bool debug() noexcept
+bool h2::gpu::cub_debug() noexcept
 {
     char const* env = std::getenv("H2_CUB_DEBUG");
     return (env && std::strlen(env) && env[0] != '0');
@@ -82,7 +87,7 @@ h2::gpu::RawCUBAllocType make_allocator(unsigned int const gf,
                                         size_t const max_cached,
                                         bool const debug)
 {
-    H2_GPU_TRACE("hipcub allocator"
+    H2_GPU_TRACE("CUB allocator"
                 "(gf={}, min={}, max={}, max_cached={}, debug={})",
                 gf,
                 min,
@@ -96,11 +101,21 @@ h2::gpu::RawCUBAllocType make_allocator(unsigned int const gf,
                                     /*skip_cleanup=*/false,
                                     /*debug=*/debug};
 }
-} // namespace
 
+static h2::gpu::RawCUBAllocType& borrow_hydrogen_cub_allocator()
+{
+    auto& alloc = hydrogen::cub::MemoryPool();
+    H2_GPU_TRACE("H2 using Hydrogen CUB allocator"
+                 "(gf={}, min={}, max={}, max_cached={}, debug={})",
+                 alloc.bin_growth,
+                 alloc.min_bin,
+                 alloc.max_bin,
+                 alloc.max_cached_bytes,
+                 alloc.debug);
+    return alloc;
+}
 h2::gpu::RawCUBAllocType& h2::gpu::default_cub_allocator()
 {
-    static RawCUBAllocType alloc = make_allocator(
-        growth_factor(), min_bin(), max_bin(), max_cached_size(), debug());
+    static auto& alloc = borrow_hydrogen_cub_allocator();
     return alloc;
 }


### PR DESCRIPTION
This should simplify debugging and streamline memory usage a bit.

This further uses Hydrogen's memory pool by default. If a user wished to separate them and instead use an internal-to-H2 pool for DistConv, they could set `H2_INTERNAL_CUB_POOL=1`.