### PR TITLE
Local tensor copy support

### DIFF
--- a/include/h2/gpu/cuda/memory_utils.hpp
+++ b/include/h2/gpu/cuda/memory_utils.hpp
@@ -1,12 +1,11 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0
 ////////////////////////////////////////////////////////////////////////////////
+
 #pragma once
-#ifndef H2_INCLUDE_H2_GPU_CUDA_MEMORY_UTILS_HPP_INCLUDED
-#define H2_INCLUDE_H2_GPU_CUDA_MEMORY_UTILS_HPP_INCLUDED
 
 /** @file
  *
@@ -73,4 +72,3 @@ inline void mem_zero(void* mem, size_t bytes, DeviceStream stream)
 
 } // namespace gpu
 } // namespace h2
-#endif // H2_INCLUDE_H2_GPU_CUDA_MEMORY_UTILS_HPP_INCLUDED

--- a/include/h2/gpu/memory_utils.hpp
+++ b/include/h2/gpu/memory_utils.hpp
@@ -1,12 +1,11 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0
 ////////////////////////////////////////////////////////////////////////////////
+
 #pragma once
-#ifndef H2_INCLUDE_H2_MEMORY_GPU_MEMORY_UTILS_HPP_INCLUDED
-#define H2_INCLUDE_H2_MEMORY_GPU_MEMORY_UTILS_HPP_INCLUDED
 
 /** @file
  *
@@ -171,4 +170,3 @@ inline void mem_zero(T* mem, size_t n_elmts, DeviceStream stream)
 
 } // namespace gpu
 } // namespace h2
-#endif // H2_INCLUDE_H2_MEMORY_GPU_MEMORY_UTILS_HPP_INCLUDED

--- a/include/h2/gpu/runtime.hpp
+++ b/include/h2/gpu/runtime.hpp
@@ -1,12 +1,11 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0
 ////////////////////////////////////////////////////////////////////////////////
+
 #pragma once
-#ifndef H2_INCLUDE_H2_GPU_RUNTIME_HPP_INCLUDED
-#define H2_INCLUDE_H2_GPU_RUNTIME_HPP_INCLUDED
 
 /** @file
  *
@@ -25,6 +24,7 @@
  *  void finalize_runtime();
  *  bool runtime_is_initialized();
  *  bool runtime_is_finalized();
+ *  bool is_integrated();
  *
  *  bool ok(DeviceError) noexcept;
  *
@@ -65,6 +65,9 @@ void finalize_runtime();
 bool runtime_is_initialized();
 bool runtime_is_finalized();
 
+/** True if the CPU and GPU are one integrated platform (like an APU) */
+bool is_integrated();
+
 DeviceStream make_stream();
 DeviceStream make_stream_nonblocking();
 void destroy(DeviceStream);
@@ -79,5 +82,3 @@ void sync(DeviceStream); // Sync on stream.
 
 } // namespace gpu
 } // namespace h2
-
-#endif // H2_INCLUDE_H2_GPU_RUNTIME_HPP_INCLUDED

