### PR TITLE
Avoid hangs in some MPI unit tests

### DIFF
--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -46,7 +46,7 @@ set_tests_properties([==[Testing the Version String.]==] PROPERTIES
 add_executable(SeqCatchTests)
 
 # Add the MPI Catch2 driver.
-add_executable(MPICatchTests MPICatchMain.cpp mpi_cumulative_reporter.cpp)
+add_executable(MPICatchTests MPICatchMain.cpp mpi_cumulative_reporter.cpp mpi_event_listener.cpp)
 target_link_libraries(MPICatchTests
   PRIVATE ${H2_LIBRARIES} Catch2::Catch2)
 set_target_properties(MPICatchTests

--- a/test/unit_test/MPICatchMain.cpp
+++ b/test/unit_test/MPICatchMain.cpp
@@ -88,6 +88,20 @@ h2::Comm& get_comm(int size)
   return comm_manager->get_comm(size);
 }
 
+h2::Comm& get_comm_or_skip(int size)
+{
+  H2_ASSERT_ALWAYS(comm_manager != nullptr, "CommManager not initialized");
+  try
+  {
+    return comm_manager->get_comm(size);
+  }
+  catch (const internal::NotParticipatingException&)
+  {
+    SKIP();
+    throw;
+  }
+}
+
 int main(int argc, char** argv)
 {
   // Initialize Catch2.

--- a/test/unit_test/mpi_event_listener.cpp
+++ b/test/unit_test/mpi_event_listener.cpp
@@ -1,0 +1,71 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#include "h2/tensor/dist_types.hpp"
+
+#include <catch2/reporters/catch_reporter_event_listener.hpp>
+#include <catch2/reporters/catch_reporter_registrars.hpp>
+
+
+namespace internal
+{
+
+// These indicate when we are actually performing a blocking global
+// operation.
+
+bool in_for_comms = false;
+
+void start_for_comms()
+{
+  in_for_comms = true;
+}
+
+void end_for_comms()
+{
+  in_for_comms = false;
+}
+
+}  // namespace internal
+
+
+/**
+ * Gracefully handle test case failures when not all ranks may see
+ * the failure. This is intended for use with the `for_comms` utility
+ * (or similar).
+ */
+class MPIEventListener final : public Catch::EventListenerBase
+{
+public:
+  using Catch::EventListenerBase::EventListenerBase;
+
+  void testCasePartialEnded(const Catch::TestCaseStats& test_case_stats,
+                            uint64_t) final
+  {
+    if (!internal::in_for_comms)
+    {
+      // Not in for_comms, nothing to do.
+      return;
+    }
+
+    // for_comms will join the allreduce from successful or
+    // non-participating ranks.
+    // We let Catch2 handle the rest of the failure as usual.
+    if (!test_case_stats.totals.assertions.allOk())
+    {
+      int test_result = 0;
+      El::mpi::AllReduce(&test_result,
+                         1,
+                         El::mpi::MIN,
+                         El::mpi::COMM_WORLD,
+                         El::SyncInfo<El::Device::CPU>{});
+      // Indicate we are done with the for_comms.
+      internal::end_for_comms();
+    }
+  }
+};
+
+CATCH_REGISTER_LISTENER(MPIEventListener);


### PR DESCRIPTION
With `for_comms`, when some portion of the ranks fail, others may be hung waiting for collective operations (e.g., communicator creation). This is a somewhat hacky fix for this by using Catch2 event listeners to identify failures and have all ranks bail out.