### PR TITLE
Revamp tensor object hierarchy

### DIFF
--- a/include/h2/tensor/dist_tensor.hpp
+++ b/include/h2/tensor/dist_tensor.hpp
@@ -100,7 +100,7 @@ public:
             device, buffer, local_shape_, dim_types_, local_strides_, stream)
   {}
 
-  /** Private constructor for views. */
+  /** Internal constructor for views. */
   DistTensor(ViewType view_type_,
              const Tensor<T>& orig_tensor_local_,
              const ShapeTuple& local_shape_,

--- a/include/h2/tensor/dist_tensor.hpp
+++ b/include/h2/tensor/dist_tensor.hpp
@@ -39,7 +39,7 @@ public:
              const DimensionTypeTuple& dim_types_,
              ProcessorGrid grid_,
              const DistributionTypeTuple& dist_types_,
-             TensorAllocation alloc_type = StrictAlloc,
+             TensorAllocationStrategy alloc_type = StrictAlloc,
              const std::optional<ComputeStream> stream = std::nullopt)
       : BaseDistTensor(shape_, dim_types_, grid_, dist_types_),
         tensor_local(device,
@@ -51,7 +51,7 @@ public:
 
   DistTensor(Device device,
              ProcessorGrid grid_,
-             TensorAllocation alloc_type = StrictAlloc,
+             TensorAllocationStrategy alloc_type = StrictAlloc,
              const std::optional<ComputeStream> stream = std::nullopt)
       : DistTensor(device,
                    ShapeTuple(),

--- a/include/h2/tensor/dist_tensor.hpp
+++ b/include/h2/tensor/dist_tensor.hpp
@@ -12,14 +12,13 @@
  * Distributed tensors that live on a device.
  */
 
+#include <optional>
+
 #include "h2/tensor/dist_tensor_base.hpp"
 #include "h2/tensor/dist_types.hpp"
 #include "h2/tensor/proc_grid.hpp"
 #include "h2/tensor/tensor.hpp"
 #include "h2/tensor/tensor_types.hpp"
-#include "dist_types.hpp"
-#include "dist_utils.hpp"
-#include "tensor_types.hpp"
 
 namespace h2
 {
@@ -38,126 +37,27 @@ public:
              const DimensionTypeTuple& dim_types_,
              ProcessorGrid grid_,
              const DistributionTypeTuple& dist_types_,
-             const ComputeStream& stream)
-      : DistTensor(
-          device, shape_, dim_types_, grid_, dist_types_, StrictAlloc, stream)
-  {}
-
-  DistTensor(Device device,
-             const ShapeTuple& shape_,
-             const DimensionTypeTuple& dim_types_,
-             ProcessorGrid grid_,
-             const DistributionTypeTuple& dist_types_)
-      : DistTensor(
-          device, shape_, dim_types_, grid_, dist_types_, ComputeStream{device})
-  {}
-
-  DistTensor(Device device,
-             const ShapeTuple& shape_,
-             const DimensionTypeTuple& dim_types_,
-             ProcessorGrid grid_,
-             const DistributionTypeTuple& dist_types_,
-             lazy_alloc_t,
-             const ComputeStream& stream)
+             TensorAllocation alloc_type = StrictAlloc,
+             const std::optional<ComputeStream> stream = std::nullopt)
       : BaseDistTensor<T>(shape_, dim_types_, grid_, dist_types_),
         tensor_local(device,
                      this->tensor_local_shape,
                      init_n(dim_types_, this->tensor_local_shape.size()),
-                     LazyAlloc,
-                     stream)
-  {}
-
-  DistTensor(Device device,
-             const ShapeTuple& shape_,
-             const DimensionTypeTuple& dim_types_,
-             ProcessorGrid grid_,
-             const DistributionTypeTuple& dist_types_,
-             lazy_alloc_t)
-      : DistTensor(device,
-                   shape_,
-                   dim_types_,
-                   grid_,
-                   dist_types_,
-                   LazyAlloc,
-                   ComputeStream{device})
-  {}
-
-  DistTensor(Device device,
-             const ShapeTuple& shape_,
-             const DimensionTypeTuple& dim_types_,
-             ProcessorGrid grid_,
-             const DistributionTypeTuple& dist_types_,
-             strict_alloc_t,
-             const ComputeStream& stream)
-      : BaseDistTensor<T>(shape_, dim_types_, grid_, dist_types_),
-        tensor_local(device,
-                     this->tensor_local_shape,
-                     init_n(dim_types_, this->tensor_local_shape.size()),
-                     StrictAlloc,
-                     stream)
-  {}
-
-  DistTensor(Device device,
-             const ShapeTuple& shape_,
-             const DimensionTypeTuple& dim_types_,
-             ProcessorGrid grid_,
-             const DistributionTypeTuple& dist_types_,
-             strict_alloc_t)
-      : DistTensor(device,
-                   shape_,
-                   dim_types_,
-                   grid_,
-                   dist_types_,
-                   StrictAlloc,
-                   ComputeStream{device})
-  {}
-
-  DistTensor(Device device, ProcessorGrid grid_, const ComputeStream& stream)
-    : DistTensor(device,
-                 ShapeTuple(),
-                 DimensionTypeTuple(),
-                 grid_,
-                 DistributionTypeTuple(),
-                 StrictAlloc,
-                 stream)
-  {}
-
-  DistTensor(Device device, ProcessorGrid grid_)
-      : DistTensor(device, grid_, ComputeStream{device})
+                     alloc_type,
+                     stream.value_or(ComputeStream{device}))
   {}
 
   DistTensor(Device device,
              ProcessorGrid grid_,
-             lazy_alloc_t,
-             const ComputeStream& stream)
+             TensorAllocation alloc_type = StrictAlloc,
+             const std::optional<ComputeStream> stream = std::nullopt)
       : DistTensor(device,
                    ShapeTuple(),
                    DimensionTypeTuple(),
                    grid_,
                    DistributionTypeTuple(),
-                   LazyAlloc,
+                   alloc_type,
                    stream)
