### PR TITLE
Lazy tensors & other memory changes

### DIFF
--- a/include/h2/tensor/fixed_size_tuple.hpp
+++ b/include/h2/tensor/fixed_size_tuple.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <array>
+#include <iterator>
 #include <type_traits>
 #include <ostream>
 
@@ -46,6 +47,11 @@ struct FixedSizeTuple {
   using type = T;
   using size_type = SizeType;
   static constexpr SizeType max_size = N;
+
+  using iterator = typename std::array<T, N>::iterator;
+  using const_iterator = typename std::array<T, N>::const_iterator;
+  using reverse_iterator = typename std::array<T, N>::reverse_iterator;
+  using const_reverse_iterator = typename std::array<T, N>::const_reverse_iterator;
 
   /**
    * Construct a tuple from the arguments and set the number of valid
@@ -87,6 +93,80 @@ struct FixedSizeTuple {
 
   /** Return a constant raw pointer to the tuple. */
   const T* const_data() const H2_NOEXCEPT { return data_.data(); }
+
+  /** Return an iterator to the first element of the tuple. */
+  constexpr iterator begin() H2_NOEXCEPT { return data_.begin(); }
+
+  constexpr const_iterator begin() const H2_NOEXCEPT { return data_.begin(); }
+
+  /** Return a constant iterator to the first element of the tuple. */
+  constexpr const_iterator cbegin() const H2_NOEXCEPT { return data_.cbegin(); }
+
+  /**
+   * Return an iterator to the element past the last element of the
+   * tuple.
+   */
+  constexpr iterator end() H2_NOEXCEPT { return data_.begin() + size_; }
+
+  constexpr const_iterator end() const H2_NOEXCEPT
+  {
+    return data_.begin() + size_;
+  }
+
+  /**
+   * Return a constant iterator to the element past the last element of
+   * the tuple.
+   */
+  constexpr const_iterator cend() const H2_NOEXCEPT
+  {
+    return data_.cbegin() + size_;
+  }
+
+  /**
+   * Return a reverse iterator to the first element of the reversed
+   * tuple.
+   */
+  constexpr reverse_iterator rbegin() H2_NOEXCEPT
+  {
+    return std::make_reverse_iterator(end());
+  }
+
+  constexpr const_reverse_iterator rbegin() const H2_NOEXCEPT
+  {
+    return std::make_reverse_iterator(end());
+  }
+
+  /**
+   * Return a const reverse iterator to the first element of the
+   * reversed tuple.
+   */
+  constexpr const_reverse_iterator crbegin() const H2_NOEXCEPT
+  {
+    return std::make_reverse_iterator(cend());
+  }
+
+  /**
+   * Return a reverse iterator to the element past the last element of
+   * the reversed tuple.
+   */
+  constexpr reverse_iterator rend() H2_NOEXCEPT
+  {
+    return std::make_reverse_iterator(begin());
+  }
+
+  constexpr const_reverse_iterator rend() const H2_NOEXCEPT
+  {
+    return std::make_reverse_iterator(begin());
+  }
+
+  /**
+   * Return a const reverse iterator to the element past the last
+   * element of the reversed tuple.
+   */
+  constexpr const_reverse_iterator crend() const H2_NOEXCEPT
+  {
+    return std::make_reverse_iterator(cbegin());
+  }
 
   /** Return the value of the tuple at the i'th index. */
   constexpr T& operator[](SizeType i) H2_NOEXCEPT {

--- a/include/h2/tensor/fixed_size_tuple.hpp
+++ b/include/h2/tensor/fixed_size_tuple.hpp
@@ -199,6 +199,21 @@ constexpr AccT inner_product(const FixedSizeTuple<T1, SizeType1, N1>& a,
   return r;
 }
 
+/**
+ * Return true if the predicate returns true for any entry in a
+ * FixedSizeTuple; otherwise return false.
+ */
+template <typename T, typename SizeType, SizeType N, typename Predicate>
+constexpr bool any_of(const FixedSizeTuple<T, SizeType, N>& tuple,
+                      Predicate p) {
+  for (SizeType i = 0; i < tuple.size(); ++i) {
+    if (p(tuple[i])) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /** @brief Get all but the last element of the input tuple */
 template <typename T, typename SizeType, SizeType N>
 constexpr h2::FixedSizeTuple<T, SizeType, N>

--- a/include/h2/tensor/raw_buffer.hpp
+++ b/include/h2/tensor/raw_buffer.hpp
@@ -84,10 +84,14 @@ public:
   RawBuffer(const SyncInfo<Dev>& sync = SyncInfo<Dev>{})
     : buffer(nullptr), buffer_size(0), sync_info(sync), unowned_buffer(false)
   {}
-  RawBuffer(std::size_t size, const SyncInfo<Dev>& sync = SyncInfo<Dev>{})
+  RawBuffer(std::size_t size, bool defer_alloc = false,
+            const SyncInfo<Dev>& sync = SyncInfo<Dev>{})
     : buffer(nullptr), buffer_size(size), sync_info(sync), unowned_buffer(false)
   {
-    ensure();
+    if (!defer_alloc)
+    {
+      ensure();
+    }
   }
   RawBuffer(T* external_buffer, std::size_t size,
             const SyncInfo<Dev>& sync = SyncInfo<Dev>{})

--- a/include/h2/tensor/raw_buffer.hpp
+++ b/include/h2/tensor/raw_buffer.hpp
@@ -82,23 +82,37 @@ template <typename T, Device Dev>
 class RawBuffer {
 public:
   RawBuffer(const SyncInfo<Dev>& sync = SyncInfo<Dev>{})
-    : buffer(nullptr), buffer_size(0), sync_info(sync)
+    : buffer(nullptr), buffer_size(0), sync_info(sync), unowned_buffer(false)
   {}
   RawBuffer(std::size_t size, const SyncInfo<Dev>& sync = SyncInfo<Dev>{})
-    : buffer(nullptr), buffer_size(size), sync_info(sync)
+    : buffer(nullptr), buffer_size(size), sync_info(sync), unowned_buffer(false)
   {
     ensure();
   }
+  RawBuffer(T* external_buffer, std::size_t size,
+            const SyncInfo<Dev>& sync = SyncInfo<Dev>{})
+    : buffer(external_buffer), buffer_size(size), sync_info(sync),
+      unowned_buffer(true)
+  {}
 
   ~RawBuffer() { release(); }
 
+  /** Allocate memory if the buffer is not present. */
   void ensure()
   {
-    if (buffer_size && !buffer) {
+    if (buffer_size && !buffer && !unowned_buffer)
+    {
       buffer = internal::Allocator<T, Dev>::allocate(buffer_size, sync_info);
     }
   }
 
+  /**
+   * Deallocate allocated memory.
+   *
+   * If the buffer is external, it will not be deallocated, but this
+   * RawBuffer will no longer refer to it. Subsequent calls to `ensure`
+   * will allocate a fresh buffer.
+   */
   void release() {
     if (buffer)
     {
@@ -112,11 +126,16 @@ public:
         }
       }
 #endif
-      internal::Allocator<T, Dev>::deallocate(buffer, sync_info);
+      if (!unowned_buffer)
+      {
+        internal::Allocator<T, Dev>::deallocate(buffer, sync_info);
+      }
       buffer = nullptr;
+      unowned_buffer = false;
     }
 #ifdef H2_HAS_GPU
-    if constexpr (Dev == Device::GPU) {
+    if constexpr (Dev == Device::GPU)
+    {
       // Clear all recorded syncs.
       pending_syncs.clear();
     }
@@ -172,6 +191,7 @@ private:
   T* buffer;  /**< Internal buffer. */
   std::size_t buffer_size;  /**< Number of elements in buffer. */
   SyncInfo<Dev> sync_info;  /**< Synchronization management. */
+  bool unowned_buffer;  /**< Whether buffer is externally managed. */
 #ifdef H2_HAS_GPU
   /** List of sync objects that no longer reference this buffer. */
   std::vector<SyncInfo<Dev>> pending_syncs;

--- a/include/h2/tensor/strided_memory.hpp
+++ b/include/h2/tensor/strided_memory.hpp
@@ -299,7 +299,7 @@ private:
     // Do not allocate a RawBuffer for empty memory.
     if (!mem_shape.empty())
     {
-      std::size_t size = product<std::size_t>(mem_shape);
+      const std::size_t size = product<std::size_t>(mem_shape);
       if (size) {
         raw_buffer = std::make_shared<raw_buffer_t>(size, lazy, sync_info);
       }

--- a/include/h2/tensor/strided_memory.hpp
+++ b/include/h2/tensor/strided_memory.hpp
@@ -65,30 +65,35 @@ class StridedMemory
 {
 private:
   static constexpr std::size_t INVALID_OFFSET = static_cast<std::size_t>(-1);
+
+  using raw_buffer_t = RawBuffer<T, Dev>;
 public:
 
   /** Allocate empty memory. */
-  StridedMemory(const SyncInfo<Dev>& sync = SyncInfo<Dev>{})
+  StridedMemory(bool lazy = false, const SyncInfo<Dev>& sync = SyncInfo<Dev>{})
     : raw_buffer(nullptr),
       mem_offset(INVALID_OFFSET),
       unowned_mem_buffer(nullptr),
       mem_strides{},
       mem_shape{},
-      sync_info(sync)
+      sync_info(sync),
+      is_mem_lazy(lazy)
   {}
 
   /** Allocate memory for shape, with unit strides. */
-  StridedMemory(ShapeTuple shape, const SyncInfo<Dev>& sync = SyncInfo<Dev>{})
-    : StridedMemory(sync)
+  StridedMemory(ShapeTuple shape, bool lazy = false,
+                const SyncInfo<Dev>& sync = SyncInfo<Dev>{})
+    : StridedMemory(lazy, sync)
   {
     if (!shape.empty())
     {
       mem_strides = get_contiguous_strides(shape);
       mem_shape = shape;
-      raw_buffer = std::make_shared<RawBuffer<T, Dev>>(
-          product<std::size_t>(shape), sync);
+      if (!lazy)
+      {
+        ensure(false);  // Allocate memory.
+      }
       mem_offset = 0;
-      unowned_mem_buffer = nullptr;
     }
   }
 
@@ -100,7 +105,8 @@ public:
       mem_strides(
         TuplePad<StrideTuple>(base.mem_strides.size())), // Will be resized.
       mem_shape(get_range_shape(coords, base.shape())),
-      sync_info(base.sync_info)
+      sync_info(base.sync_info),
+      is_mem_lazy(base.is_lazy())
   {
     H2_ASSERT_DEBUG(coords.size() <= base.mem_strides.size(),
                     "coords size not compatible with strides");
@@ -126,14 +132,59 @@ public:
       unowned_mem_buffer(buffer),
       mem_strides(strides),
       mem_shape(shape),
-      sync_info(sync)
-  {}
+      sync_info(sync),
+      is_mem_lazy(false)
+  {
+    H2_ASSERT_DEBUG(buffer
+                    || shape.empty()
+                    || any_of(shape, [](ShapeTuple::type x) { return x == 0; }),
+                    "Null buffer but non-zero shape provided to StridedMemory");
+  }
 
   ~StridedMemory()
   {
     if (raw_buffer)
     {
       raw_buffer->register_release(sync_info);
+    }
+  }
+
+  void ensure(bool attempt_recover = true)
+  {
+    if (unowned_mem_buffer || raw_buffer)
+    {
+      return;  // Data is already allocated.
+    }
+    if (attempt_recover)
+    {
+      // If the old raw buffer is still allocated, reuse it.
+      raw_buffer = old_raw_buffer.lock();
+    }
+    if (!raw_buffer)
+    {
+      // Either not attempting to recover or no old raw buffer.
+      // Do not allocate a RawBuffer for empty memory.
+      if (!mem_shape.empty())
+      {
+        std::size_t size = product<std::size_t>(mem_shape);
+        if (size) {
+          raw_buffer = std::make_shared<raw_buffer_t>(size, sync_info);
+        }
+      }
+    }
+    old_raw_buffer.reset();  // Drop reference to old raw buffer.
+  }
+
+  void release()
+  {
+    if (unowned_mem_buffer)
+    {
+      unowned_mem_buffer = nullptr;
+    }
+    else if (raw_buffer)
+    {
+      old_raw_buffer = raw_buffer;
+      raw_buffer.reset();
     }
   }
 
@@ -155,7 +206,9 @@ public:
     }
     if (raw_buffer)
     {
-      H2_ASSERT_DEBUG(mem_offset != INVALID_OFFSET, "Invalid offset");
+      H2_ASSERT_DEBUG(mem_offset != INVALID_OFFSET,
+                      "Invalid offset in StridedMemory: "
+                      "raw_buffer is non-null but no offset was set");
       return raw_buffer->data() + mem_offset;
     }
     return nullptr;
@@ -224,6 +277,11 @@ public:
     }
   }
 
+  bool is_lazy() const H2_NOEXCEPT
+  {
+    return is_mem_lazy;
+  }
+
 private:
   /**
    * Raw underlying memory buffer.
@@ -231,18 +289,25 @@ private:
    * This may be shared across StridedMemory objects that have different
    * strides or offsets into the raw buffer.
    *
-   * If there is no memory, or we are wrapping externally managed
-   * memory, this is null.
+   * If there is no memory, we are lazy and memory has not yet been
+   * allocated, or we are wrapping externally managed memory, this is
+   * null.
    *
    * As `RawBuffer` may change the underlying memory, when using one,
    * we work with offsets instead of direct pointers into it.
    */
-  std::shared_ptr<RawBuffer<T, Dev>> raw_buffer;
+  std::shared_ptr<raw_buffer_t> raw_buffer;
   std::size_t mem_offset;  /**< Offset to start of raw_buffer. */
   T* unowned_mem_buffer;  /**< Pointer to an externally managed  buffer. */
+  /**
+   * Reference to the prior `raw_buffer`, which may be used when
+   * recovering existing memory from views using `ensure`.
+   */
+  std::weak_ptr<raw_buffer_t> old_raw_buffer;
   StrideTuple mem_strides;  /**< Strides associated with the memory. */
   ShapeTuple mem_shape;  /**< Shape describing the extent of the memory. */
   SyncInfo<Dev> sync_info;  /**< Synchronization info for operations. */
+  bool is_mem_lazy;  /**< Whether allocation is lazy. */
 };
 
 /** Support printing StridedMemory. */
@@ -251,7 +316,9 @@ inline std::ostream& operator<<(std::ostream& os,
                                 const StridedMemory<T, Dev>& mem)
 {
   // TODO: Print the type along with the device.
-  os << "StridedMemory<" << Dev << ">(" << mem.data() << ", " << mem.strides()
+  os << "StridedMemory<" << Dev << ">("
+     << (mem.is_lazy() ? "lazy" : "not lazy") << ", "
+     << mem.data() << ", " << mem.strides()
      << ", " << mem.shape() << ")";
   return os;
 }

--- a/include/h2/tensor/tensor.hpp
+++ b/include/h2/tensor/tensor.hpp
@@ -151,7 +151,6 @@ public:
 
   Tensor<T, Dev>* view(CoordTuple coords) override
   {
-    ensure();
     return make_view(coords, ViewType::Mutable);
   }
 

--- a/include/h2/tensor/tensor.hpp
+++ b/include/h2/tensor/tensor.hpp
@@ -123,7 +123,8 @@ public:
     return tensor_memory.const_data();
   }
 
-  void ensure(bool attempt_recover = true) override
+  void ensure(
+    TensorEnsure attempt_recover = TensorEnsure::AttemptRecovery) override
   {
     tensor_memory.ensure();
   }

--- a/include/h2/tensor/tensor_base.hpp
+++ b/include/h2/tensor/tensor_base.hpp
@@ -17,6 +17,13 @@
 namespace h2
 {
 
+/** For controlling `BaseTensor::ensure`. */
+enum class TensorEnsure
+{
+  NoRecovery,
+  AttemptRecovery
+};
+
 /**
  * Base class for n-dimensional tensors.
  *
@@ -37,7 +44,7 @@ namespace h2
  * can optionally "recover" the original memory. This ensures that any
  * views of the original tensor remain in sync. (This is the default.)
  *
- * Certain operations may implicitly call `ensure` (`data` and `view`).
+ * Certain operations may implicitly call `ensure` (e.g., `data`).
  * This only happens when the tensor is not const.
  */
 template <typename T>
@@ -164,7 +171,8 @@ public:
    * Optionally attempt to reuse existing memory from still-extant
    * views of this tensor.
    */
-  virtual void ensure(bool attempt_recover = true) = 0;
+  virtual void ensure(
+    TensorEnsure attempt_recover = TensorEnsure::AttemptRecovery) = 0;
 
   /**
    * Release memory associated with this tensor.

--- a/include/h2/tensor/tensor_base.hpp
+++ b/include/h2/tensor/tensor_base.hpp
@@ -28,9 +28,9 @@ namespace h2
  * freed until all references to it, e.g., views, have been destroyed
  * or have released their memory).
  *
- * A view cannot `ensure` or `release` memory. Further, creating a view
- * of a tensor requires that its memory be allocated (i.e., that
- * `ensure` has been called).
+ * A view of a lazy tensor functions as usual. `ensure` may be called
+ * on either the original tensor or the view to allocate memory, even
+ * if the view is const.
  *
  * If a tensor `release`s its memory, then calls `ensure` while its
  * original memory remains (e.g., due to a still-extant view), `ensure`

--- a/include/h2/tensor/tensor_base.hpp
+++ b/include/h2/tensor/tensor_base.hpp
@@ -17,12 +17,10 @@
 namespace h2
 {
 
-/** For controlling `BaseTensor::ensure`. */
-enum class TensorEnsure
-{
-  NoRecovery,
-  AttemptRecovery
-};
+/** Do not attempt recovery in `BaseTensor::ensure`. */
+static constexpr struct tensor_no_recovery_t {} TensorNoRecovery;
+/** Attempt recovery in `BaseTensor::ensure`. */
+static constexpr struct tensor_attempt_recovery_t {} TensorAttemptRecovery;
 
 /**
  * Base class for n-dimensional tensors.
@@ -168,11 +166,26 @@ public:
   /**
    * Ensure memory is backing this tensor, allocating if necessary.
    *
-   * Optionally attempt to reuse existing memory from still-extant
+   * This attempts to reuse existing memory from still-extant views of
+   * this tensor.
+   */
+  virtual void ensure() = 0;
+
+  /**
+   * Ensure memory is backing this tensor, allocating if necessary.
+   *
+   * This does not attempt to reuse existing memory from still-extant
    * views of this tensor.
    */
-  virtual void ensure(
-    TensorEnsure attempt_recover = TensorEnsure::AttemptRecovery) = 0;
+  virtual void ensure(tensor_no_recovery_t) = 0;
+
+  /**
+   * Ensure memory is backing this tensor, allocating if necessary.
+   *
+   * This attempts to reuse existing memory from still-extant views of
+   * this tensor.
+   */
+  virtual void ensure(tensor_attempt_recovery_t) = 0;
 
   /**
    * Release memory associated with this tensor.

--- a/test/static_test/tensor/fixed_size_tuple.cpp
+++ b/test/static_test/tensor/fixed_size_tuple.cpp
@@ -25,6 +25,9 @@ static_assert(h2::product<int>(test_tuple) == 1,
               "Product of empty tuple is wrong.");
 static_assert(h2::inner_product<int>(test_tuple, test_tuple2) == 0,
               "Inner product of empty tuples is wrong");
+static_assert(!h2::any_of(test_tuple,
+                          [](TestFixedSizeTuple::type x) { return x == 0; }),
+              "Any of for empty tuples is wrong");
 
 constexpr auto test_tuple_copy = test_tuple;
 static_assert(test_tuple_copy.size() == 0,
@@ -63,6 +66,12 @@ static_assert(h2::product<int>(test_tuple) == 2,
               "Sized tuple product has wrong value");
 static_assert(h2::inner_product<int>(test_tuple, test_tuple2) == 5,
               "Inner product of sized tuples has wrong value");
+static_assert(h2::any_of(test_tuple,
+                         [](TestFixedSizeTuple::type x) { return x == 1; }),
+              "Any of for sized tuples is wrong");
+static_assert(!h2::any_of(test_tuple,
+                          [](TestFixedSizeTuple::type x) { return x == 3; }),
+              "Any of for sized tuples is wrong");
 
 constexpr auto test_tuple_copy = test_tuple;
 static_assert(test_tuple_copy.size() == 2,

--- a/test/static_test/tensor/fixed_size_tuple.cpp
+++ b/test/static_test/tensor/fixed_size_tuple.cpp
@@ -29,6 +29,15 @@ static_assert(!h2::any_of(test_tuple,
                           [](TestFixedSizeTuple::type x) { return x == 0; }),
               "Any of for empty tuples is wrong");
 
+static_assert(test_tuple.begin() == test_tuple.end(),
+              "Empty tuple iterators are wrong");
+static_assert(test_tuple.cbegin() == test_tuple.cend(),
+              "Empty tuple iterators are wrong");
+static_assert(test_tuple.rbegin() == test_tuple.rend(),
+              "Empty tuple reverse iterators are wrong");
+static_assert(test_tuple.crbegin() == test_tuple.crend(),
+              "Empty tuple reverse iterators are wrong");
+
 constexpr auto test_tuple_copy = test_tuple;
 static_assert(test_tuple_copy.size() == 0,
               "Empty tuple copy does not have size 0");
@@ -72,6 +81,20 @@ static_assert(h2::any_of(test_tuple,
 static_assert(!h2::any_of(test_tuple,
                           [](TestFixedSizeTuple::type x) { return x == 3; }),
               "Any of for sized tuples is wrong");
+
+static_assert(*test_tuple.begin() == 1,
+              "Sized tuple iterators are wrong");
+static_assert(*std::next(test_tuple.begin()) == 2,
+              "Sized tuple iterators are wrong");
+static_assert(test_tuple.begin() + test_tuple.size() == test_tuple.end(),
+              "Sized tuple iterators are wrong");
+
+static_assert(*test_tuple.rbegin() == 2,
+              "Sized tuple reverse iterators are wrong");
+static_assert(*std::next(test_tuple.rbegin()) == 1,
+              "Sized tuple reverse iterators are wrong");
+static_assert(test_tuple.rbegin() + test_tuple.size() == test_tuple.rend(),
+              "Sized tuple reverse iterators are wrong");
 
 constexpr auto test_tuple_copy = test_tuple;
 static_assert(test_tuple_copy.size() == 2,

--- a/test/unit_test/tensor/unit_test_hydrogen_interop.cpp
+++ b/test/unit_test/tensor/unit_test_hydrogen_interop.cpp
@@ -33,8 +33,9 @@ TEST_CASE("is_chw_packed predicate", "[tensor][utilities]")
     // This is simply a pointer that can be used to construct a tensor
     // using the "pointer-attach" constructors. The data is never read
     // in these tests, which just exercise metadata capabilities, so
-    // it doesn't matter that the pointer is null.
-    DataType* mock_data = nullptr;
+    // it doesn't matter that the pointer is invalid.
+    // Don't use nullptr because that is checked.
+    DataType* mock_data = reinterpret_cast<DataType*>(1);
 
     SECTION("Empty tensor is considered trivially packed.")
     {
@@ -280,8 +281,8 @@ TEMPLATE_LIST_TEST_CASE("DiHydrogen to Hydrogen conversion",
     using MatrixType = El::Matrix<DataType, HDev>;
 
     // Metadata checks ONLY
-    DataType* const mock_data = nullptr;
-    DataType const* const mock_const_data = nullptr;
+    DataType* const mock_data = reinterpret_cast<DataType* const>(1);
+    DataType const* const mock_const_data = reinterpret_cast<DataType const* const>(1);
 
     SECTION("Rank-1 contiguous tensor")
     {

--- a/test/unit_test/tensor/unit_test_raw_buffer.cpp
+++ b/test/unit_test/tensor/unit_test_raw_buffer.cpp
@@ -128,6 +128,31 @@ TEMPLATE_LIST_TEST_CASE("Raw buffer with explicit size 0 is sane",
   }
 }
 
+TEMPLATE_LIST_TEST_CASE("Raw buffer with external memory is sane",
+                        "[tensor][raw_buffer]",
+                        AllDevList)
+{
+  using BufType = RawBuffer<DataType, TestType::value>;
+
+  DataType test_data[] = {0, 0, 0, 0};
+  BufType buf = BufType(test_data, 4);
+
+  REQUIRE(buf.size() == 4);
+  REQUIRE(buf.data() == test_data);
+  REQUIRE(buf.const_data() == test_data);
+  buf.ensure();
+  REQUIRE(buf.data() == test_data);
+  REQUIRE(buf.const_data() == test_data);
+  buf.release();
+  REQUIRE(buf.data() == nullptr);
+  REQUIRE(buf.const_data() == nullptr);
+  buf.ensure();
+  REQUIRE(buf.data() != nullptr);
+  REQUIRE(buf.const_data() != nullptr);
+  REQUIRE(buf.data() != test_data);
+  REQUIRE(buf.const_data() != test_data);
+}
+
 TEMPLATE_LIST_TEST_CASE("Raw buffers are writable",
                         "[tensor][raw_buffer]",
                         AllDevList)

--- a/test/unit_test/tensor/unit_test_raw_buffer.cpp
+++ b/test/unit_test/tensor/unit_test_raw_buffer.cpp
@@ -92,6 +92,42 @@ TEMPLATE_LIST_TEST_CASE("Empty raw buffers are sane",
   }
 }
 
+TEMPLATE_LIST_TEST_CASE("Raw buffer with explicit size 0 is sane",
+                        "[tensor][raw_buffer]",
+                        AllDevList)
+{
+  using BufType = RawBuffer<DataType, TestType::value>;
+
+  BufType buf(0);
+
+  REQUIRE(buf.size() == 0);
+  REQUIRE(buf.data() == nullptr);
+  REQUIRE(buf.const_data() == nullptr);
+
+  SECTION("Ensure then release works") {
+    buf.ensure();
+    REQUIRE(buf.size() == 0);
+    REQUIRE(buf.data() == nullptr);
+    REQUIRE(buf.const_data() == nullptr);
+
+    buf.release();
+    REQUIRE(buf.size() == 0);
+    REQUIRE(buf.data() == nullptr);
+    REQUIRE(buf.const_data() == nullptr);
+  }
+  SECTION("Release then ensure works") {
+    buf.release();
+    REQUIRE(buf.size() == 0);
+    REQUIRE(buf.data() == nullptr);
+    REQUIRE(buf.const_data() == nullptr);
+
+    buf.ensure();
+    REQUIRE(buf.size() == 0);
+    REQUIRE(buf.data() == nullptr);
+    REQUIRE(buf.const_data() == nullptr);
+  }
+}
+
 TEMPLATE_LIST_TEST_CASE("Raw buffers are writable",
                         "[tensor][raw_buffer]",
                         AllDevList)

--- a/test/unit_test/tensor/unit_test_strided_memory.cpp
+++ b/test/unit_test/tensor/unit_test_strided_memory.cpp
@@ -353,6 +353,36 @@ TEMPLATE_LIST_TEST_CASE("Lazy StridedMemory works",
     REQUIRE(mem.data() != mem2.data());
     REQUIRE(mem.const_data() != mem2.const_data());
   }
+
+  SECTION("Viewing lazy strided memory works")
+  {
+    MemType mem2 = mem;
+    REQUIRE(mem2.is_lazy());
+    REQUIRE(mem2.data() == nullptr);
+    REQUIRE(mem2.const_data() == nullptr);
+
+    SECTION("Ensure from view 1 works")
+    {
+      mem.ensure();
+      REQUIRE(mem.data() != nullptr);
+      REQUIRE(mem.const_data() != nullptr);
+      REQUIRE(mem.data() == mem2.data());
+      REQUIRE(mem.const_data() == mem2.const_data());
+      mem.release();
+      REQUIRE(mem.data() == nullptr);
+      REQUIRE(mem.const_data() == nullptr);
+      REQUIRE(mem2.data() != nullptr);
+      REQUIRE(mem2.const_data() != nullptr);
+    }
+    SECTION("Ensure from view 2 works")
+    {
+      mem2.ensure();
+      REQUIRE(mem2.data() != nullptr);
+      REQUIRE(mem2.const_data() != nullptr);
+      REQUIRE(mem.data() == mem2.data());
+      REQUIRE(mem.const_data() == mem2.const_data());
+    }
+  }
 }
 
 TEMPLATE_LIST_TEST_CASE("Empty lazy StridedMemory works",

--- a/test/unit_test/tensor/unit_test_strided_memory.cpp
+++ b/test/unit_test/tensor/unit_test_strided_memory.cpp
@@ -393,15 +393,45 @@ TEMPLATE_LIST_TEST_CASE("StridedMemory with external buffers works",
   REQUIRE(mem.shape() == ShapeTuple{2, 2});
   REQUIRE(mem.strides() == StrideTuple{1, 2});
 
-  mem.ensure();
-  REQUIRE(mem.data() == test_data);
-  REQUIRE(mem.const_data() == test_data);
-  mem.release();
-  REQUIRE(mem.data() == nullptr);
-  REQUIRE(mem.const_data() == nullptr);
-  mem.ensure();
-  REQUIRE(mem.data() != nullptr);
-  REQUIRE(mem.const_data() != nullptr);
+  SECTION("Ensure and release works")
+  {
+    mem.ensure();
+    REQUIRE(mem.data() == test_data);
+    REQUIRE(mem.const_data() == test_data);
+    mem.release();
+    REQUIRE(mem.data() == nullptr);
+    REQUIRE(mem.const_data() == nullptr);
+    mem.ensure();
+    REQUIRE(mem.data() != nullptr);
+    REQUIRE(mem.const_data() != nullptr);
+  }
 
-  // TODO: Views.
+  SECTION("Views work")
+  {
+    MemType mem2 = mem;
+    REQUIRE(mem.data() == mem2.data());
+    REQUIRE(mem.const_data() == mem2.const_data());
+    mem.release();
+    REQUIRE(mem.data() == nullptr);
+    REQUIRE(mem.const_data() == nullptr);
+    mem.ensure();
+    REQUIRE(mem.data() == mem2.data());
+    REQUIRE(mem.const_data() == mem2.const_data());
+    mem.release();
+    mem.ensure(false);
+    REQUIRE(mem.data() != nullptr);
+    REQUIRE(mem.data() != mem2.data());
+    REQUIRE(mem.const_data() != nullptr);
+    REQUIRE(mem.const_data() != mem2.const_data());
+    mem.release();
+    mem2.release();
+    mem.ensure();
+    mem2.ensure();
+    REQUIRE(mem.data() != nullptr);
+    REQUIRE(mem.const_data() != nullptr);
+    REQUIRE(mem2.data() != nullptr);
+    REQUIRE(mem2.const_data() != nullptr);
+    REQUIRE(mem.data() != mem2.data());
+    REQUIRE(mem.const_data() != mem2.const_data());
+  }
 }

--- a/test/unit_test/tensor/unit_test_strided_memory.cpp
+++ b/test/unit_test/tensor/unit_test_strided_memory.cpp
@@ -62,7 +62,7 @@ TEMPLATE_LIST_TEST_CASE("StridedMemory is sane",
                         AllDevList) {
   using MemType = StridedMemory<DataType, TestType::value>;
 
-  MemType mem = MemType({3, 7});
+  MemType mem = MemType(ShapeTuple{3, 7});
   REQUIRE(mem.data() != nullptr);
   REQUIRE(mem.const_data() != nullptr);
   REQUIRE(mem.strides() == StrideTuple{1, 3});
@@ -71,6 +71,36 @@ TEMPLATE_LIST_TEST_CASE("StridedMemory is sane",
   REQUIRE(mem.shape() == ShapeTuple{3, 7});
   REQUIRE(mem.shape(0) == 3);
   REQUIRE(mem.shape(1) == 7);
+  REQUIRE_FALSE(mem.is_lazy());
+
+  SECTION("Ensure then release works")
+  {
+    DataType* orig_data = mem.data();
+    mem.ensure();
+    REQUIRE(mem.data() == orig_data);
+    REQUIRE(mem.const_data() == orig_data);
+    mem.ensure();
+    REQUIRE(mem.data() == orig_data);
+    REQUIRE(mem.const_data() == orig_data);
+    mem.release();
+    REQUIRE(mem.data() == nullptr);
+    REQUIRE(mem.const_data() == nullptr);
+    mem.release();
+    REQUIRE(mem.data() == nullptr);
+    REQUIRE(mem.const_data() == nullptr);
+    mem.ensure();
+    REQUIRE(mem.data() != nullptr);
+    REQUIRE(mem.const_data() != nullptr);
+  }
+  SECTION("Release then ensure works")
+  {
+    mem.release();
+    REQUIRE(mem.data() == nullptr);
+    REQUIRE(mem.const_data() == nullptr);
+    mem.ensure();
+    REQUIRE(mem.data() != nullptr);
+    REQUIRE(mem.const_data() != nullptr);
+  }
 }
 
 TEMPLATE_LIST_TEST_CASE("Empty StridedMemory is sane",
@@ -84,6 +114,56 @@ TEMPLATE_LIST_TEST_CASE("Empty StridedMemory is sane",
   REQUIRE(mem.const_data() == nullptr);
   REQUIRE(mem.strides() == StrideTuple{});
   REQUIRE(mem.shape() == ShapeTuple{});
+  REQUIRE_FALSE(mem.is_lazy());
+
+  SECTION("Ensure then release works")
+  {
+    mem.ensure();
+    REQUIRE(mem.data() == nullptr);
+    REQUIRE(mem.const_data() == nullptr);
+    mem.release();
+    REQUIRE(mem.data() == nullptr);
+    REQUIRE(mem.const_data() == nullptr);
+    mem.ensure();
+    REQUIRE(mem.data() == nullptr);
+    REQUIRE(mem.const_data() == nullptr);
+  }
+  SECTION("Release then ensure works")
+  {
+    mem.release();
+    REQUIRE(mem.data() == nullptr);
+    REQUIRE(mem.const_data() == nullptr);
+    mem.ensure();
+    REQUIRE(mem.data() == nullptr);
+    REQUIRE(mem.const_data() == nullptr);
+  }
+}
+
+TEMPLATE_LIST_TEST_CASE("StridedMemory with empty shape is sane",
+                        "[tensor][strided_memory]",
+                        AllDevList)
+{
+  using MemType = StridedMemory<DataType, TestType::value>;
+
+  MemType mem = MemType(ShapeTuple{});
+  REQUIRE(mem.data() == nullptr);
+  REQUIRE(mem.const_data() == nullptr);
+  REQUIRE(mem.strides() == StrideTuple{});
+  REQUIRE(mem.shape() == ShapeTuple{});
+  REQUIRE_FALSE(mem.is_lazy());
+}
+
+TEMPLATE_LIST_TEST_CASE("StridedMemory with zero in shape is sane",
+                        "[tensor][strided_memory]",
+                        AllDevList)
+{
+  using MemType = StridedMemory<DataType, TestType::value>;
+
+  MemType mem = MemType(ShapeTuple{7, 0});
+  REQUIRE(mem.data() == nullptr);
+  REQUIRE(mem.const_data() == nullptr);
+  REQUIRE(mem.shape() == ShapeTuple{7, 0});
+  REQUIRE_FALSE(mem.is_lazy());
 }
 
 TEMPLATE_LIST_TEST_CASE("StridedMemory indexing works",
@@ -92,7 +172,7 @@ TEMPLATE_LIST_TEST_CASE("StridedMemory indexing works",
 {
   using MemType = StridedMemory<DataType, TestType::value>;
 
-  MemType mem = MemType({3, 7, 2});
+  MemType mem = MemType(ShapeTuple{3, 7, 2});
   // This should iterate in exactly the generalized column-major order
   // data is stored in.
   DataIndexType idx = 0;
@@ -117,7 +197,7 @@ TEMPLATE_LIST_TEST_CASE("StridedMemory writing works",
   constexpr Device Dev = TestType::value;
   using MemType = StridedMemory<DataType, TestType::value>;
 
-  MemType mem = MemType({3, 7, 2});
+  MemType mem = MemType(ShapeTuple{3, 7, 2});
   DataType* buf = mem.data();
   for (std::size_t i = 0; i < product<std::size_t>(mem.shape()); ++i)
   {
@@ -158,6 +238,7 @@ TEMPLATE_LIST_TEST_CASE("StridedMemory views work",
     REQUIRE(mem.strides() == StrideTuple{1, 3, 21});
     REQUIRE(mem.shape() == ShapeTuple{2, 7, 2});
     REQUIRE(mem.data() == (base_mem.data() + base_mem.get_index({1, 0, 1})));
+    REQUIRE_FALSE(mem.is_lazy());
     for (DimType k = 0; k < mem.shape(2); ++k)
     {
       for (DimType j = 0; j < mem.shape(1); ++j)
@@ -201,6 +282,7 @@ TEMPLATE_LIST_TEST_CASE("StridedMemory views work",
     REQUIRE(mem.strides() == StrideTuple{3, 21});
     REQUIRE(mem.shape() == ShapeTuple{7, 2});
     REQUIRE(mem.data() == (base_mem.data() + base_mem.get_index({1, 0, 1})));
+    REQUIRE_FALSE(mem.is_lazy());
     for (DimType k = 0; k < mem.shape(1); ++k)
     {
       for (DimType j = 0; j < mem.shape(0); ++j)
@@ -210,4 +292,116 @@ TEMPLATE_LIST_TEST_CASE("StridedMemory views work",
       }
     }
   }
+}
+
+TEMPLATE_LIST_TEST_CASE("Lazy StridedMemory works",
+                        "[tensor][strided_memory]",
+                        AllDevList)
+{
+  using MemType = StridedMemory<DataType, TestType::value>;
+
+  MemType mem = MemType(ShapeTuple{3, 7}, true);
+  REQUIRE(mem.is_lazy());
+  REQUIRE(mem.data() == nullptr);
+  REQUIRE(mem.const_data() == nullptr);
+
+  SECTION("Ensure and release work")
+  {
+    mem.ensure();
+    REQUIRE(mem.data() != nullptr);
+    REQUIRE(mem.const_data() != nullptr);
+    mem.ensure();  // Test calling ensure multiple times.
+    REQUIRE(mem.data() != nullptr);
+    REQUIRE(mem.const_data() != nullptr);
+    mem.release();
+    REQUIRE(mem.data() == nullptr);
+    REQUIRE(mem.const_data() == nullptr);
+    mem.release();
+    REQUIRE(mem.data() == nullptr);
+    REQUIRE(mem.const_data() == nullptr);
+    mem.ensure();
+    REQUIRE(mem.data() != nullptr);
+    REQUIRE(mem.const_data() != nullptr);
+  }
+
+  SECTION("Buffer recovery works")
+  {
+    mem.ensure();
+    MemType mem2 = mem;
+    REQUIRE(mem.data() == mem2.data());
+    REQUIRE(mem.const_data() == mem2.const_data());
+    mem.release();
+    REQUIRE(mem.data() == nullptr);
+    REQUIRE(mem.const_data() == nullptr);
+    mem.ensure();
+    REQUIRE(mem.data() == mem2.data());
+    REQUIRE(mem.const_data() == mem2.const_data());
+    mem.release();
+    mem.ensure(false);
+    REQUIRE(mem.data() != nullptr);
+    REQUIRE(mem.data() != mem2.data());
+    REQUIRE(mem.const_data() != nullptr);
+    REQUIRE(mem.const_data() != mem2.const_data());
+    mem.release();
+    mem2.release();
+    mem.ensure();
+    mem2.ensure();
+    REQUIRE(mem.data() != nullptr);
+    REQUIRE(mem.const_data() != nullptr);
+    REQUIRE(mem2.data() != nullptr);
+    REQUIRE(mem2.const_data() != nullptr);
+    REQUIRE(mem.data() != mem2.data());
+    REQUIRE(mem.const_data() != mem2.const_data());
+  }
+}
+
+TEMPLATE_LIST_TEST_CASE("Empty lazy StridedMemory works",
+                        "[tensor][strided_memory]",
+                        AllDevList)
+{
+  using MemType = StridedMemory<DataType, TestType::value>;
+
+  MemType mem = MemType(true);
+  REQUIRE(mem.is_lazy());
+  REQUIRE(mem.data() == nullptr);
+  REQUIRE(mem.const_data() == nullptr);
+
+  mem.ensure();
+  REQUIRE(mem.data() == nullptr);
+  REQUIRE(mem.const_data() == nullptr);
+
+  mem.release();
+  REQUIRE(mem.data() == nullptr);
+  REQUIRE(mem.const_data() == nullptr);
+
+  mem.ensure();
+  REQUIRE(mem.data() == nullptr);
+  REQUIRE(mem.const_data() == nullptr);
+}
+
+TEMPLATE_LIST_TEST_CASE("StridedMemory with external buffers works",
+                        "[tensor][strided_memory]",
+                        AllDevList)
+{
+  using MemType = StridedMemory<DataType, TestType::value>;
+
+  DataType test_data[] = {0, 0, 0, 0};
+  MemType mem = MemType(test_data, ShapeTuple{2, 2}, StrideTuple{1, 2});
+
+  REQUIRE(mem.data() == test_data);
+  REQUIRE(mem.const_data() == test_data);
+  REQUIRE(mem.shape() == ShapeTuple{2, 2});
+  REQUIRE(mem.strides() == StrideTuple{1, 2});
+
+  mem.ensure();
+  REQUIRE(mem.data() == test_data);
+  REQUIRE(mem.const_data() == test_data);
+  mem.release();
+  REQUIRE(mem.data() == nullptr);
+  REQUIRE(mem.const_data() == nullptr);
+  mem.ensure();
+  REQUIRE(mem.data() != nullptr);
+  REQUIRE(mem.const_data() != nullptr);
+
+  // TODO: Views.
 }

--- a/test/unit_test/tensor/unit_test_tensor.cpp
+++ b/test/unit_test/tensor/unit_test_tensor.cpp
@@ -102,6 +102,7 @@ TEMPLATE_LIST_TEST_CASE("Tensor metadata is sane", "[tensor]", AllDevList)
   REQUIRE(tensor.data() != nullptr);
   REQUIRE(tensor.const_data() != nullptr);
   REQUIRE(tensor.get({0, 0}) == tensor.data());
+  REQUIRE_FALSE(tensor.is_lazy());
 
   const TensorType const_tensor = TensorType({4, 6}, {DT::Sample, DT::Any});
   REQUIRE(const_tensor.shape() == ShapeTuple{4, 6});
@@ -124,6 +125,7 @@ TEMPLATE_LIST_TEST_CASE("Tensor metadata is sane", "[tensor]", AllDevList)
   REQUIRE(const_tensor.data() != nullptr);
   REQUIRE(const_tensor.const_data() != nullptr);
   REQUIRE(const_tensor.get({0, 0}) == const_tensor.data());
+  REQUIRE_FALSE(const_tensor.is_lazy());
 }
 
 TEMPLATE_LIST_TEST_CASE("Empty tensor metadata is sane", "[tensor]", AllDevList)
@@ -145,6 +147,21 @@ TEMPLATE_LIST_TEST_CASE("Empty tensor metadata is sane", "[tensor]", AllDevList)
   REQUIRE(tensor.get_device() == TestType::value);
   REQUIRE(tensor.data() == nullptr);
   REQUIRE(tensor.const_data() == nullptr);
+  REQUIRE_FALSE(tensor.is_lazy());
+}
+
+TEMPLATE_LIST_TEST_CASE("Lazy and unlazy tensors are sane",
+                        "[tensor]",
+                        AllDevList)
+{
+  using TensorType = Tensor<DataType, TestType::value>;
+
+  REQUIRE_FALSE(TensorType().is_lazy());
+  REQUIRE_FALSE(TensorType(UnlazyAlloc).is_lazy());
+  REQUIRE(TensorType(LazyAlloc).is_lazy());
+
+  REQUIRE_FALSE(TensorType({4, 6}, {DT::Sample, DT::Any}, UnlazyAlloc).is_lazy());
+  REQUIRE(TensorType({4, 6}, {DT::Sample, DT::Any}, LazyAlloc).is_lazy());
 }
 
 TEMPLATE_LIST_TEST_CASE("Resizing tensors works", "[tensor]", AllDevList)


### PR DESCRIPTION
This primarily adds support for lazy allocation in tensors. This involved significant reworking of `RawBuffer` and `StridedMemory`.