--- a/include/h2/tensor/CMakeLists.txt
+++ b/include/h2/tensor/CMakeLists.txt
@@ -13,6 +13,7 @@ h2_add_sources_to_target_and_install(
   TARGET H2Core COMPONENT CORE SCOPE INTERFACE
   INSTALL_PREFIX "${H2_CURRENT_INSTALL_PREFIX}"
   SOURCES
+  copy.hpp
   dist_tensor_base.hpp
   dist_tensor.hpp
   dist_types.hpp

--- a/include/h2/tensor/copy.hpp
+++ b/include/h2/tensor/copy.hpp
@@ -1,0 +1,92 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+/** @file
+ *
+ * Routines to copy data and tensors.
+ */
+
+
+#include <h2_config.hpp>
+
+#include <cstring>
+
+#include "h2/tensor/tensor_types.hpp"
+#include "h2/tensor/tensor.hpp"
+#include "h2/tensor/dist_tensor.hpp"
+
+#ifdef H2_HAS_GPU
+#include "h2/gpu/runtime.hpp"
+#include "h2/gpu/memory_utils.hpp"
+#endif
+
+namespace h2
+{
+
+// Low-level copy routines operating on buffers (raw pointers):
+
+/**
+ * Copy count elements on Dev from src to dst.
+ *
+ * If GPU buffers are involved, this will be asynchronous.
+ */
+template <Device DstDev, Device SrcDev, typename T>
+void CopyBuffer(T* dst,
+                const SyncInfo<DstDev>& dst_sync,
+                const T* src,
+                const SyncInfo<SrcDev>& src_sync,
+                std::size_t count)
+{
+  if constexpr (SrcDev == Device::CPU && DstDev == Device::CPU)
+  {
+    std::memcpy(dst, src, count * sizeof(T));
+  }
+#ifdef H2_HAS_GPU
+  else if constexpr (SrcDev == Device::GPU && DstDev == Device::GPU)
+  {
+    auto sync = El::MakeMultiSync(dst_sync, src_sync);
+    gpu::mem_copy<T>(dst, src, count, dst_sync.Stream());
+  }
+  else if constexpr (SrcDev == Device::CPU && DstDev == Device::GPU)
+  {
+    // No sync needed in this case: The CPU is always synchronized and
+    // the copy will be enqueued on the destination GPU stream.
+    gpu::mem_copy<T>(dst, src, count, dst_sync.Stream());
+  }
+  else if constexpr (SrcDev == Device::GPU && DstDev == Device::CPU)
+  {
+    // No sync needed: Ditto.
+    gpu::mem_copy<T>(dst, src, count, src_sync.Stream());
+  }
+#endif
+  else
+  {
+    throw H2Exception("Unknown device combination");
+  }
+}
+
+/** Special case where both buffers are on the same device. */
+template <Device Dev, typename T>
+void CopyBuffer(T* dst,
+                const SyncInfo<Dev>& dst_sync,
+                const T* src,
+                const SyncInfo<Dev>& src_sync,
+                std::size_t count)
+{
+  CopyBuffer<Dev, Dev>(src, src_sync, dst, dst_sync, count);
+}
+
+// General copy routines:
+
+
+// ToDevice routines:
+
+
+
+}

--- a/include/h2/tensor/copy.hpp
+++ b/include/h2/tensor/copy.hpp
@@ -187,8 +187,4 @@ void Copy(BaseTensor<DstT>& dst, const BaseTensor<SrcT>& src)
   }
 }
 
-// ToDevice routines:
-
-
-
 }

--- a/include/h2/tensor/tensor_base.hpp
+++ b/include/h2/tensor/tensor_base.hpp
@@ -170,6 +170,16 @@ public:
                       const DimensionTypeTuple& new_dim_types) = 0;
 
   /**
+   * Resize the tensor to a new shape, also changing dimension types
+   * and specifying new strides.
+   *
+   * It is an error to call this on a view.
+   */
+  virtual void resize(const ShapeTuple& new_shape,
+                      const DimensionTypeTuple& new_dim_types,
+                      const StrideTuple& new_strides) = 0;
+
+  /**
    * Return a raw pointer to the underlying storage.
    *
    * @note Remember to account for the strides when accessing this.

--- a/include/h2/tensor/tensor_utils.hpp
+++ b/include/h2/tensor/tensor_utils.hpp
@@ -188,8 +188,8 @@ intersect_index_ranges(const IndexRangeTuple& ir1,
 /**
  * Iterate over an n-dimensional region.
  *
- * The given function f will be called with a `SingleCoordTuple` for
- * each coordinate position.
+ * The given function f will be called with a `ScalarIndexTuple` for
+ * each index position.
  *
  * @todo In the future, we could specialize for specific dimensions.
  */

--- a/src/gpu/cuda/runtime.cpp
+++ b/src/gpu/cuda/runtime.cpp
@@ -1,9 +1,10 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0
 ////////////////////////////////////////////////////////////////////////////////
+
 #include "h2/gpu/runtime.hpp"
 
 #include "h2/gpu/logger.hpp"
@@ -237,6 +238,12 @@ bool h2::gpu::runtime_is_initialized()
 bool h2::gpu::runtime_is_finalized()
 {
     return !initialized_;
+}
+
+bool h2::gpu::is_integrated()
+{
+  // Currently no Nvidia system offers this.
+  return false;
 }
 
 cudaStream_t h2::gpu::make_stream()

--- a/src/gpu/rocm/runtime.cpp
+++ b/src/gpu/rocm/runtime.cpp
@@ -1,9 +1,10 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2022 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0
 ////////////////////////////////////////////////////////////////////////////////
+
 #include "h2/gpu/runtime.hpp"
 
 #include "h2/gpu/logger.hpp"