-  {}
-
-  DistTensor(Device device, ProcessorGrid grid_, lazy_alloc_t)
-      : DistTensor(device, grid_, LazyAlloc, ComputeStream{device})
-  {}
-
-  DistTensor(Device device,
-             ProcessorGrid grid_,
-             strict_alloc_t,
-             const ComputeStream& stream)
-      : DistTensor(device,
-                   ShapeTuple(),
-                   DimensionTypeTuple(),
-                   grid_,
-                   DistributionTypeTuple(),
-                   StrictAlloc,
-                   stream)
-  {}
-
-  DistTensor(Device device, ProcessorGrid grid_, strict_alloc_t)
-      : DistTensor(device, grid_, StrictAlloc, ComputeStream{device})
   {}
 
   DistTensor(Device device,

--- a/include/h2/tensor/dist_tensor_base.hpp
+++ b/include/h2/tensor/dist_tensor_base.hpp
@@ -44,12 +44,9 @@ namespace h2
  * A key exception is views of distributed tensors, which may not
  * eliminate any dimensions.
  */
-template <typename T>
 class BaseDistTensor : public Describable
 {
 public:
-
-  using value_type = T;
 
   /**
    * Construct a tensor with the given shape and dimension types,
@@ -181,27 +178,6 @@ public:
    */
   bool is_local_empty() const H2_NOEXCEPT { return local_numel() == 0; }
 
-  /** Output a short description of the tensor. */
-  void short_describe(std::ostream& os) const override
-  {
-    os << "DistTensor<" << TypeName<T>() << ", " << get_device() << ">(";
-    tensor_grid.short_describe(os);
-    os << ": ";
-    if (is_view())
-    {
-      os << get_view_type() << " of ";
-    }
-    for (ShapeTuple::size_type i = 0; i < ndim(); ++i)
-    {
-      os << distribution(i) << ":" << dim_type(i) << ":" << shape(i);
-      if (i < ndim() - 1)
-      {
-        os << " x ";
-      }
-    }
-    os << ")";
-  }
-
   /** Return true if this tensor is a view (i.e., does not own its storage). */
   bool is_view() const H2_NOEXCEPT
   {
@@ -219,171 +195,6 @@ public:
 
   /** Return the type of device this tensor is on. */
   virtual Device get_device() const H2_NOEXCEPT = 0;
-
-  /**
-   * Clear the tensor and reset it to empty.
-   *
-   * If this is a view, this is equivalent to `unview`.
-   */
-  virtual void empty() = 0;
-
-  /**
-   * Resize the tensor to a new shape.
-   *
-   * The number of dimensions must be the same as the existing tensor,
-   * or the existing tensor must be empty.
-   *
-   * It is an error to call this on a view.
-   */
-  virtual void resize(const ShapeTuple& new_shape) = 0;
-
-  /**
-   * Resize the tensor to a new shape and change its dimension types.
-   *
-   * The number of dimensions must be the same as the existing tensor,
-   * or the existing tensor must be empty.
-   *
-   * It is an error to call this on a view.
-   */
-  virtual void resize(const ShapeTuple& new_shape,
-                      const DimensionTypeTuple& new_dim_types) = 0;
-
-  /**
-   * Resize the tensor to a new shape and change its dimension types
-   * and distribution.
-   *
-   * The number of dimensions must be the same as the existing tensor,
-   * or the existing tensor must be empty.
-   *
-   * It is an error to call this on a view.
-   */
-  virtual void resize(const ShapeTuple& new_shape,
-                      const DimensionTypeTuple& new_dim_types,
-                      const DistributionTypeTuple& new_dist_types) = 0;
-
-  /**
-   * Return a raw pointer to the underlying local storage.
-   *
-   * @note Remember to account for the strides when accessing this.
-   * @note Just because a tensor is globally non-empty does not mean it
-   * has local data.
-   */
-  virtual T* data() = 0;
-
-  /** Return a raw constant pointer to the underlying local storage. */
-  virtual const T* data() const = 0;
-
-  /** Return a raw constant pointer to the underlying local storage. */
-  virtual const T* const_data() const = 0;
-
-  /** Return the underlying local tensor. */
-  virtual Tensor<T>& local_tensor() = 0;
-
-  /** Return a constant reference to the underlying local tensor. */
-  virtual const Tensor<T>& local_tensor() const = 0;
-
-  /** Return a constant reference to the underlying local tensor. */
-  virtual const Tensor<T>& const_local_tensor() const = 0;
-
-  /**
-   * Ensure memory is backing this tensor, allocating if necessary.
-   *
-   * This attempts to reuse existing memory from still-extant views of
-   * this tensor.
-   */
-  virtual void ensure() = 0;
-
-  /**
-   * Ensure memory is backing this tensor, allocating if necessary.
-   *
-   * This does not attempt to reuse existing memory from still-extant
-   * views of this tensor.
-   */
-  virtual void ensure(tensor_no_recovery_t) = 0;
-
-  /**
-   * Ensure memory is backing this tensor, allocating if necessary.
-   *
-   * This attempts to reuse existing memory from still-extant views of
-   * this tensor.
-   */
-  virtual void ensure(tensor_attempt_recovery_t) = 0;
-
-  /**
-   * Release memory associated with this tensor.
-   *
-   * Note that if there are views, memory may not be deallocated
-   * immediately.
-   */
-  virtual void release() = 0;
-
-  /**
-   * Return a view of this tensor.
-   *
-   * A view will share the same underlying memory as the original tensor,
-   * and will therefore reflect any changes made to the data; likewise,
-   * changes made through the view will be reflected in the original
-   * tensor. Additionally, the memory will remain valid so long as the
-   * view exists, even if the original tensor no longer exists.
-   *
-   * However, changes to metadata (e.g., shape, stride, etc.) do not
-   * propagate to views. It is up to the caller to ensure views remain
-   * consistent. Certain operations that would require changes to the
-   * underlying memory (e.g., `resize`) are not permitted on views and
-   * will throw an exception. Other operations have special semantics
-   * when the tensor is a view (e.g., `contiguous`, `empty`).
-   */
-  virtual BaseDistTensor<T>* view() = 0;
-
-  /** Return a constant view of this tensor. */
-  virtual BaseDistTensor<T>* view() const = 0;
-
-  /**
-   * Return a view of a subtensor of this tensor.
-   *
-   * Note that (inherent in the definition of `IndexRange`), views
-   * must be of contiguous subsets of the tensor (i.e., no strides).
-   *
-   * The `coords` given may omit dimensions on the right. In this case,
-   * they are assumed to have their full range. However, if `coords` is
-   * fully empty, the view will be empty.
-   *
-   * No entries of `coords` may be scalar: Dimensions cannot be
-   * eliminated from a distributed tensor, unless the entire view is
-   * empty.
-   */
-  virtual BaseDistTensor<T>* view(const IndexRangeTuple& coords) = 0;
-
-  /**
-   * Return a constant view of a subtensor of this tensor.
-   */
-  virtual BaseDistTensor<T>* view(const IndexRangeTuple& coords) const = 0;
-
-  /**
-   * If this tensor is a view, stop viewing.
-   *
-   * The tensor will have empty dimensions after this.
-   *
-   * It is an error to call this if the tensor is not a view.
-   */
-  virtual void unview() = 0;
-
-  // Note: The operator() is abstract rather than defaulting to
-  // view(coords) because we need to covariant return type.
-
-  /** Convenience wrapper for view(coords). */
-  virtual BaseDistTensor<T>* operator()(const IndexRangeTuple& coords) = 0;
-
-  /** Return a constant view of this tensor. */
-  virtual BaseDistTensor<T>* const_view() const = 0;
-
-  /** Return a constant view of a subtensor of this tensor. */
-  virtual BaseDistTensor<T>*
-  const_view(const IndexRangeTuple& coords) const = 0;
-
-  /** Convenience wrapper for const_view(coords). */
-  virtual BaseDistTensor<T>*
-  operator()(const IndexRangeTuple& coords) const = 0;
 
 protected:
   ShapeTuple tensor_shape;  /**< Global shape of the tensor. */

--- a/include/h2/tensor/dist_tensor_base.hpp
+++ b/include/h2/tensor/dist_tensor_base.hpp
@@ -15,7 +15,7 @@
 #include "h2/tensor/dist_types.hpp"
 #include "h2/tensor/dist_utils.hpp"
 #include "h2/tensor/proc_grid.hpp"
-#include "h2/tensor/tensor_base.hpp"
+#include "h2/tensor/tensor.hpp"
 #include "h2/tensor/tensor_types.hpp"
 #include "h2/utils/Describable.hpp"
 #include "h2/utils/typename.hpp"
@@ -277,13 +277,13 @@ public:
   virtual const T* const_data() const = 0;
 
   /** Return the underlying local tensor. */
-  virtual BaseTensor<T>& local_tensor() = 0;
+  virtual Tensor<T>& local_tensor() = 0;
 
   /** Return a constant reference to the underlying local tensor. */
-  virtual const BaseTensor<T>& local_tensor() const = 0;
+  virtual const Tensor<T>& local_tensor() const = 0;
 
   /** Return a constant reference to the underlying local tensor. */
-  virtual const BaseTensor<T>& const_local_tensor() const = 0;
+  virtual const Tensor<T>& const_local_tensor() const = 0;
 
   /**
    * Ensure memory is backing this tensor, allocating if necessary.

--- a/include/h2/tensor/tensor.hpp
+++ b/include/h2/tensor/tensor.hpp
@@ -41,7 +41,7 @@ public:
          lazy_alloc_t,
          const ComputeStream& stream = ComputeStream{Dev}) :
     BaseTensor<T>(shape_, dim_types_),
-    tensor_memory(shape_, true, stream)
+    tensor_memory(Dev, shape_, true, stream)
   {}
 
   Tensor(const ShapeTuple& shape_,
@@ -49,7 +49,7 @@ public:
          strict_alloc_t,
          const ComputeStream& stream = ComputeStream{Dev}) :
     BaseTensor<T>(shape_, dim_types_),
-    tensor_memory(shape_, false, stream)
+    tensor_memory(Dev, shape_, false, stream)
   {}
 
   Tensor(const ComputeStream& stream = ComputeStream{Dev})
@@ -68,7 +68,7 @@ public:
          const StrideTuple& strides_,
          const ComputeStream& stream = ComputeStream{Dev}) :
     BaseTensor<T>(ViewType::Mutable, shape_, dim_types_),
-    tensor_memory(buffer, shape_, strides_, stream)
+    tensor_memory(Dev, buffer, shape_, strides_, stream)
   {}
 
   Tensor(const T* buffer,
@@ -77,7 +77,7 @@ public:
          const StrideTuple& strides_,
          const ComputeStream& stream = ComputeStream{Dev}) :
     BaseTensor<T>(ViewType::Const, shape_, dim_types_),
-    tensor_memory(const_cast<T*>(buffer), shape_, strides_, stream)
+    tensor_memory(Dev, const_cast<T*>(buffer), shape_, strides_, stream)
   {}
 
   StrideTuple strides() const H2_NOEXCEPT override {
@@ -99,7 +99,7 @@ public:
   void empty() override
   {
     auto stream = tensor_memory.get_stream();
-    tensor_memory = StridedMemory<T, Dev>(tensor_memory.is_lazy(), stream);
+    tensor_memory = StridedMemory<T>(Dev, tensor_memory.is_lazy(), stream);
     this->tensor_shape = ShapeTuple();
     this->tensor_dim_types = DimensionTypeTuple();
     if (this->is_view()) {
@@ -130,8 +130,8 @@ public:
       return;
     }
     auto stream = tensor_memory.get_stream();
-    tensor_memory = StridedMemory<T, Dev>(
-      new_shape, tensor_memory.is_lazy(), stream);
+    tensor_memory = StridedMemory<T>(
+      Dev, new_shape, tensor_memory.is_lazy(), stream);
     this->tensor_shape = new_shape;
     this->tensor_dim_types = new_dim_types;
   }
@@ -154,8 +154,8 @@ public:
       return;
     }
     auto stream = tensor_memory.get_stream();
-    tensor_memory = StridedMemory<T, Dev>(
-      new_shape, new_strides, tensor_memory.is_lazy(), stream);
+    tensor_memory = StridedMemory<T>(
+      Dev, new_shape, new_strides, tensor_memory.is_lazy(), stream);
     this->tensor_shape = new_shape;
     this->tensor_dim_types = new_dim_types;
   }
@@ -283,11 +283,11 @@ public:
 
 private:
   /** Underlying memory buffer for the tensor. */
-  StridedMemory<T, Dev> tensor_memory;
+  StridedMemory<T> tensor_memory;
 
   /** Private constructor for views. */
   Tensor(ViewType view_type_,
-         const StridedMemory<T, Dev>& mem_,
+         const StridedMemory<T>& mem_,
          const ShapeTuple& shape_,
          const DimensionTypeTuple& dim_types_,
          const IndexRangeTuple& coords)

--- a/include/h2/tensor/tensor.hpp
+++ b/include/h2/tensor/tensor.hpp
@@ -12,6 +12,8 @@
  * Local tensors that live on a device.
  */
 
+#include <optional>
+
 #include "h2/tensor/tensor_base.hpp"
 #include "h2/tensor/strided_memory.hpp"
 #include "h2/tensor/tensor_types.hpp"
@@ -32,67 +34,19 @@ public:
   Tensor(Device device,
          const ShapeTuple& shape_,
          const DimensionTypeTuple& dim_types_,
-         const ComputeStream& stream)
-    : Tensor(device, shape_, dim_types_, StrictAlloc, stream)
+         TensorAllocation alloc_type = StrictAlloc,
+         const std::optional<ComputeStream> stream = std::nullopt)
+      : BaseTensor<T>(shape_, dim_types_),
+        tensor_memory(device,
+                      shape_,
+                      alloc_type == LazyAlloc,
+                      stream.value_or(ComputeStream{device}))
   {}
 
   Tensor(Device device,
-         const ShapeTuple& shape_,
-         const DimensionTypeTuple& dim_types_)
-    : Tensor(device, shape_, dim_types_, ComputeStream{device}) {}
-
-  Tensor(Device device,
-         const ShapeTuple& shape_,
-         const DimensionTypeTuple& dim_types_,
-         lazy_alloc_t,
-         const ComputeStream& stream) :
-    BaseTensor<T>(shape_, dim_types_),
-    tensor_memory(device, shape_, true, stream)
-  {}
-
-  Tensor(Device device,
-         const ShapeTuple& shape_,
-         const DimensionTypeTuple& dim_types_,
-         lazy_alloc_t)
-      : Tensor(device, shape_, dim_types_, LazyAlloc, ComputeStream{device})
-  {}
-
-  Tensor(Device device,
-         const ShapeTuple& shape_,
-         const DimensionTypeTuple& dim_types_,
-         strict_alloc_t,
-         const ComputeStream& stream) :
-    BaseTensor<T>(shape_, dim_types_),
-    tensor_memory(device, shape_, false, stream)
-  {}
-
-  Tensor(Device device,
-         const ShapeTuple& shape_,
-         const DimensionTypeTuple& dim_types_,
-         strict_alloc_t)
-      : Tensor(device, shape_, dim_types_, StrictAlloc, ComputeStream{device})
-  {}
-
-  Tensor(Device device, const ComputeStream& stream)
-      : Tensor(device, ShapeTuple(), DimensionTypeTuple(), StrictAlloc, stream)
-  {}
-
-  Tensor(Device device) : Tensor(device, ComputeStream{device}) {}
-
-  Tensor(Device device, lazy_alloc_t, const ComputeStream& stream)
-      : Tensor(device, ShapeTuple(), DimensionTypeTuple(), LazyAlloc, stream)
-  {}
-
-  Tensor(Device device, lazy_alloc_t)
-      : Tensor(device, LazyAlloc, ComputeStream{device})
-  {}
-
-  Tensor(Device device, strict_alloc_t, const ComputeStream& stream)
-      : Tensor(device, ShapeTuple(), DimensionTypeTuple(), StrictAlloc, stream)
-  {}
-
-  Tensor(Device device, strict_alloc_t)
-      : Tensor(device, StrictAlloc, ComputeStream{device})
+         TensorAllocation alloc_type = StrictAlloc,
+         const std::optional<ComputeStream> stream = std::nullopt)
+      : Tensor(device, ShapeTuple(), DimensionTypeTuple(), alloc_type, stream)
   {}
 
   Tensor(Device device,

--- a/include/h2/tensor/tensor.hpp
+++ b/include/h2/tensor/tensor.hpp
@@ -71,7 +71,7 @@ public:
     tensor_memory(device, const_cast<T*>(buffer), shape_, strides_, stream)
   {}
 
-  /** Private constructor for views. */
+  /** Internal constructor for views. */
   Tensor(ViewType view_type_,
          const StridedMemory<T>& mem_,
          const ShapeTuple& shape_,

--- a/include/h2/tensor/tensor.hpp
+++ b/include/h2/tensor/tensor.hpp
@@ -27,7 +27,7 @@ template <typename T> class DistTensor;
 
 /** Tensor class for arbitrary types and devices. */
 template <typename T>
-class Tensor : public BaseTensor<T> {
+class Tensor : public BaseTensor {
 public:
   using value_type = T;
 
@@ -36,7 +36,7 @@ public:
          const DimensionTypeTuple& dim_types_,
          TensorAllocation alloc_type = StrictAlloc,
          const std::optional<ComputeStream> stream = std::nullopt)
-      : BaseTensor<T>(shape_, dim_types_),
+      : BaseTensor(shape_, dim_types_),
         tensor_memory(device,
                       shape_,
                       alloc_type == LazyAlloc,
@@ -55,7 +55,7 @@ public:
          const DimensionTypeTuple& dim_types_,
          const StrideTuple& strides_,
          const ComputeStream& stream) :
-    BaseTensor<T>(ViewType::Mutable, shape_, dim_types_),
+    BaseTensor(ViewType::Mutable, shape_, dim_types_),
     tensor_memory(device, buffer, shape_, strides_, stream)
   {}
 
@@ -65,9 +65,30 @@ public:
          const DimensionTypeTuple& dim_types_,
          const StrideTuple& strides_,
          const ComputeStream& stream) :
-    BaseTensor<T>(ViewType::Const, shape_, dim_types_),
+    BaseTensor(ViewType::Const, shape_, dim_types_),
     tensor_memory(device, const_cast<T*>(buffer), shape_, strides_, stream)
   {}
+
+  virtual ~Tensor() = default;
+
+  /** Output a short description of the tensor. */
+  void short_describe(std::ostream& os) const override
+  {
+    os << "Tensor<" << TypeName<T>() << ", " << get_device() << ">(";
+    if (is_view())
+    {
+      os << get_view_type() << " of ";
+    }
+    for (ShapeTuple::size_type i = 0; i < ndim(); ++i)
+    {
+      os << dim_type(i) << ":" << shape(i);
+      if (i < ndim() - 1)
+      {
+        os << " x ";
+      }
+    }
+    os << ")";
+  }
 
   StrideTuple strides() const H2_NOEXCEPT override {
     return tensor_memory.strides();
@@ -88,7 +109,12 @@ public:
     return tensor_memory.get_device();
   }
 
-  void empty() override
+  /**
+   * Clear the tensor and reset it to empty.
+   *
+   * If this is a view, this is equivalent to `unview`.
+   */
+  void empty()
   {
     auto stream = tensor_memory.get_stream();
     tensor_memory =
@@ -100,15 +126,25 @@ public:
     }
   }
 
-  void resize(const ShapeTuple& new_shape) override
+  /**
+   * Resize the tensor to a new shape, keeping dimension types the same.
+   *
+   * It is an error to call this on a view.
+   */
+  void resize(const ShapeTuple& new_shape)
   {
     H2_ASSERT_ALWAYS(new_shape.size() <= this->tensor_shape.size(),
                      "Must provide dimension types to resize larger");
     resize(new_shape, init_n(this->tensor_dim_types, new_shape.size()));
   }
 
+  /**
+   * Resize the tensor to a new shape, also changing dimension types.
+   *
+   * It is an error to call this on a view.
+   */
   void resize(const ShapeTuple& new_shape,
-              const DimensionTypeTuple& new_dim_types) override
+              const DimensionTypeTuple& new_dim_types)
   {
     // We do not call the resize-with-new-strides version so we do not
     // have to compute the strides manually.
@@ -129,9 +165,15 @@ public:
     this->tensor_dim_types = new_dim_types;
   }
 
+  /**
+   * Resize the tensor to a new shape, also changing dimension types
+   * and specifying new strides.
+   *
+   * It is an error to call this on a view.
+   */
   void resize(const ShapeTuple& new_shape,
               const DimensionTypeTuple& new_dim_types,
-              const StrideTuple& new_strides) override
+              const StrideTuple& new_strides)
   {
     H2_ASSERT_ALWAYS(!this->is_view(), "Cannot resize a view");
     H2_ASSERT_ALWAYS(new_dim_types.size() == new_shape.size(),
@@ -153,7 +195,12 @@ public:
     this->tensor_dim_types = new_dim_types;
   }
 
-  T* data() override {
+  /**
+   * Return a raw pointer to the underlying storage.
+   *
+   * @note Remember to account for the strides when accessing this.
+   */
+  T* data() {
     if (this->tensor_view_type == ViewType::Const) {
       throw H2Exception("Cannot access non-const buffer of const view");
     }
@@ -161,93 +208,179 @@ public:
     return tensor_memory.data();
   }
 
-  const T* data() const override
+  /** Return a raw constant pointer to the underlying storage. */
+  const T* data() const
   {
     return tensor_memory.const_data();
   }
 
-  const T* const_data() const override {
+  /** Return a raw constant pointer to the underlying storage. */
+  const T* const_data() const {
     return tensor_memory.const_data();
   }
 
-  void ensure() override
+  /**
+   * Ensure memory is backing this tensor, allocating if necessary.
+   *
+   * This attempts to reuse existing memory from still-extant views of
+   * this tensor.
+   */
+  void ensure()
   {
     ensure(TensorAttemptRecovery);
   }
 
-  void ensure(tensor_no_recovery_t) override
+  /**
+   * Ensure memory is backing this tensor, allocating if necessary.
+   *
+   * This does not attempt to reuse existing memory from still-extant
+   * views of this tensor.
+   */
+  void ensure(tensor_no_recovery_t)
   {
     tensor_memory.ensure(false);
   }
 
-  void ensure(tensor_attempt_recovery_t) override
+  /**
+   * Ensure memory is backing this tensor, allocating if necessary.
+   *
+   * This attempts to reuse existing memory from still-extant views of
+   * this tensor.
+   */
+  void ensure(tensor_attempt_recovery_t)
   {
     tensor_memory.ensure(true);
   }
 
-  void release() override
+  /**
+   * Release memory associated with this tensor.
+   *
+   * Note that if there are views, memory may not be deallocated
+   * immediately.
+   */
+  void release()
   {
     tensor_memory.release();
   }
 
-  Tensor<T>* contiguous() override {
+  /**
+   * Return a contiguous version of this tensor.
+   *
+   * If the tensor is contiguous, a view of the original tensor is
+   * returned. Otherwise, a new tensor is allocated.
+   *
+   * If this tensor is a view, the returned tensor will be distinct
+   * from the viewed tensor. Any views of this tensor will still be
+   * viewing the original tensor, not the contiguous tensor.
+   */
+  Tensor<T>* contiguous() {
     if (is_contiguous()) {
       return view();
     }
     throw H2Exception("contiguous() not implemented");
   }
 
-  Tensor<T>* view() override {
+  /**
+   * Return a view of this tensor.
+   *
+   * A view will share the same underlying memory as the original tensor,
+   * and will therefore reflect any changes made to the data; likewise,
+   * changes made through the view will be reflected in the original
+   * tensor. Additionally, the memory will remain valid so long as the
+   * view exists, even if the original tensor no longer exists.
+   *
+   * However, changes to metadata (e.g., shape, stride, etc.) do not
+   * propagate to views. It is up to the caller to ensure views remain
+   * consistent. Certain operations that would require changes to the
+   * underlying memory (e.g., `resize`) are not permitted on views and
+   * will throw an exception. Other operations have special semantics
+   * when the tensor is a view (e.g., `contiguous`, `empty`).
+   */
+  Tensor<T>* view() {
     return view(IndexRangeTuple(
         TuplePad<IndexRangeTuple>(this->tensor_shape.size(), ALL)));
   }
 
-  Tensor<T>* view() const override
+  /** Return a constant view of this tensor. */
+  Tensor<T>* view() const
   {
     return view(IndexRangeTuple(
         TuplePad<IndexRangeTuple>(this->tensor_shape.size(), ALL)));
   }
 
-  Tensor<T>* view(const IndexRangeTuple& coords) override
+  /**
+   * Return a view of a subtensor of this tensor.
+   *
+   * Note that (inherent in the definition of `IndexRange`), views
+   * must be of contiguous subsets of the tensor (i.e., no strides).
+   *
+   * The `coords` given may omit dimensions on the right. In this case,
+   * they are assumed to have their full range. However, if `coords` is
+   * fully empty, the view iwll be empty.
+   *
+   * If dimensions in `coords` are given as scalars, these dimensions
+   * are eliminated from the tensor. If all dimensions are eliminated,
+   * i.e., you access a specific element, the resulting view will have
+   * one dimension with dimension-type `Scalar`.
+   */
+  Tensor<T>* view(const IndexRangeTuple& coords)
   {
     return make_view(coords, ViewType::Mutable);
   }
 
-  Tensor<T>* view(const IndexRangeTuple& coords) const override
+  /**
+   * Return a constant view of a subtensor of this tensor.
+   */
+  Tensor<T>* view(const IndexRangeTuple& coords) const
   {
     return make_view(coords, ViewType::Const);
   }
 
-  Tensor<T>* operator()(const IndexRangeTuple& coords) override
+  /** Convenience wrapper for view(coords). */
+  Tensor<T>* operator()(const IndexRangeTuple& coords)
   {
     return view(coords);
   }
 
-  void unview() override {
+  /**
+   * If this tensor is a view, stop viewing.
+   *
+   * The tensor will have empty dimensions after this.
+   *
+   * It is an error to call this if the tensor is not a view.
+   */
+  void unview() {
     H2_ASSERT_DEBUG(this->is_view(), "Must be a view to unview");
     empty();  // Emptying a view is equivalent to unviewing.
   }
 
-  Tensor<T>* const_view() const override {
+  /** Return a constant view of this tensor. */
+  Tensor<T>* const_view() const {
     return const_view(IndexRangeTuple(
         TuplePad<IndexRangeTuple>(this->tensor_shape.size(), ALL)));
   }
 
-  Tensor<T>* const_view(const IndexRangeTuple& coords) const override
+  /** Return a constant view of a subtensor of this tensor. */
+  Tensor<T>* const_view(const IndexRangeTuple& coords) const
   {
     return make_view(coords, ViewType::Const);
   }
 
-  Tensor<T>* operator()(const IndexRangeTuple& coords) const override {
+  /** Convenience wrapper for const_view(coords). */
+  Tensor<T>* operator()(const IndexRangeTuple& coords) const {
     return const_view(coords);
   }
 
-  T* get(const ScalarIndexTuple& coords) override
+  /** Return a pointer to the tensor at a particular coordinate. */
+  T* get(const ScalarIndexTuple& coords)
   {
     return tensor_memory.get(coords);
   }
 
-  const T* get(const ScalarIndexTuple& coords) const override
+  /**
+   * Return a constant pointer to the tensor at a particular coordinate.
+   */
+  const T* get(const ScalarIndexTuple& coords) const
   {
     return tensor_memory.get(coords);
   }
@@ -282,7 +415,7 @@ private:
          const DimensionTypeTuple& dim_types_,
          const IndexRangeTuple& coords)
       :
-    BaseTensor<T>(view_type_, shape_, dim_types_),
+    BaseTensor(view_type_, shape_, dim_types_),
     tensor_memory(mem_, coords)
   {}
 

--- a/include/h2/tensor/tensor.hpp
+++ b/include/h2/tensor/tensor.hpp
@@ -36,7 +36,7 @@ public:
   Tensor(Device device,
          const ShapeTuple& shape_,
          const DimensionTypeTuple& dim_types_,
-         TensorAllocation alloc_type = StrictAlloc,
+         TensorAllocationStrategy alloc_type = StrictAlloc,
          const std::optional<ComputeStream> stream = std::nullopt)
       : BaseTensor(shape_, dim_types_),
         tensor_memory(device,
@@ -46,7 +46,7 @@ public:
   {}
 
   Tensor(Device device,
-         TensorAllocation alloc_type = StrictAlloc,
+         TensorAllocationStrategy alloc_type = StrictAlloc,
          const std::optional<ComputeStream> stream = std::nullopt)
       : Tensor(device, ShapeTuple(), DimensionTypeTuple(), alloc_type, stream)
   {}

--- a/include/h2/tensor/tensor_types.hpp
+++ b/include/h2/tensor/tensor_types.hpp
@@ -265,9 +265,11 @@ static constexpr struct tensor_no_recovery_t {} TensorNoRecovery;
 /** Attempt recovery in `BaseTensor::ensure`. */
 static constexpr struct tensor_attempt_recovery_t {} TensorAttemptRecovery;
 
-/** Tag to indicate a tensor should allocate lazily. */
-static constexpr struct lazy_alloc_t {} LazyAlloc;
-/** Tag to indicate a tensor should not allocate lazily. */
-static constexpr struct strict_alloc_t {} StrictAlloc;
+/** Control whether tensors allocate data lazily or not. */
+enum TensorAllocation
+{
+  LazyAlloc,  /**< Tensor data should be allocated lazily. */
+  StrictAlloc  /**< Tensor data should not be allocated lazily. */
+};
 
 }  // namespace h2

--- a/include/h2/tensor/tensor_types.hpp
+++ b/include/h2/tensor/tensor_types.hpp
@@ -266,7 +266,7 @@ static constexpr struct tensor_no_recovery_t {} TensorNoRecovery;
 static constexpr struct tensor_attempt_recovery_t {} TensorAttemptRecovery;
 
 /** Control whether tensors allocate data lazily or not. */
-enum TensorAllocation
+enum TensorAllocationStrategy
 {
   LazyAlloc,  /**< Tensor data should be allocated lazily. */
   StrictAlloc  /**< Tensor data should not be allocated lazily. */

--- a/include/h2/utils/CMakeLists.txt
+++ b/include/h2/utils/CMakeLists.txt
@@ -18,5 +18,6 @@ h2_add_sources_to_target_and_install(
   Error.hpp
   IntegerMath.hpp
   Logger.hpp
+  passkey.hpp
   typename.hpp
   )

--- a/include/h2/utils/passkey.hpp
+++ b/include/h2/utils/passkey.hpp
@@ -1,0 +1,74 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+/** @file
+ *
+ * Provides an implementation of the "passkey" idiom.
+ */
+
+namespace h2
+{
+
+/**
+ * A generic passkey.
+ *
+ * The "passkey" idiom allows a class to restrict access to methods at
+ * a finer-grained level than friendship by requiring the caller to
+ * pass an object (the passkey) that only certain classes can create.
+ *
+ * This provides a copyable passkey.
+ *
+ * This is especially useful for things like `std::make_unique` and
+ * private constructors.
+ *
+ * This implementation is derived from the classic one provided here:
+ * https://stackoverflow.com/questions/3217390/clean-c-granular-friend-equivalent-answer-attorney-client-idiom/3218920#3218920
+ */
+template <typename T>
+class Passkey
+{
+private:
+  friend T;
+
+  Passkey() = default;
+};
+
+/**
+ * Version of Passkey that supports two types.
+ *
+ * Whenever we switch to C++26, we can use variadic friends (P2893R0)
+ * to eliminate this.
+ */
+template <typename T, typename U>
+class Passkey2
+{
+private:
+  friend T;
+  friend U;
+
+  Passkey2() = default;
+
+public:
+  Passkey2(Passkey<T>) {}
+  Passkey2(Passkey<U>) {}
+};
+
+/** A non-copyable passkey. */
+template <typename T>
+class NonCopyablePasskey
+{
+private:
+  friend T;
+
+  NonCopyablePasskey() = default;
+  NonCopyablePasskey(const NonCopyablePasskey&) = delete;
+  NonCopyablePasskey& operator=(const NonCopyablePasskey&) = delete;
+};
+
+}  // namespace h2

--- a/test/unit_test/tensor/unit_test_copy.cpp
+++ b/test/unit_test/tensor/unit_test_copy.cpp
@@ -34,7 +34,7 @@ TEMPLATE_LIST_TEST_CASE("Buffer copy works", "[tensor][copy]", AllDevPairsList)
     write_ele<DstDev>(dst.buf, i, dst_val);
   }
 
-  REQUIRE_NOTHROW(CopyBuffer<DstDev, SrcDev>(
+  REQUIRE_NOTHROW(CopyBuffer(
       dst.buf, dst_stream, src.buf, src_stream, buf_size));
 
   for (std::size_t i = 0; i < buf_size; ++i)
@@ -52,15 +52,15 @@ TEMPLATE_LIST_TEST_CASE("Same-type tensor copy works",
 {
   constexpr Device SrcDev = meta::tlist::At<TestType, 0>::value;
   constexpr Device DstDev = meta::tlist::At<TestType, 1>::value;
-  using SrcTensorType = Tensor<DataType, SrcDev>;
-  using DstTensorType = Tensor<DataType, DstDev>;
+  using SrcTensorType = Tensor<DataType>;
+  using DstTensorType = Tensor<DataType>;
   constexpr DataType src_val = static_cast<DataType>(1);
   constexpr DataType dst_val = static_cast<DataType>(2);
 
   SECTION("Copying into existing tensor works without resizing")
   {
-    SrcTensorType src_tensor({4, 6}, {DT::Sample, DT::Any});
-    DstTensorType dst_tensor({4, 6}, {DT::Any, DT::Any});
+    SrcTensorType src_tensor(SrcDev, {4, 6}, {DT::Sample, DT::Any});
+    DstTensorType dst_tensor(DstDev, {4, 6}, {DT::Any, DT::Any});
 
     DataType* dst_orig_data = dst_tensor.data();
 
@@ -91,8 +91,8 @@ TEMPLATE_LIST_TEST_CASE("Same-type tensor copy works",
 
   SECTION("Copying into different-sized tensor works")
   {
-    SrcTensorType src_tensor({4, 6}, {DT::Sample, DT::Any});
-    DstTensorType dst_tensor({2, 2}, {DT::Any, DT::Any});
+    SrcTensorType src_tensor(SrcDev, {4, 6}, {DT::Sample, DT::Any});
+    DstTensorType dst_tensor(DstDev, {2, 2}, {DT::Any, DT::Any});
 
     for (std::size_t i = 0; i < src_tensor.numel(); ++i)
     {
@@ -126,8 +126,8 @@ TEMPLATE_LIST_TEST_CASE("Same-type tensor copy works",
 
   SECTION("Copying an empty tensor works")
   {
-    SrcTensorType src_tensor;
-    DstTensorType dst_tensor({2, 4}, {DT::Any, DT::Any});
+    SrcTensorType src_tensor(SrcDev);
+    DstTensorType dst_tensor(DstDev, {2, 4}, {DT::Any, DT::Any});
 
     REQUIRE_NOTHROW(Copy(dst_tensor, src_tensor));
 
@@ -136,8 +136,8 @@ TEMPLATE_LIST_TEST_CASE("Same-type tensor copy works",
 
   SECTION("Copying non-contiguous tensors works")
   {
-    SrcTensorType src_tensor({4, 6}, {DT::Sample, DT::Any});
-    DstTensorType dst_tensor({4, 6}, {DT::Any, DT::Any});
+    SrcTensorType src_tensor(SrcDev, {4, 6}, {DT::Sample, DT::Any});
+    DstTensorType dst_tensor(DstDev, {4, 6}, {DT::Any, DT::Any});
 
     // Resize to be non-contiguous.
     src_tensor.resize(

--- a/test/unit_test/tensor/unit_test_dist_tensor.cpp
+++ b/test/unit_test/tensor/unit_test_dist_tensor.cpp
@@ -20,13 +20,15 @@ TEMPLATE_LIST_TEST_CASE("Distributed tensors can be created",
                         "[dist-tensor]",
                         AllDevList)
 {
-  using DistTensorType = DistTensor<DataType, TestType::value>;
+  constexpr Device Dev = TestType::value;
+  using DistTensorType = DistTensor<DataType>;
 
   for_comms([&](Comm& comm) {
     for_grid_shapes([&](ShapeTuple shape) {
       ProcessorGrid grid = ProcessorGrid(comm, shape);
-      REQUIRE_NOTHROW(DistTensorType(grid));
+      REQUIRE_NOTHROW(DistTensorType(Dev, grid));
       REQUIRE_NOTHROW(DistTensorType(
+          Dev,
           shape,
           DTTuple(TuplePad<DTTuple>(shape.size(), DT::Any)),
           grid,
@@ -39,7 +41,8 @@ TEMPLATE_LIST_TEST_CASE("Distributed tensor metadata is sane",
                         "[dist-tensor]",
                         AllDevList)
 {
-  using DistTensorType = DistTensor<DataType, TestType::value>;
+  constexpr Device Dev = TestType::value;
+  using DistTensorType = DistTensor<DataType>;
 
   SECTION("Block distribution")
   {
@@ -50,8 +53,8 @@ TEMPLATE_LIST_TEST_CASE("Distributed tensor metadata is sane",
         tensor_shape.set_size(grid.ndim());
         DTTuple tensor_dim_types(TuplePad<DTTuple>(grid.ndim(), DT::Any));
         DistTTuple tensor_dist(TuplePad<DistTTuple>(grid.ndim(), Distribution::Block));
-        DistTensorType tensor =
-            DistTensorType(tensor_shape, tensor_dim_types, grid, tensor_dist);
+        DistTensorType tensor = DistTensorType(
+            Dev, tensor_shape, tensor_dim_types, grid, tensor_dist);
 
         // Compute the local shape.
         ShapeTuple local_shape(TuplePad<ShapeTuple>(grid.ndim(), 0));
@@ -126,8 +129,8 @@ TEMPLATE_LIST_TEST_CASE("Distributed tensor metadata is sane",
         tensor_shape.set_size(grid.ndim());
         DTTuple tensor_dim_types(TuplePad<DTTuple>(grid.ndim(), DT::Any));
         DistTTuple tensor_dist(TuplePad<DistTTuple>(grid.ndim(), Distribution::Replicated));
-        DistTensorType tensor =
-            DistTensorType(tensor_shape, tensor_dim_types, grid, tensor_dist);
+        DistTensorType tensor = DistTensorType(
+            Dev, tensor_shape, tensor_dim_types, grid, tensor_dist);
 
         // Compute the local shape.
         ShapeTuple local_shape = tensor_shape;
@@ -175,8 +178,8 @@ TEMPLATE_LIST_TEST_CASE("Distributed tensor metadata is sane",
         tensor_shape.set_size(grid.ndim());
         DTTuple tensor_dim_types(TuplePad<DTTuple>(grid.ndim(), DT::Any));
         DistTTuple tensor_dist(TuplePad<DistTTuple>(grid.ndim(), Distribution::Single));
-        DistTensorType tensor =
-            DistTensorType(tensor_shape, tensor_dim_types, grid, tensor_dist);
+        DistTensorType tensor = DistTensorType(
+            Dev, tensor_shape, tensor_dim_types, grid, tensor_dist);
 
         // Compute the local shape.
         ShapeTuple local_shape;
@@ -245,8 +248,8 @@ TEMPLATE_LIST_TEST_CASE("Distributed tensor metadata is sane",
         DistTTuple tensor_dist(Distribution::Block,
                                Distribution::Replicated,
                                Distribution::Single);
-        DistTensorType tensor =
-            DistTensorType(tensor_shape, tensor_dim_types, grid, tensor_dist);
+        DistTensorType tensor = DistTensorType(
+            Dev, tensor_shape, tensor_dim_types, grid, tensor_dist);
 
         // Compute the local shape.
         ShapeTuple local_shape(TuplePad<ShapeTuple>(grid.ndim()));
@@ -322,12 +325,13 @@ TEMPLATE_LIST_TEST_CASE("Empty distributed tensor metadata is sane",
                         "[dist-tensor]",
                         AllDevList)
 {
-  using DistTensorType = DistTensor<DataType, TestType::value>;
+  constexpr Device Dev = TestType::value;
+  using DistTensorType = DistTensor<DataType>;
 
   for_comms([&](Comm& comm) {
     for_grid_shapes([&](ShapeTuple grid_shape) {
       ProcessorGrid grid = ProcessorGrid(comm, grid_shape);
-      DistTensorType tensor = DistTensorType(grid);
+      DistTensorType tensor = DistTensorType(Dev, grid);
 
       REQUIRE(tensor.shape() == ShapeTuple{});
       REQUIRE(tensor.dim_types() == DTTuple{});
@@ -359,19 +363,20 @@ TEMPLATE_LIST_TEST_CASE("Lazy and strict distributed tensors are sane",
                         "[dist-tensor]",
                         AllDevList)
 {
-  using DistTensorType = DistTensor<DataType, TestType::value>;
+  constexpr Device Dev = TestType::value;
+  using DistTensorType = DistTensor<DataType>;
 
   Comm& comm = get_comm_or_skip(1);
   ProcessorGrid grid(comm, ShapeTuple{1});
 
-  REQUIRE_FALSE(DistTensorType(grid).is_lazy());
-  REQUIRE_FALSE(DistTensorType(grid, StrictAlloc).is_lazy());
-  REQUIRE(DistTensorType(grid, LazyAlloc).is_lazy());
+  REQUIRE_FALSE(DistTensorType(Dev, grid).is_lazy());
+  REQUIRE_FALSE(DistTensorType(Dev, grid, StrictAlloc).is_lazy());
+  REQUIRE(DistTensorType(Dev, grid, LazyAlloc).is_lazy());
 
   REQUIRE_FALSE(
-      DistTensorType({4}, {DT::Any}, grid, {Distribution::Block}, StrictAlloc)
+    DistTensorType(Dev, {4}, {DT::Any}, grid, {Distribution::Block}, StrictAlloc)
           .is_lazy());
-  REQUIRE(DistTensorType({4}, {DT::Any}, grid, {Distribution::Block}, LazyAlloc)
+  REQUIRE(DistTensorType(Dev, {4}, {DT::Any}, grid, {Distribution::Block}, LazyAlloc)
               .is_lazy());
 }
 
@@ -379,7 +384,8 @@ TEMPLATE_LIST_TEST_CASE("Resizing distributed tensors works",
                         "[dist-tensor]",
                         AllDevList)
 {
-  using DistTensorType = DistTensor<DataType, TestType::value>;
+  constexpr Device Dev = TestType::value;
+  using DistTensorType = DistTensor<DataType>;
 
   SECTION("Resizing works")
   {
@@ -391,8 +397,8 @@ TEMPLATE_LIST_TEST_CASE("Resizing distributed tensors works",
         tensor_shape.set_size(grid.ndim());
         DTTuple tensor_dim_types(TuplePad<DTTuple>(grid.ndim(), DT::Any));
         DistTTuple tensor_dist(TuplePad<DistTTuple>(grid.ndim(), Distribution::Block));
-        DistTensorType tensor =
-          DistTensorType(tensor_shape, tensor_dim_types, grid, tensor_dist);
+        DistTensorType tensor = DistTensorType(
+            Dev, tensor_shape, tensor_dim_types, grid, tensor_dist);
 
         ShapeTuple new_shape(4, 10);
         new_shape.set_size(grid.ndim());
@@ -451,8 +457,8 @@ TEMPLATE_LIST_TEST_CASE("Resizing distributed tensors works",
         tensor_shape.set_size(grid.ndim());
         DTTuple tensor_dim_types(TuplePad<DTTuple>(grid.ndim(), DT::Any));
         DistTTuple tensor_dist(TuplePad<DistTTuple>(grid.ndim(), Distribution::Block));
-        DistTensorType tensor =
-          DistTensorType(tensor_shape, tensor_dim_types, grid, tensor_dist);
+        DistTensorType tensor = DistTensorType(
+            Dev, tensor_shape, tensor_dim_types, grid, tensor_dist);
 
         tensor.empty();
         REQUIRE(tensor.shape() == ShapeTuple{});
@@ -484,8 +490,8 @@ TEMPLATE_LIST_TEST_CASE("Resizing distributed tensors works",
         tensor_shape.set_size(grid.ndim());
         DTTuple tensor_dim_types(TuplePad<DTTuple>(grid.ndim(), DT::Any));
         DistTTuple tensor_dist(TuplePad<DistTTuple>(grid.ndim(), Distribution::Block));
-        DistTensorType tensor =
-          DistTensorType(tensor_shape, tensor_dim_types, grid, tensor_dist);
+        DistTensorType tensor = DistTensorType(
+            Dev, tensor_shape, tensor_dim_types, grid, tensor_dist);
 
         tensor.empty();
         ShapeTuple new_shape(4, 10);
@@ -540,7 +546,7 @@ TEMPLATE_LIST_TEST_CASE("Writing to distributed tensors works",
                         "[dist-tensor]",
                         AllDevList)
 {
-  using DistTensorType = DistTensor<DataType, TestType::value>;
+  using DistTensorType = DistTensor<DataType>;
   constexpr Device Dev = TestType::value;
 
   for_comms([&](Comm& comm) {
@@ -555,8 +561,8 @@ TEMPLATE_LIST_TEST_CASE("Writing to distributed tensors works",
         tensor_shape.set_size(grid.ndim());
         DTTuple tensor_dim_types(TuplePad<DTTuple>(grid.ndim(), DT::Any));
         DistTTuple tensor_dist(TuplePad<DistTTuple>(grid.ndim(), dist));
-        DistTensorType tensor =
-          DistTensorType(tensor_shape, tensor_dim_types, grid, tensor_dist);
+        DistTensorType tensor = DistTensorType(
+            Dev, tensor_shape, tensor_dim_types, grid, tensor_dist);
         typename DistTensorType::local_tensor_type local_tensor =
           tensor.local_tensor();
 
@@ -581,7 +587,7 @@ TEMPLATE_LIST_TEST_CASE(
     "[dist-tensor]",
     AllDevList)
 {
-  using DistTensorType = DistTensor<DataType, TestType::value>;
+  using DistTensorType = DistTensor<DataType>;
   constexpr Device Dev = TestType::value;
 
   for_comms([&](Comm& comm) {
@@ -607,13 +613,15 @@ TEMPLATE_LIST_TEST_CASE(
         write_ele<Dev>(buf.buf, i, static_cast<DataType>(i));
       }
 
-      DistTensorType tensor(buf.buf,
+      DistTensorType tensor(Dev,
+                            buf.buf,
                             tensor_shape,
                             tensor_dim_types,
                             grid,
                             tensor_dist,
                             tensor_local_shape,
-                            tensor_local_strides);
+                            tensor_local_strides,
+                            ComputeStream{Dev});
 
       REQUIRE(tensor.shape() == tensor_shape);
       REQUIRE(tensor.dim_types() == tensor_dim_types);
@@ -649,7 +657,7 @@ TEMPLATE_LIST_TEST_CASE("Viewing distributed tensors works",
                         "[dist-tensor]",
                         AllDevList)
 {
-  using DistTensorType = DistTensor<DataType, TestType::value>;
+  using DistTensorType = DistTensor<DataType>;
   constexpr Device Dev = TestType::value;
 
   SECTION("Basic views work")
@@ -666,8 +674,8 @@ TEMPLATE_LIST_TEST_CASE("Viewing distributed tensors works",
           tensor_shape.set_size(grid.ndim());
           DTTuple tensor_dim_types(TuplePad<DTTuple>(grid.ndim(), DT::Any));
           DistTTuple tensor_dist(TuplePad<DistTTuple>(grid.ndim(), dist));
-          DistTensorType tensor =
-            DistTensorType(tensor_shape, tensor_dim_types, grid, tensor_dist);
+          DistTensorType tensor = DistTensorType(
+              Dev, tensor_shape, tensor_dim_types, grid, tensor_dist);
           typename DistTensorType::local_tensor_type local_tensor =
             tensor.local_tensor();
 
@@ -722,8 +730,8 @@ TEMPLATE_LIST_TEST_CASE("Viewing distributed tensors works",
           tensor_shape.set_size(grid.ndim());
           DTTuple tensor_dim_types(TuplePad<DTTuple>(grid.ndim(), DT::Any));
           DistTTuple tensor_dist(TuplePad<DistTTuple>(grid.ndim(), dist));
-          DistTensorType tensor =
-            DistTensorType(tensor_shape, tensor_dim_types, grid, tensor_dist);
+          DistTensorType tensor = DistTensorType(
+              Dev, tensor_shape, tensor_dim_types, grid, tensor_dist);
           typename DistTensorType::local_tensor_type local_tensor =
             tensor.local_tensor();
 
@@ -778,8 +786,8 @@ TEMPLATE_LIST_TEST_CASE("Viewing distributed tensors works",
           tensor_shape.set_size(grid.ndim());
           DTTuple tensor_dim_types(TuplePad<DTTuple>(grid.ndim(), DT::Any));
           DistTTuple tensor_dist(TuplePad<DistTTuple>(grid.ndim(), dist));
-          DistTensorType tensor =
-            DistTensorType(tensor_shape, tensor_dim_types, grid, tensor_dist);
+          DistTensorType tensor = DistTensorType(
+              Dev, tensor_shape, tensor_dim_types, grid, tensor_dist);
           typename DistTensorType::local_tensor_type local_tensor =
             tensor.local_tensor();
 
@@ -909,8 +917,8 @@ TEMPLATE_LIST_TEST_CASE("Viewing distributed tensors works",
           tensor_shape.set_size(grid.ndim());
           DTTuple tensor_dim_types(TuplePad<DTTuple>(grid.ndim(), DT::Any));
           DistTTuple tensor_dist(TuplePad<DistTTuple>(grid.ndim(), dist));
-          DistTensorType tensor =
-            DistTensorType(tensor_shape, tensor_dim_types, grid, tensor_dist);
+          DistTensorType tensor = DistTensorType(
+              Dev, tensor_shape, tensor_dim_types, grid, tensor_dist);
 
           IndexRangeTuple view_indices({IRng(0)});
 
@@ -934,8 +942,8 @@ TEMPLATE_LIST_TEST_CASE("Viewing distributed tensors works",
           tensor_shape.set_size(grid.ndim());
           DTTuple tensor_dim_types(TuplePad<DTTuple>(grid.ndim(), DT::Any));
           DistTTuple tensor_dist(TuplePad<DistTTuple>(grid.ndim(), dist));
-          DistTensorType tensor =
-            DistTensorType(tensor_shape, tensor_dim_types, grid, tensor_dist);
+          DistTensorType tensor = DistTensorType(
+              Dev, tensor_shape, tensor_dim_types, grid, tensor_dist);
           typename DistTensorType::local_tensor_type local_tensor =
             tensor.local_tensor();
 
@@ -991,8 +999,8 @@ TEMPLATE_LIST_TEST_CASE("Viewing distributed tensors works",
           tensor_shape.set_size(grid.ndim());
           DTTuple tensor_dim_types(TuplePad<DTTuple>(grid.ndim(), DT::Any));
           DistTTuple tensor_dist(TuplePad<DistTTuple>(grid.ndim(), dist));
-          DistTensorType tensor =
-            DistTensorType(tensor_shape, tensor_dim_types, grid, tensor_dist);
+          DistTensorType tensor = DistTensorType(
+              Dev, tensor_shape, tensor_dim_types, grid, tensor_dist);
           typename DistTensorType::local_tensor_type local_tensor =
             tensor.local_tensor();
 
@@ -1033,8 +1041,8 @@ TEMPLATE_LIST_TEST_CASE("Viewing distributed tensors works",
           tensor_shape.set_size(grid.ndim());
           DTTuple tensor_dim_types(TuplePad<DTTuple>(grid.ndim(), DT::Any));
           DistTTuple tensor_dist(TuplePad<DistTTuple>(grid.ndim(), dist));
-          DistTensorType tensor =
-            DistTensorType(tensor_shape, tensor_dim_types, grid, tensor_dist);
+          DistTensorType tensor = DistTensorType(
+              Dev, tensor_shape, tensor_dim_types, grid, tensor_dist);
           typename DistTensorType::local_tensor_type local_tensor =
             tensor.local_tensor();
 
@@ -1066,7 +1074,7 @@ TEMPLATE_LIST_TEST_CASE("Empty distributed tensor views work",
                         "[dist-tensor]",
                         AllDevList)
 {
-  using DistTensorType = DistTensor<DataType, TestType::value>;
+  using DistTensorType = DistTensor<DataType>;
   constexpr Device Dev = TestType::value;
 
   SECTION("View with fully empty coordinates works")
@@ -1083,8 +1091,8 @@ TEMPLATE_LIST_TEST_CASE("Empty distributed tensor views work",
           tensor_shape.set_size(grid.ndim());
           DTTuple tensor_dim_types(TuplePad<DTTuple>(grid.ndim(), DT::Any));
           DistTTuple tensor_dist(TuplePad<DistTTuple>(grid.ndim(), dist));
-          DistTensorType tensor =
-            DistTensorType(tensor_shape, tensor_dim_types, grid, tensor_dist);
+          DistTensorType tensor = DistTensorType(
+              Dev, tensor_shape, tensor_dim_types, grid, tensor_dist);
 
           DistTensorType* view = tensor.view(IndexRangeTuple{});
           REQUIRE(view->shape() == ShapeTuple{});
@@ -1126,8 +1134,8 @@ TEMPLATE_LIST_TEST_CASE("Empty distributed tensor views work",
           tensor_shape.set_size(grid.ndim());
           DTTuple tensor_dim_types(TuplePad<DTTuple>(grid.ndim(), DT::Any));
           DistTTuple tensor_dist(TuplePad<DistTTuple>(grid.ndim(), dist));
-          DistTensorType tensor =
-              DistTensorType(tensor_shape, tensor_dim_types, grid, tensor_dist);
+          DistTensorType tensor = DistTensorType(
+              Dev, tensor_shape, tensor_dim_types, grid, tensor_dist);
 
           IndexRangeTuple view_indices({IRng(), IRng(2, 3), IRng(1, 2)});
           view_indices.set_size(grid.ndim());
@@ -1163,7 +1171,8 @@ TEMPLATE_LIST_TEST_CASE("Distributed tensors are printable",
                         "[dist-tensor]",
                         AllDevList)
 {
-  using DistTensorType = DistTensor<DataType, TestType::value>;
+  constexpr Device Dev = TestType::value;
+  using DistTensorType = DistTensor<DataType>;
 
   std::stringstream dev_ss;
   dev_ss << TestType::value;
@@ -1180,8 +1189,8 @@ TEMPLATE_LIST_TEST_CASE("Distributed tensors are printable",
         tensor_shape.set_size(grid.ndim());
         DTTuple tensor_dim_types(TuplePad<DTTuple>(grid.ndim(), DT::Any));
         DistTTuple tensor_dist(TuplePad<DistTTuple>(grid.ndim(), dist));
-        DistTensorType tensor =
-            DistTensorType(tensor_shape, tensor_dim_types, grid, tensor_dist);
+        DistTensorType tensor = DistTensorType(
+            Dev, tensor_shape, tensor_dim_types, grid, tensor_dist);
 
         std::stringstream ss;
         ss << tensor;

--- a/test/unit_test/tensor/unit_test_dist_tensor.cpp
+++ b/test/unit_test/tensor/unit_test_dist_tensor.cpp
@@ -685,7 +685,7 @@ TEMPLATE_LIST_TEST_CASE("Viewing distributed tensors works",
             write_ele<Dev>(buf, i, static_cast<DataType>(i));
           }
 
-          DistTensorType* view = tensor.view();
+          std::unique_ptr<DistTensorType> view = tensor.view();
           REQUIRE(view->shape() == tensor_shape);
           REQUIRE(view->local_shape() == tensor.local_shape());
           REQUIRE(view->dim_types() == tensor_dim_types);
@@ -741,7 +741,7 @@ TEMPLATE_LIST_TEST_CASE("Viewing distributed tensors works",
             write_ele<Dev>(buf, i, static_cast<DataType>(i));
           }
 
-          DistTensorType* view = tensor.const_view();
+          std::unique_ptr<DistTensorType> view = tensor.const_view();
           REQUIRE(view->shape() == tensor_shape);
           REQUIRE(view->local_shape() == tensor.local_shape());
           REQUIRE(view->dim_types() == tensor_dim_types);
@@ -848,7 +848,7 @@ TEMPLATE_LIST_TEST_CASE("Viewing distributed tensors works",
             local_start = get_index_range_start(local_view_indices);
           }
 
-          DistTensorType* view = tensor.view(view_indices);
+          std::unique_ptr<DistTensorType> view = tensor.view(view_indices);
           REQUIRE(view->shape() == view_shape);
           REQUIRE(view->local_shape() == local_shape);
           REQUIRE(view->dim_types() == tensor_dim_types);
@@ -953,8 +953,8 @@ TEMPLATE_LIST_TEST_CASE("Viewing distributed tensors works",
             write_ele<Dev>(buf, i, static_cast<DataType>(i));
           }
 
-          DistTensorType* orig_view = tensor.view();
-          DistTensorType* view = orig_view->view();
+          std::unique_ptr<DistTensorType> orig_view = tensor.view();
+          std::unique_ptr<DistTensorType> view = orig_view->view();
           REQUIRE(view->shape() == tensor_shape);
           REQUIRE(view->local_shape() == tensor.local_shape());
           REQUIRE(view->dim_types() == tensor_dim_types);
@@ -1010,7 +1010,7 @@ TEMPLATE_LIST_TEST_CASE("Viewing distributed tensors works",
             write_ele<Dev>(buf, i, static_cast<DataType>(i));
           }
 
-          DistTensorType* view = tensor.view();
+          std::unique_ptr<DistTensorType> view = tensor.view();
           REQUIRE(view->is_view());
           view->unview();
           REQUIRE_FALSE(view->is_view());
@@ -1052,7 +1052,7 @@ TEMPLATE_LIST_TEST_CASE("Viewing distributed tensors works",
             write_ele<Dev>(buf, i, static_cast<DataType>(i));
           }
 
-          DistTensorType* view = tensor.view();
+          std::unique_ptr<DistTensorType> view = tensor.view();
           REQUIRE(view->is_view());
           view->empty();
           REQUIRE_FALSE(view->is_view());
@@ -1094,7 +1094,7 @@ TEMPLATE_LIST_TEST_CASE("Empty distributed tensor views work",
           DistTensorType tensor = DistTensorType(
               Dev, tensor_shape, tensor_dim_types, grid, tensor_dist);
 
-          DistTensorType* view = tensor.view(IndexRangeTuple{});
+          std::unique_ptr<DistTensorType> view = tensor.view(IndexRangeTuple{});
           REQUIRE(view->shape() == ShapeTuple{});
           REQUIRE(view->local_shape() == ShapeTuple{});
           REQUIRE(view->dim_types() == DTTuple{});
@@ -1140,7 +1140,7 @@ TEMPLATE_LIST_TEST_CASE("Empty distributed tensor views work",
           IndexRangeTuple view_indices({IRng(), IRng(2, 3), IRng(1, 2)});
           view_indices.set_size(grid.ndim());
 
-          DistTensorType* view = tensor.view(view_indices);
+          std::unique_ptr<DistTensorType> view = tensor.view(view_indices);
           REQUIRE(view->shape() == ShapeTuple{});
           REQUIRE(view->local_shape() == ShapeTuple{});
           REQUIRE(view->dim_types() == DTTuple{});

--- a/test/unit_test/tensor/unit_test_strided_memory.cpp
+++ b/test/unit_test/tensor/unit_test_strided_memory.cpp
@@ -77,11 +77,14 @@ TEST_CASE("get_extent_from_strides works", "[tensor][strided_memor]")
 
 TEMPLATE_LIST_TEST_CASE("StridedMemory is sane",
                         "[tensor][strided_memory]",
-                        AllDevList) {
-  using MemType = StridedMemory<DataType, TestType::value>;
+                        AllDevList)
+{
+  constexpr Device Dev = TestType::value;
+  using MemType = StridedMemory<DataType>;
 
-  MemType mem = MemType(ShapeTuple{3, 7});
+  MemType mem = MemType(Dev, ShapeTuple{3, 7}, false, ComputeStream{Dev});
   REQUIRE(mem.size() == 21);
+  REQUIRE(mem.get_device() == Dev);
   REQUIRE(mem.data() != nullptr);
   REQUIRE(mem.const_data() != nullptr);
   REQUIRE(mem.strides() == StrideTuple{1, 3});
@@ -133,10 +136,12 @@ TEMPLATE_LIST_TEST_CASE("Empty StridedMemory is sane",
                         "[tensor][strided_memory]",
                         AllDevList)
 {
-  using MemType = StridedMemory<DataType, TestType::value>;
+  constexpr Device Dev = TestType::value;
+  using MemType = StridedMemory<DataType>;
 
-  MemType mem;
+  MemType mem{Dev, false, ComputeStream{Dev}};
   REQUIRE(mem.size() == 0);
+  REQUIRE(mem.get_device() == Dev);
   REQUIRE(mem.data() == nullptr);
   REQUIRE(mem.const_data() == nullptr);
   REQUIRE(mem.strides() == StrideTuple{});
@@ -175,10 +180,12 @@ TEMPLATE_LIST_TEST_CASE("StridedMemory with empty shape is sane",
                         "[tensor][strided_memory]",
                         AllDevList)
 {
-  using MemType = StridedMemory<DataType, TestType::value>;
+  constexpr Device Dev = TestType::value;
+  using MemType = StridedMemory<DataType>;
 
-  MemType mem = MemType(ShapeTuple{});
+  MemType mem = MemType(Dev, ShapeTuple{}, false, ComputeStream{Dev});
   REQUIRE(mem.size() == 0);
+  REQUIRE(mem.get_device() == Dev);
   REQUIRE(mem.data() == nullptr);
   REQUIRE(mem.const_data() == nullptr);
   REQUIRE(mem.strides() == StrideTuple{});
@@ -190,10 +197,12 @@ TEMPLATE_LIST_TEST_CASE("StridedMemory with zero in shape is sane",
                         "[tensor][strided_memory]",
                         AllDevList)
 {
-  using MemType = StridedMemory<DataType, TestType::value>;
+  constexpr Device Dev = TestType::value;
+  using MemType = StridedMemory<DataType>;
 
-  MemType mem = MemType(ShapeTuple{7, 0});
+  MemType mem = MemType(Dev, ShapeTuple{7, 0}, false, ComputeStream{Dev});
   REQUIRE(mem.size() == 0);
+  REQUIRE(mem.get_device() == Dev);
   REQUIRE(mem.data() == nullptr);
   REQUIRE(mem.const_data() == nullptr);
   REQUIRE(mem.shape() == ShapeTuple{7, 0});
@@ -204,9 +213,10 @@ TEMPLATE_LIST_TEST_CASE("StridedMemory indexing works",
                         "[tensor][strided_memory]",
                         AllDevList)
 {
-  using MemType = StridedMemory<DataType, TestType::value>;
+  constexpr Device Dev = TestType::value;
+  using MemType = StridedMemory<DataType>;
 
-  MemType mem = MemType(ShapeTuple{3, 7, 2});
+  MemType mem = MemType(Dev, ShapeTuple{3, 7, 2}, false, ComputeStream{Dev});
   // This should iterate in exactly the generalized column-major order
   // data is stored in.
   DataIndexType idx = 0;
@@ -229,9 +239,9 @@ TEMPLATE_LIST_TEST_CASE("StridedMemory writing works",
                         AllDevList)
 {
   constexpr Device Dev = TestType::value;
-  using MemType = StridedMemory<DataType, TestType::value>;
+  using MemType = StridedMemory<DataType>;
 
-  MemType mem = MemType(ShapeTuple{3, 7, 2});
+  MemType mem = MemType(Dev, ShapeTuple{3, 7, 2}, false, ComputeStream{Dev});
   DataType* buf = mem.data();
   for (std::size_t i = 0; i < product<std::size_t>(mem.shape()); ++i)
   {
@@ -258,11 +268,16 @@ TEMPLATE_LIST_TEST_CASE("StridedMemory with non-contiguous strides is sane",
                         AllDevList)
 {
   constexpr Device Dev = TestType::value;
-  using MemType = StridedMemory<DataType, TestType::value>;
+  using MemType = StridedMemory<DataType>;
 
-  MemType mem(ShapeTuple{3, 7, 2}, StrideTuple{2, 4, 21});
+  MemType mem(Dev,
+              ShapeTuple{3, 7, 2},
+              StrideTuple{2, 4, 21},
+              false,
+              ComputeStream{Dev});
 
   REQUIRE(mem.size() == 50);
+  REQUIRE(mem.get_device() == Dev);
   REQUIRE(mem.data() != nullptr);
   REQUIRE(mem.const_data() != nullptr);
   REQUIRE(mem.strides() == StrideTuple{2, 4, 21});
@@ -275,9 +290,10 @@ TEMPLATE_LIST_TEST_CASE("StridedMemory views work",
                         AllDevList)
 {
   constexpr Device Dev = TestType::value;
-  using MemType = StridedMemory<DataType, TestType::value>;
+  using MemType = StridedMemory<DataType>;
 
-  MemType base_mem = MemType(ShapeTuple{3, 7, 3});
+  MemType base_mem =
+      MemType(Dev, ShapeTuple{3, 7, 3}, false, ComputeStream{Dev});
   for (std::size_t i = 0; i < product<std::size_t>(base_mem.shape()); ++i)
   {
     write_ele<Dev>(base_mem.data(), i, static_cast<DataType>(i));
@@ -394,9 +410,10 @@ TEMPLATE_LIST_TEST_CASE("Lazy StridedMemory works",
                         "[tensor][strided_memory]",
                         AllDevList)
 {
-  using MemType = StridedMemory<DataType, TestType::value>;
+  constexpr Device Dev = TestType::value;
+  using MemType = StridedMemory<DataType>;
 
-  MemType mem = MemType(ShapeTuple{3, 7}, true);
+  MemType mem = MemType(Dev, ShapeTuple{3, 7}, true, ComputeStream{Dev});
   REQUIRE(mem.is_lazy());
   REQUIRE(mem.data() == nullptr);
   REQUIRE(mem.const_data() == nullptr);
@@ -485,9 +502,10 @@ TEMPLATE_LIST_TEST_CASE("Empty lazy StridedMemory works",
                         "[tensor][strided_memory]",
                         AllDevList)
 {
-  using MemType = StridedMemory<DataType, TestType::value>;
+  constexpr Device Dev = TestType::value;
+  using MemType = StridedMemory<DataType>;
 
-  MemType mem = MemType(true);
+  MemType mem = MemType(Dev, true, ComputeStream{Dev});
   REQUIRE(mem.is_lazy());
   REQUIRE(mem.data() == nullptr);
   REQUIRE(mem.const_data() == nullptr);
@@ -509,11 +527,14 @@ TEMPLATE_LIST_TEST_CASE("StridedMemory with external buffers works",
                         "[tensor][strided_memory]",
                         AllDevList)
 {
-  using MemType = StridedMemory<DataType, TestType::value>;
+  constexpr Device Dev = TestType::value;
+  using MemType = StridedMemory<DataType>;
 
   DataType test_data[] = {0, 0, 0, 0};
-  MemType mem = MemType(test_data, ShapeTuple{2, 2}, StrideTuple{1, 2});
+  MemType mem = MemType(
+      Dev, test_data, ShapeTuple{2, 2}, StrideTuple{1, 2}, ComputeStream{Dev});
 
+  REQUIRE(mem.get_device() == Dev);
   REQUIRE(mem.data() == test_data);
   REQUIRE(mem.const_data() == test_data);
   REQUIRE(mem.shape() == ShapeTuple{2, 2});
@@ -566,7 +587,8 @@ TEMPLATE_LIST_TEST_CASE("StridedMemory is printable",
                         "[tensor][strided_memory]",
                         AllDevList)
 {
-  using MemType = StridedMemory<DataType, TestType::value>;
+  constexpr Device Dev = TestType::value;
+  using MemType = StridedMemory<DataType>;
 
   std::stringstream dev_ss;
   dev_ss << TestType::value;
@@ -575,7 +597,7 @@ TEMPLATE_LIST_TEST_CASE("StridedMemory is printable",
 
   SECTION("Lazy")
   {
-    MemType mem({3, 5}, true);
+    MemType mem(Dev, {3, 5}, true, ComputeStream{Dev});
     ss << mem;
 
     REQUIRE_THAT(ss.str(),
@@ -587,7 +609,7 @@ TEMPLATE_LIST_TEST_CASE("StridedMemory is printable",
 
   SECTION("Unlazy")
   {
-    MemType mem({3, 5}, false);
+    MemType mem(Dev, {3, 5}, false, ComputeStream{Dev});
     ss << mem;
 
     REQUIRE_THAT(ss.str(),

--- a/test/unit_test/tensor/unit_test_tensor.cpp
+++ b/test/unit_test/tensor/unit_test_tensor.cpp
@@ -406,7 +406,7 @@ TEMPLATE_LIST_TEST_CASE("Viewing tensors works", "[tensor]", AllDevList)
 
   SECTION("Basic views work")
   {
-    TensorType* view = tensor.view();
+    std::unique_ptr<TensorType> view = tensor.view();
     REQUIRE(view->shape() == ShapeTuple{4, 6});
     REQUIRE(view->dim_types() == DTTuple{DT::Sample, DT::Any});
     REQUIRE(view->strides() == StrideTuple{1, 4});
@@ -425,7 +425,7 @@ TEMPLATE_LIST_TEST_CASE("Viewing tensors works", "[tensor]", AllDevList)
   }
   SECTION("Constant views work")
   {
-    TensorType* view = tensor.const_view();
+    std::unique_ptr<TensorType> view = tensor.const_view();
     REQUIRE(view->shape() == ShapeTuple{4, 6});
     REQUIRE(view->dim_types() == DTTuple{DT::Sample, DT::Any});
     REQUIRE(view->strides() == StrideTuple{1, 4});
@@ -440,7 +440,7 @@ TEMPLATE_LIST_TEST_CASE("Viewing tensors works", "[tensor]", AllDevList)
   }
   SECTION("Viewing a subtensor works")
   {
-    TensorType* view = tensor.view({IRng(1), ALL});
+    std::unique_ptr<TensorType> view = tensor.view({IRng(1), ALL});
     REQUIRE(view->shape() == ShapeTuple{6});
     REQUIRE(view->dim_types() == DTTuple{DT::Any});
     REQUIRE(view->strides() == StrideTuple{4});
@@ -457,7 +457,7 @@ TEMPLATE_LIST_TEST_CASE("Viewing tensors works", "[tensor]", AllDevList)
   }
   SECTION("Operator-style views work")
   {
-    TensorType* view = tensor({IRng(1, 3), ALL});
+    std::unique_ptr<TensorType> view = tensor({IRng(1, 3), ALL});
     REQUIRE(view->shape() == ShapeTuple{2, 6});
     REQUIRE(view->dim_types() == DTTuple{DT::Sample, DT::Any});
     REQUIRE(view->strides() == StrideTuple{1, 4});
@@ -477,7 +477,7 @@ TEMPLATE_LIST_TEST_CASE("Viewing tensors works", "[tensor]", AllDevList)
   }
   SECTION("View of a single element works")
   {
-    TensorType* view = tensor.view({IRng(1, 2), IRng(0, 1)});
+    std::unique_ptr<TensorType> view = tensor.view({IRng(1, 2), IRng(0, 1)});
     REQUIRE(view->shape() == ShapeTuple{1, 1});
     REQUIRE(view->dim_types() == DTTuple{DT::Sample, DT::Any});
     REQUIRE(view->strides() == StrideTuple{1, 1});
@@ -491,7 +491,7 @@ TEMPLATE_LIST_TEST_CASE("Viewing tensors works", "[tensor]", AllDevList)
   }
   SECTION("View of a single element, eliminating dimensions, works")
   {
-    TensorType* view = tensor.view({IRng(1), IRng(0)});
+    std::unique_ptr<TensorType> view = tensor.view({IRng(1), IRng(0)});
     REQUIRE(view->shape() == ShapeTuple{1});
     REQUIRE(view->dim_types() == DTTuple{DT::Scalar});
     REQUIRE(view->strides() == StrideTuple{1});
@@ -505,8 +505,8 @@ TEMPLATE_LIST_TEST_CASE("Viewing tensors works", "[tensor]", AllDevList)
   }
   SECTION("Viewing a view works")
   {
-    TensorType* view_orig = tensor.view();
-    TensorType* view = view_orig->view();
+    std::unique_ptr<TensorType> view_orig = tensor.view();
+    std::unique_ptr<TensorType> view = view_orig->view();
     REQUIRE(view->shape() == ShapeTuple{4, 6});
     REQUIRE(view->dim_types() == DTTuple{DT::Sample, DT::Any});
     REQUIRE(view->strides() == StrideTuple{1, 4});
@@ -523,7 +523,7 @@ TEMPLATE_LIST_TEST_CASE("Viewing tensors works", "[tensor]", AllDevList)
   }
   SECTION("Unviewing a view works")
   {
-    TensorType* view = tensor.view();
+    std::unique_ptr<TensorType> view = tensor.view();
     REQUIRE(view->is_view());
     view->unview();
     REQUIRE_FALSE(view->is_view());
@@ -537,7 +537,7 @@ TEMPLATE_LIST_TEST_CASE("Viewing tensors works", "[tensor]", AllDevList)
   }
   SECTION("Emptying a view unviews")
   {
-    TensorType* view = tensor.view();
+    std::unique_ptr<TensorType> view = tensor.view();
     view->empty();
     REQUIRE_FALSE(view->is_view());
     REQUIRE(view->shape() == ShapeTuple{});
@@ -556,7 +556,7 @@ TEMPLATE_LIST_TEST_CASE("Viewing tensors works", "[tensor]", AllDevList)
 #endif
   SECTION("Resizing a view fails")
   {
-    TensorType* view = tensor.view();
+    std::unique_ptr<TensorType> view = tensor.view();
     REQUIRE_THROWS(view->resize(ShapeTuple{2, 3}));
     REQUIRE_THROWS(view->resize(ShapeTuple{2, 3, 4},
                                 DTTuple{DT::Sample, DT::Any, DT::Any}));
@@ -579,7 +579,7 @@ TEMPLATE_LIST_TEST_CASE("Viewing a tensor with a single element works",
 
   SECTION("Basic views work")
   {
-    TensorType* view = tensor.view();
+    std::unique_ptr<TensorType> view = tensor.view();
     REQUIRE(view->shape() == ShapeTuple{1});
     REQUIRE(view->dim_types() == DTTuple{DT::Sample});
     REQUIRE(view->strides() == StrideTuple{1});
@@ -595,7 +595,7 @@ TEMPLATE_LIST_TEST_CASE("Viewing a tensor with a single element works",
 
   SECTION("Manually-specified view range works")
   {
-    TensorType* view = tensor.view({IRng(0, 1)});
+    std::unique_ptr<TensorType> view = tensor.view({IRng(0, 1)});
     REQUIRE(view->shape() == ShapeTuple{1});
     REQUIRE(view->dim_types() == DTTuple{DT::Sample});
     REQUIRE(view->strides() == StrideTuple{1});
@@ -611,7 +611,7 @@ TEMPLATE_LIST_TEST_CASE("Viewing a tensor with a single element works",
 
   SECTION("View with a scalar index works")
   {
-    TensorType* view = tensor.view({IRng(0)});
+    std::unique_ptr<TensorType> view = tensor.view({IRng(0)});
     REQUIRE(view->shape() == ShapeTuple{1});
     REQUIRE(view->dim_types() == DTTuple{DT::Scalar});
     REQUIRE(view->strides() == StrideTuple{1});
@@ -637,7 +637,7 @@ TEMPLATE_LIST_TEST_CASE("Viewing constant tensors works",
 
   SECTION("Basic views work")
   {
-    TensorType* view = tensor.view();
+    std::unique_ptr<TensorType> view = tensor.view();
     REQUIRE(view->shape() == ShapeTuple{4, 6});
     REQUIRE(view->dim_types() == DTTuple{DT::Sample, DT::Any});
     REQUIRE(view->strides() == StrideTuple{1, 4});
@@ -652,7 +652,7 @@ TEMPLATE_LIST_TEST_CASE("Viewing constant tensors works",
   }
   SECTION("Operator-style views work")
   {
-    TensorType* view = tensor({IRng(1, 3), ALL});
+    std::unique_ptr<TensorType> view = tensor({IRng(1, 3), ALL});
     REQUIRE(view->shape() == ShapeTuple{2, 6});
     REQUIRE(view->dim_types() == DTTuple{DT::Sample, DT::Any});
     REQUIRE(view->strides() == StrideTuple{1, 4});
@@ -680,7 +680,7 @@ TEMPLATE_LIST_TEST_CASE("Empty views work", "[tensor]", AllDevList)
 
   SECTION("View with fully empty coordinates work")
   {
-    TensorType* view = tensor.view(IndexRangeTuple{});
+    std::unique_ptr<TensorType> view = tensor.view(IndexRangeTuple{});
     REQUIRE(view->shape() == ShapeTuple{});
     REQUIRE(view->dim_types() == DTTuple{});
     REQUIRE(view->strides() == StrideTuple{});
@@ -695,7 +695,7 @@ TEMPLATE_LIST_TEST_CASE("Empty views work", "[tensor]", AllDevList)
 
   SECTION("View with one coordinate empty works")
   {
-    TensorType* view = tensor.view({IRng(0, 1), IRng()});
+    std::unique_ptr<TensorType> view = tensor.view({IRng(0, 1), IRng()});
     REQUIRE(view->shape() == ShapeTuple{});
     REQUIRE(view->dim_types() == DTTuple{});
     REQUIRE(view->strides() == StrideTuple{});
@@ -726,16 +726,16 @@ TEMPLATE_LIST_TEST_CASE("Making tensors contiguous works",
   SECTION("Making contiguous tensors contiguous works")
   {
     REQUIRE(tensor.is_contiguous());
-    TensorType* contig = tensor.contiguous();
+    std::unique_ptr<TensorType> contig = tensor.contiguous();
     REQUIRE(contig->is_view());
     REQUIRE(contig->data() == tensor.data());
   }
   SECTION("Making non-contiguous tensors contiguous work")
   {
-    TensorType* view = tensor.view({IRng(1, 2), ALL});
+    std::unique_ptr<TensorType> view = tensor.view({IRng(1, 2), ALL});
     REQUIRE_FALSE(view->is_contiguous());
 
-    TensorType* contig = view->contiguous();
+    std::unique_ptr<TensorType> contig = view->contiguous();
     REQUIRE(contig->is_contiguous());
     REQUIRE(contig->data() != view->data());
     REQUIRE(contig->shape() == ShapeTuple{6});
@@ -769,7 +769,7 @@ TEMPLATE_LIST_TEST_CASE("Tensors are printable", "[tensor]", AllDevList)
 
   SECTION("View")
   {
-    TensorType* view = tensor.view();
+    std::unique_ptr<TensorType> view = tensor.view();
     ss << *view;
     REQUIRE(ss.str()
             == std::string("Tensor<") + TypeName<DataType>() + ", "


### PR DESCRIPTION
(Depends on #124.)

* Eliminates the `Device` template from many of our objects.
* Eliminates the datatype template from abstract base tensors.
* Switch to using `unique_ptr`s rather than manual heap allocation for returning tensors.
* Also provides an implementation of the passkey idiom.