### PR TITLE
MPI catch testing

### DIFF
--- a/include/h2/utils/Error.hpp
+++ b/include/h2/utils/Error.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/include/h2/utils/Error.hpp
+++ b/include/h2/utils/Error.hpp
@@ -66,6 +66,15 @@ H2_DEFINE_FORWARDING_EXCEPTION(H2Exception, std::runtime_error);
 #define H2_ASSERT_DEBUG(cond, msg)
 #endif
 
+/** @def H2_ASSERT_ALWAYS
+ * @brief Check that a condition is true and throw an exception if
+ *        not regardless of the build type.
+ *
+ * @param cond Boolean condition to test.
+ * @param msg Message to pass to the exception if the condition fails.
+ */
+#define H2_ASSERT_ALWAYS(cond, msg) H2_ASSERT(cond, H2Exception, msg)
+
 namespace h2
 {
 

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -44,6 +44,17 @@ set_tests_properties([==[Testing the Version String.]==] PROPERTIES
 #
 
 add_executable(SeqCatchTests)
+
+# Add the MPI Catch2 driver.
+add_executable(MPICatchTests MPICatchMain.cpp mpi_cumulative_reporter.cpp)
+target_link_libraries(MPICatchTests
+  PRIVATE ${H2_LIBRARIES} Catch2::Catch2)
+set_target_properties(MPICatchTests
+  PROPERTIES
+  CXX_STANDARD 17
+  CXX_EXTENSIONS OFF
+  CXX_STANDARD_REQUIRED ON)
+
 if (H2_HAS_GPU)
   add_executable(GPUCatchTests GPUCatchMain.cpp)
   target_link_libraries(GPUCatchTests
@@ -53,6 +64,8 @@ if (H2_HAS_GPU)
     CXX_STANDARD 17
     CXX_EXTENSIONS OFF
     CXX_STANDARD_REQUIRED ON)
+  # MPI testing always tests with GPUs when built with them.
+  target_compile_definitions(MPICatchTests PRIVATE H2_TEST_WITH_GPU=1)
 endif ()
 
 # Add Catch2 unit tests

--- a/test/unit_test/GPUCatchMain.cpp
+++ b/test/unit_test/GPUCatchMain.cpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -27,6 +27,19 @@ struct GPUEnvironment
 
 int main(int argc, char** argv)
 {
+    // Initialize and parse the Catch2 command line before any other
+    // initialization.
+    Catch::Session session;
+    {
+        const int return_code = session.applyCommandLine(argc, argv);
+        if (return_code != 0 || session.configData().showHelp)
+        {
+            return return_code;
+        }
+    }
+
+    // Initialize the GPU environment.
     GPUEnvironment env;
-    return Catch::Session().run(argc, argv);
+
+    return session.run();
 }

--- a/test/unit_test/MPICatchMain.cpp
+++ b/test/unit_test/MPICatchMain.cpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/test/unit_test/MPICatchMain.cpp
+++ b/test/unit_test/MPICatchMain.cpp
@@ -90,14 +90,9 @@ h2::Comm& get_comm(int size)
 
 int main(int argc, char** argv)
 {
-  // Set up the basic test environment.
-  TestEnvironment env(argc, argv);
-  comm_manager = new CommManager();
-
-  int rank = El::mpi::COMM_WORLD.Rank();
-  int size = El::mpi::COMM_WORLD.Size();
-
   // Initialize Catch2.
+  // This is done first to avoid any initialization if the user asks
+  // for help.
   Catch::Session session;
 
   int hang_rank = -1;
@@ -106,14 +101,21 @@ int main(int argc, char** argv)
                       "Hang this rank to attach a debugger.");
   session.cli(cli);
 
-  // Parse the command line.
+  // Parse the command line. Also exit if the user asks for help.
   {
     const int return_code = session.applyCommandLine(argc, argv);
-    if (return_code != 0)
+    if (return_code != 0 || session.configData().showHelp)
     {
       return return_code;
     }
   }
+
+  // Set up the basic test environment.
+  TestEnvironment env(argc, argv);
+  comm_manager = new CommManager();
+
+  int rank = El::mpi::COMM_WORLD.Rank();
+  int size = El::mpi::COMM_WORLD.Size();
 
   // Handle a debugger hang.
   if (rank == hang_rank)

--- a/test/unit_test/MPICatchMain.cpp
+++ b/test/unit_test/MPICatchMain.cpp
@@ -1,0 +1,157 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#include <catch2/catch_session.hpp>
+#include <catch2/internal/catch_clara.hpp>
+using Catch::Clara::Opt;
+
+#include <unistd.h>
+
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <string_view>
+
+#include <El.hpp>
+#include <h2_config.hpp>
+
+#ifdef H2_HAS_GPU
+#include <h2/gpu/runtime.hpp>
+#endif
+
+#include "mpi_utils.hpp"
+
+
+/**
+ * Replace a filename with a modified per-MPI rank version.
+ *
+ * Replaces "foo" with "foo.mpirank.mpisize" and replaces "foo.ext"
+ * with "foo.mpirank.mpisize.ext". Anything after the last "." is
+ * considered to be the extension. If mpisize is 1 or filename is
+ * empty, the original string is returned.
+ */
+std::string edit_output_filename(std::string_view filename,
+                                 int mpirank,
+                                 int mpisize)
+{
+  if (mpisize == 0 || filename.size() == 1UL)
+  {
+    return std::string{filename};
+  }
+
+  const auto split = filename.find_last_of('.');
+  std::ostringstream oss;
+  oss << filename.substr(0, split) << '.' << mpirank << '.' << mpisize;
+  if (split != std::string_view::npos)
+  {
+    oss << '.' << filename.substr(split+1, std::string_view::npos);
+  }
+  return oss.str();
+}
+
+// Note: We must initialize GPU support if we were built with it.
+// Aluminum will be expecting it.
+
+struct TestEnvironment
+{
+  TestEnvironment(int& argc, char**& argv)
+  {
+#ifdef H2_HAS_GPU
+    El::gpu::Initialize();
+    h2::gpu::init_runtime();
+#endif
+    El::mpi::InitializeThread(argc, argv, El::mpi::THREAD_MULTIPLE);
+  }
+
+  ~TestEnvironment()
+  {
+    El::mpi::Finalize();
+#ifdef H2_HAS_GPU
+    h2::gpu::finalize_runtime();
+    El::gpu::Finalize();
+#endif
+  }
+};
+
+namespace
+{
+CommManager* comm_manager = nullptr;
+}
+
+h2::Comm& get_comm(int size)
+{
+  H2_ASSERT_ALWAYS(comm_manager != nullptr, "CommManager not initialized");
+  return comm_manager->get_comm(size);
+}
+
+int main(int argc, char** argv)
+{
+  // Set up the basic test environment.
+  TestEnvironment env(argc, argv);
+  comm_manager = new CommManager();
+
+  int rank = El::mpi::COMM_WORLD.Rank();
+  int size = El::mpi::COMM_WORLD.Size();
+
+  // Initialize Catch2.
+  Catch::Session session;
+
+  int hang_rank = -1;
+  auto cli =
+    session.cli() | Opt(hang_rank, "Rank to hang")["--hang-rank"](
+                      "Hang this rank to attach a debugger.");
+  session.cli(cli);
+
+  // Parse the command line.
+  {
+    const int return_code = session.applyCommandLine(argc, argv);
+    if (return_code != 0)
+    {
+      return return_code;
+    }
+  }
+
+  // Handle a debugger hang.
+  if (rank == hang_rank)
+  {
+    char hostname[1024];
+    gethostname(hostname, 1024);
+    std::cerr << "[hang]: (hostname: " << hostname << ", pid: " << getpid()
+              << ")" << std::endl;
+    int volatile wait = 1;
+    while (wait) {}
+  }
+  MPI_Barrier(MPI_COMM_WORLD);  // This should hang the other ranks.
+
+  // Manipulate output file(s) if needed.
+  auto& output_file = session.configData().defaultOutputFilename;
+  if (output_file.size() > 0)
+  {
+    output_file = edit_output_filename(output_file, rank, size);
+  }
+
+  // Handle reporter-specific output files.
+  for (auto& spec : session.configData().reporterSpecifications)
+  {
+    const auto& outfile = spec.outputFile();
+    if (outfile.some())
+    {
+      spec = Catch::ReporterSpec(spec.name(),
+                                 edit_output_filename(*outfile, rank, size),
+                                 spec.colourMode(),
+                                 spec.customOptions());
+    }
+  }
+
+  // Run the Catch tests, outputting to the given file.
+  const int num_failed = session.run();
+
+  // Clean up.
+  delete comm_manager;
+  comm_manager = nullptr;
+  return num_failed;
+}

--- a/test/unit_test/mpi_cumulative_reporter.cpp
+++ b/test/unit_test/mpi_cumulative_reporter.cpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/test/unit_test/mpi_cumulative_reporter.cpp
+++ b/test/unit_test/mpi_cumulative_reporter.cpp
@@ -1,0 +1,197 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#include <mpi.h>
+
+#include <array>
+#include <iomanip>
+
+#include <catch2/reporters/catch_reporter_cumulative_base.hpp>
+#include <catch2/reporters/catch_reporter_registrars.hpp>
+
+namespace
+{
+
+void update_maxes(Catch::Counts& current,
+                  std::uint64_t& current_total,
+                  Catch::Counts const& in)
+{
+    current.passed = std::max(current.passed, in.passed);
+    current.failed = std::max(current.failed, in.failed);
+    current.failedButOk = std::max(current.failedButOk, in.failedButOk);
+    current.skipped = std::max(current.skipped, in.skipped);
+    current_total = std::max(current_total, in.total());
+}
+
+void update_maxes(Catch::Counts& current,
+                  std::uint64_t& current_total,
+                  Catch::Totals const& totals)
+{
+    update_maxes(current, current_total, totals.assertions);
+    update_maxes(current, current_total, totals.testCases);
+}
+
+void write_report(std::vector<Catch::Totals> const& all_totals,
+                  std::ostream& os)
+{
+    using array_type = std::array<std::uint64_t, 6>;
+    using size_type = typename array_type::size_type;
+
+    // Compute field widths
+    enum : size_type
+    {
+        TOTAL = 0,
+        PASS,
+        FAIL,
+        XFAIL,
+        SKIP,
+        MPISIZE
+    };
+
+    std::uint64_t max_total = 0;
+    Catch::Counts max_counts;
+    for (auto const& t : all_totals)
+    {
+        update_maxes(max_counts, max_total, t);
+    }
+
+    auto const mpi_size = all_totals.size();
+    array_type fwidth = {
+        max_total,
+        max_counts.passed,
+        max_counts.failed,
+        max_counts.failedButOk,
+        max_counts.skipped,
+        mpi_size,
+    };
+
+    std::uint64_t width = 60; // THIS VALUE IS SPECIAL
+    for (auto& x : fwidth)
+    {
+        x = std::to_string(x).size();
+        width += x;
+    }
+    // Convenience and brevity
+    using std::right;
+    using std::setw;
+
+    // Later reporting
+    std::vector<size_t> failed_ranks;
+
+    os << '\n' << std::string(width, '=') << '\n';
+    for (size_t mpi_rank = 0; mpi_rank < mpi_size; ++mpi_rank)
+    {
+        auto const& t = all_totals[mpi_rank];
+        if (t.assertions.failed || t.assertions.failed)
+            os << "** ";
+        else
+            os << "   ";
+
+        // clang-format off
+        os << "RANK " << setw(fwidth[MPISIZE]) << right
+           << mpi_rank << ": assertions( "
+           << setw(fwidth[TOTAL]) << right << t.assertions.total() << " | "
+           << setw(fwidth[PASS]) << right
+           << t.assertions.passed << " pass | "
+           << setw(fwidth[FAIL]) << right
+           << t.assertions.failed << " fail | "
+           << setw(fwidth[XFAIL]) << right
+           << t.assertions.failedButOk << " xfail | "
+           << setw(fwidth[SKIP]) << right
+           << t.assertions.skipped << " skip )\n";
+        // clang-format on
+
+        if (t.assertions.failed > 0)
+            failed_ranks.push_back(mpi_rank);
+    }
+    auto const num_failed_ranks = failed_ranks.size();
+    if (num_failed_ranks == mpi_size)
+    {
+        os << "\nFAILED RANKS: ALL\n";
+    }
+    else if (num_failed_ranks)
+    {
+        auto const rwidth = std::to_string(num_failed_ranks).size();
+        os << "\nFAILED RANKS:";
+        for (size_t i = 0; i < num_failed_ranks; ++i)
+        {
+            if (i > 0 && i % 8 == 0)
+                os << "\n             "; // "\nFAILED RANKS:"
+            os << " " << setw(rwidth) << right << failed_ranks[i];
+        }
+        os << "\n";
+    }
+    endl(os);
+    flush(os);
+}
+} // namespace
+
+// Assumptions
+// - All processes in MPI_COMM_WORLD participate in testing.
+// - All processes in MPI_COMM_WORLD see the same command line.
+// - All processes in MPI_COMM_WORLD enter the same TEST_CASE*s (this
+//   includes "partial" tests cases, as Catch2 calls them).
+// - Some processes in MPI_COMM_WORLD may skip some TEST_CASE*s in
+//   which other processes in MPI_COMM_WORLD participate.
+// - Some processes in MPI_COMM_WORLD may not participate in some
+//   SECTIONs in which other processes in MPI_COMM_WORLD participate.
+//
+// For now, the synchronization point will be the end of the test
+// case. Since every rank is assumed to be in the same TEST_CASE,
+// we'll just send FILE/LINE/RETURNSTATUS for each assertion.
+class MPICumulativeReporter final : public Catch::CumulativeReporterBase
+{
+    int rank;
+    int size;
+
+public:
+    MPICumulativeReporter(Catch::ReporterConfig&& _config)
+        : Catch::CumulativeReporterBase{std::move(_config)}
+    {
+        int flag;
+        MPI_Initialized(&flag);
+        if (!flag)
+            throw std::runtime_error("MPI not initialized!");
+
+        MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+        MPI_Comm_size(MPI_COMM_WORLD, &size);
+    }
+
+    ~MPICumulativeReporter() final = default;
+
+    static std::string getDescription()
+    {
+        return "Report test results on Rank 0 in an MPI context.";
+    }
+
+    void testRunEnded(Catch::TestRunStats const& _testRunStats) final
+    {
+        Catch::CumulativeReporterBase::testRunEnded(_testRunStats);
+
+        int rank, size;
+        MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+        MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+        bool const i_am_root = (rank == 0);
+        std::vector<Catch::Totals> all_totals(i_am_root ? size : 0);
+        MPI_Gather(&_testRunStats.totals,
+                   8,
+                   MPI_UINT64_T,
+                   all_totals.data(),
+                   8,
+                   MPI_UINT64_T,
+                   0,
+                   MPI_COMM_WORLD);
+
+        if (i_am_root)
+            write_report(all_totals, m_stream);
+    }
+
+    void testRunEndedCumulative() final {}
+};
+
+CATCH_REGISTER_REPORTER("mpicumulative", MPICumulativeReporter);

--- a/test/unit_test/mpi_utils.hpp
+++ b/test/unit_test/mpi_utils.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/test/unit_test/mpi_utils.hpp
+++ b/test/unit_test/mpi_utils.hpp
@@ -1,0 +1,151 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#include <algorithm>
+#include <memory>
+#include <unordered_map>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <catch2/generators/catch_generators_adapters.hpp>
+
+#include "h2/tensor/proc_grid.hpp"
+#include "h2/utils/Error.hpp"
+
+
+namespace internal
+{
+// Thrown by CommManager::get_comm if the rank is not participating.
+struct NotParticipatingException {};
+}
+
+/**
+ * Manages instances of communicators for testing.
+ *
+ * This avoids tests creating too many communicators by reusing them.
+ */
+class CommManager
+{
+public:
+  CommManager()
+  {
+    world_size = El::mpi::COMM_WORLD.Size();
+  }
+
+  ~CommManager()
+  {
+    clear();
+  }
+
+  El::mpi::Comm& get_comm(int size = -1)
+  {
+    H2_ASSERT_ALWAYS(size <= world_size,
+                     "Requested communicator size exceeds world size");
+
+    if (size < 0)
+    {
+      size = world_size;
+    }
+
+    // All ranks in the world have to participate in the split, but
+    // only the ones in that should be in the returned communicator
+    // actually return.
+    int world_rank = El::mpi::COMM_WORLD.Rank();
+
+    if (!comms.count(size))
+    {
+      h2::Comm comm;
+      El::mpi::Split(El::mpi::COMM_WORLD, world_rank < size, world_rank, comm);
+      if (world_rank >= size)
+      {
+        // Need to add an entry to prevent trying to split in future
+        // calls. This essentially adds MPI_COMM_NULL.
+        comm.Reset();
+      }
+      comms.emplace(size, std::move(comm));
+    }
+
+    if (world_rank >= size)
+    {
+      // Not participating.
+      throw internal::NotParticipatingException();
+    }
+
+    return comms[size];
+  }
+
+  void clear() { comms.clear(); }
+
+private:
+  std::unordered_map<int, h2::Comm> comms;
+  int world_size;
+};
+
+/**
+ * Return a communicator of the given size (-1, default, for the world).
+ *
+ * Throws NotParticipatingException if the caller is not present in the
+ * communicator.
+ */
+h2::Comm& get_comm(int size = -1);
+// Implemented in MPICatchMain.cpp.
+
+/**
+ * Invoke a test case with communicators of every size between the
+ * specified minimum and maximum.
+ *
+ * This expects a callable which takes a single `h2::Comm&` as an
+ * argument, which contains the actual test case to run.
+ *
+ * If the specified minimum requires more ranks than exist, all tests
+ * will be skipped. Likewise, if the specified maximum would result in
+ * some cases requiring more ranks than exist, those cases will be
+ * skipped.
+ *
+ * A barrier (on COMM_WORLD) is performed after each communicator size.
+ *
+ * This should only be called inside of Catch2 test cases.
+ *
+ * This ensures that all ranks participate in any necessary
+ * communicator creation.
+ *
+ * @tparam Test A callable accepting `h2::Comm&`.
+ * @param t The test case to invoke.
+ * @param min_size Minimum communicator size to use.
+ * @param max_size Maximum communicator size to use; -1 for COMM_WORLD
+ * regardless of its size.
+ */
+template <typename Test>
+void for_comms(Test t, int min_size = 1, int max_size = -1)
+{
+  // Sanity check.
+  H2_ASSERT_ALWAYS(max_size < 0 || min_size <= max_size,
+                   "Cannot have min_size greater than max_size");
+
+  int world_size = El::mpi::COMM_WORLD.Size();
+  if (max_size < 0 || max_size > world_size)
+  {
+    max_size = world_size;
+  }
+  // Skip everything if the test requires more ranks than we have.
+  if (min_size > world_size)
+  {
+    SKIP();
+    return;
+  }
+
+  for (int i = min_size; i <= max_size; ++i)
+  {
+    try
+    {
+      h2::Comm& comm = get_comm(i);
+      t(comm);
+    }
+    catch (const internal::NotParticipatingException&) {}
+    El::mpi::Barrier(El::mpi::COMM_WORLD);
+  }
+}


### PR DESCRIPTION
This adds basic support for testing MPI applications with Catch2.

* Provides a driver, `MPICatchTests`, for running tests that need MPI. (This also enables GPU support if H2 was built with it.)
* Provides a reporter, selectable with `-r mpicumulative`, for aggregating results from all ranks.
* If output to a specific file is selected, the driver automatically rewrites the filename into a per-rank name.
* Provides a helper function, `for_comms`, for writing tests that try many communicator sizes. Example usage:

```c++
TEST_CASE("Processor grids can be created", "[dist-tensor][proc-grid]")
{
  for_comms([&](h2::Comm& comm) {
    REQUIRE_NOTHROW([&] {
      ProcessorGrid grid = ProcessorGrid(comm, {comm.Size()});
    });
  });
}
```