@@ -158,6 +159,8 @@ static char const* rsmi_status_to_string(rsmi_status_t const status)
 // We should have reasonable behavior for all cases (which might just
 // be to raise an error).
 bool initialized_ = false;
+
+bool is_integrated_ = false;
 
 static int guess_local_rank() noexcept
 {
@@ -354,6 +357,13 @@ void h2::gpu::init_runtime()
         H2_GPU_TRACE("found {} devices", num_gpus());
         set_reasonable_default_gpu();
         initialized_ = true;
+
+        // TODO: Currently broken, but this check should handle this in
+        // the future.
+        //hipDeviceProp_t props;
+        //H2_CHECK_HIP(hipGetDevicePropertieee(&props, current_gpu()));
+        //is_integrated_ = props.integrated;
+        is_integrated_ = false;
     }
     else
     {
@@ -379,6 +389,11 @@ bool h2::gpu::runtime_is_initialized()
 bool h2::gpu::runtime_is_finalized()
 {
     return !initialized_;
+}
+
+bool h2::gpu::is_integrated()
+{
+  return is_integrated_;
 }
 
 hipStream_t h2::gpu::make_stream()

--- a/test/unit_test/tensor/CMakeLists.txt
+++ b/test/unit_test/tensor/CMakeLists.txt
@@ -6,6 +6,7 @@
 ################################################################################
 
 target_sources(SeqCatchTests PRIVATE
+  unit_test_copy.cpp
   unit_test_dist_utils_nompi.cpp
   unit_test_raw_buffer.cpp
   unit_test_strided_memory.cpp
@@ -15,6 +16,7 @@ target_sources(SeqCatchTests PRIVATE
 
 if (H2_HAS_GPU)
   target_sources(GPUCatchTests PRIVATE
+    unit_test_copy.cpp
     unit_test_raw_buffer.cpp
     unit_test_strided_memory.cpp
     unit_test_tensor.cpp

--- a/test/unit_test/tensor/unit_test_copy.cpp
+++ b/test/unit_test/tensor/unit_test_copy.cpp
@@ -45,3 +45,126 @@ TEMPLATE_LIST_TEST_CASE("Buffer copy works", "[tensor][copy]", AllDevPairsList)
     REQUIRE(read_ele<DstDev>(dst.buf, i) == src_val);
   }
 }
+
+TEMPLATE_LIST_TEST_CASE("Same-type tensor copy works",
+                        "[tensor][copy]",
+                        AllDevPairsList)
+{
+  constexpr Device SrcDev = meta::tlist::At<TestType, 0>::value;
+  constexpr Device DstDev = meta::tlist::At<TestType, 1>::value;
+  using SrcTensorType = Tensor<DataType, SrcDev>;
+  using DstTensorType = Tensor<DataType, DstDev>;
+  constexpr DataType src_val = static_cast<DataType>(1);
+  constexpr DataType dst_val = static_cast<DataType>(2);
+
+  SECTION("Copying into existing tensor works without resizing")
+  {
+    SrcTensorType src_tensor({4, 6}, {DT::Sample, DT::Any});
+    DstTensorType dst_tensor({4, 6}, {DT::Any, DT::Any});
+
+    DataType* dst_orig_data = dst_tensor.data();
+
+    for (std::size_t i = 0; i < src_tensor.numel(); ++i)
+    {
+      write_ele<SrcDev>(src_tensor.data(), i, src_val);
+      write_ele<DstDev>(dst_tensor.data(), i, dst_val);
+    }
+
+    REQUIRE_NOTHROW(Copy(dst_tensor, src_tensor));
+
+    REQUIRE(dst_tensor.shape() == ShapeTuple{4, 6});
+    REQUIRE(dst_tensor.dim_types() == DTTuple{DT::Sample, DT::Any});
+    REQUIRE(dst_tensor.strides() == StrideTuple{1, 4});
+    REQUIRE(dst_tensor.numel() == 4 * 6);
+    REQUIRE_FALSE(dst_tensor.is_empty());
+    REQUIRE(dst_tensor.is_contiguous());
+    REQUIRE_FALSE(dst_tensor.is_view());
+    REQUIRE(src_tensor.data() != dst_tensor.data());
+    REQUIRE(dst_tensor.data() == dst_orig_data);
+
+    for (std::size_t i = 0; i < src_tensor.numel(); ++i)
+    {
+      REQUIRE(read_ele<SrcDev>(src_tensor.data(), i) == src_val);
+      REQUIRE(read_ele<DstDev>(dst_tensor.data(), i) == src_val);
+    }
+  }
+
+  SECTION("Copying into different-sized tensor works")
+  {
+    SrcTensorType src_tensor({4, 6}, {DT::Sample, DT::Any});
+    DstTensorType dst_tensor({2, 2}, {DT::Any, DT::Any});
+
+    for (std::size_t i = 0; i < src_tensor.numel(); ++i)
+    {
+      write_ele<SrcDev>(src_tensor.data(), i, src_val);
+    }
+    for (std::size_t i = 0; i < dst_tensor.numel(); ++i)
+    {
+      write_ele<DstDev>(dst_tensor.data(), i, dst_val);
+    }
+
+    REQUIRE_NOTHROW(Copy(dst_tensor, src_tensor));
+
+    REQUIRE(dst_tensor.shape() == ShapeTuple{4, 6});
+    REQUIRE(dst_tensor.dim_types() == DTTuple{DT::Sample, DT::Any});
+    REQUIRE(dst_tensor.strides() == StrideTuple{1, 4});
+    REQUIRE(dst_tensor.numel() == 4 * 6);
+    REQUIRE_FALSE(dst_tensor.is_empty());
+    REQUIRE(dst_tensor.is_contiguous());
+    REQUIRE_FALSE(dst_tensor.is_view());
+    REQUIRE(src_tensor.data() != dst_tensor.data());
+
+    for (std::size_t i = 0; i < src_tensor.numel(); ++i)
+    {
+      REQUIRE(read_ele<SrcDev>(src_tensor.data(), i) == src_val);
+    }
+    for (std::size_t i = 0; i < src_tensor.numel(); ++i)
+    {
+      REQUIRE(read_ele<DstDev>(dst_tensor.data(), i) == src_val);
+    }
+  }
+
+  SECTION("Copying an empty tensor works")
+  {
+    SrcTensorType src_tensor;
+    DstTensorType dst_tensor({2, 4}, {DT::Any, DT::Any});
+
+    REQUIRE_NOTHROW(Copy(dst_tensor, src_tensor));
+
+    REQUIRE(dst_tensor.is_empty());
+  }
+
+  SECTION("Copying non-contiguous tensors works")
+  {
+    SrcTensorType src_tensor({4, 6}, {DT::Sample, DT::Any});
+    DstTensorType dst_tensor({4, 6}, {DT::Any, DT::Any});
+
+    // Resize to be non-contiguous.
+    src_tensor.resize(
+        src_tensor.shape(), src_tensor.dim_types(), StrideTuple{2, 4});
+
+    for (std::size_t i = 0; i < src_tensor.numel(); ++i)
+    {
+      write_ele<DstDev>(dst_tensor.data(), i, dst_val);
+    }
+    for_ndim(src_tensor.shape(), [&](const ScalarIndexTuple& i) {
+      write_ele<SrcDev>(src_tensor.get(i), 0, src_val);
+    });
+
+    REQUIRE_NOTHROW(Copy(dst_tensor, src_tensor));
+
+    REQUIRE(dst_tensor.shape() == ShapeTuple{4, 6});
+    REQUIRE(dst_tensor.dim_types() == DTTuple{DT::Sample, DT::Any});
+    REQUIRE(dst_tensor.strides() == StrideTuple{2, 4});
+    REQUIRE(dst_tensor.numel() == 4 * 6);
+    REQUIRE_FALSE(dst_tensor.is_empty());
+    REQUIRE_FALSE(dst_tensor.is_contiguous());
+    REQUIRE_FALSE(dst_tensor.is_view());
+    REQUIRE(src_tensor.data() != dst_tensor.data());
+
+    for_ndim(src_tensor.shape(), [&](const ScalarIndexTuple& i) {
+      REQUIRE(read_ele<SrcDev>(src_tensor.get(i)) == src_val);
+      REQUIRE(read_ele<DstDev>(dst_tensor.get(i)) == src_val);
+    });
+  }
+}

--- a/test/unit_test/tensor/unit_test_copy.cpp
+++ b/test/unit_test/tensor/unit_test_copy.cpp
@@ -1,0 +1,47 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+
+#include "h2/tensor/tensor.hpp"
+#include "h2/tensor/copy.hpp"
+#include "utils.hpp"
+
+using namespace h2;
+
+TEMPLATE_LIST_TEST_CASE("Buffer copy works", "[tensor][copy]", AllDevPairsList)
+{
+  constexpr Device SrcDev = meta::tlist::At<TestType, 0>::value;
+  constexpr Device DstDev = meta::tlist::At<TestType, 1>::value;
+  constexpr std::size_t buf_size = 32;
+  constexpr DataType src_val = static_cast<DataType>(1);
+  constexpr DataType dst_val = static_cast<DataType>(2);
+
+  auto src_sync = SyncInfo<SrcDev>{};
+  auto dst_sync = SyncInfo<DstDev>{};
+
+  DeviceBuf<DataType, SrcDev> src(buf_size);
+  DeviceBuf<DataType, DstDev> dst(buf_size);
+
+  for (std::size_t i = 0; i < buf_size; ++i)
+  {
+    write_ele<SrcDev>(src.buf, i, src_val);
+    write_ele<DstDev>(dst.buf, i, dst_val);
+  }
+
+  REQUIRE_NOTHROW(CopyBuffer<DstDev, SrcDev>(
+      dst.buf, dst_sync, src.buf, src_sync, buf_size));
+
+  for (std::size_t i = 0; i < buf_size; ++i)
+  {
+    // Source is unchanged:
+    REQUIRE(read_ele<SrcDev>(src.buf, i) == src_val);
+    // Destination has the source value:
+    REQUIRE(read_ele<DstDev>(dst.buf, i) == src_val);
+  }
+}

--- a/test/unit_test/tensor/unit_test_tensor.cpp
+++ b/test/unit_test/tensor/unit_test_tensor.cpp
@@ -277,6 +277,18 @@ TEMPLATE_LIST_TEST_CASE("Resizing tensors works", "[tensor]", AllDevList)
   SECTION("Resizing while adding dimensions requires dim types") {
     REQUIRE_THROWS(tensor.resize({2, 3, 4}));
   }
+  SECTION("Resizing while changing strides works")
+  {
+    tensor.resize({4, 6}, {DT::Sample, DT::Any}, {1, 8});
+    REQUIRE(tensor.shape() == ShapeTuple{4, 6});
+    REQUIRE(tensor.dim_types() == DTTuple{DT::Sample, DT::Any});
+    REQUIRE(tensor.strides() == StrideTuple{1, 8});
+    REQUIRE(tensor.ndim() == 2);
+    REQUIRE(tensor.numel() == 4*6);
+    REQUIRE_FALSE(tensor.is_contiguous());
+    REQUIRE(tensor.data() != nullptr);
+    REQUIRE(tensor.const_data() != nullptr);
+  }
   SECTION("Emptying tensors") {
     tensor.empty();
     REQUIRE(tensor.shape() == ShapeTuple{});

--- a/test/unit_test/tensor/utils.hpp
+++ b/test/unit_test/tensor/utils.hpp
@@ -23,8 +23,13 @@ using CPUDev_t = std::integral_constant<h2::Device, h2::Device::CPU>;
 #ifdef H2_TEST_WITH_GPU
 using GPUDev_t = std::integral_constant<h2::Device, h2::Device::GPU>;
 using AllDevList = h2::meta::TL<CPUDev_t, GPUDev_t>;
+using AllDevPairsList = h2::meta::TL<h2::meta::TL<CPUDev_t, CPUDev_t>,
+                                     h2::meta::TL<GPUDev_t, GPUDev_t>,
+                                     h2::meta::TL<CPUDev_t, GPUDev_t>,
+                                     h2::meta::TL<GPUDev_t, CPUDev_t>>;
 #else
 using AllDevList = h2::meta::TL<CPUDev_t>;
+using AllDevPairsList = h2::meta::TL<h2::meta::TL<CPUDev_t, CPUDev_t>>;
 #endif
 
 // Standard datatype to be used when testing.


### PR DESCRIPTION
(Depends on #122.)

This adds support for copying local tensors, and does some additional cleanup and fixes.
* Adds a method to check whether we have an integrated GPU (like an APU).
* Fixes up some `StridedMemory` issues in calculating buffer sizes by using the extent defined by the strides.
* Support resizing tensors and specifying their strides. (No constructor support for that right now, maybe later.)
* Support copying raw buffers.
* Support copying local tensors.