### PR TITLE
Copy-to-device (with elision) & sync fixes

### DIFF
--- a/include/h2/core/sync.hpp
+++ b/include/h2/core/sync.hpp
@@ -17,6 +17,7 @@
 #include <El.hpp>
 
 #include <tuple>
+#include <utility>
 
 #include "h2/core/device.hpp"
 #include "h2/utils/Error.hpp"
@@ -248,12 +249,10 @@ public:
     H2_DEVICE_DISPATCH(
         device,
         {
-          cpu_event = other.cpu_event;
-          other.cpu_event = 0;
+          cpu_event = std::exchange(other.cpu_event, 0);
         },
         {
-          gpu_event = other.gpu_event;
-          other.gpu_event = nullptr;
+          gpu_event = std::exchange(other.gpu_event, nullptr);
         });
   }
   SyncEvent& operator=(SyncEvent&& other)
@@ -262,12 +261,10 @@ public:
     H2_DEVICE_DISPATCH(
         device,
         {
-          cpu_event = other.cpu_event;
-          other.cpu_event = 0;
+          cpu_event = std::exchange(other.cpu_event, 0);
         },
         {
-          gpu_event = other.gpu_event;
-          other.gpu_event = nullptr;
+          gpu_event = std::exchange(other.gpu_event, nullptr);
         });
     return *this;
   }
@@ -507,12 +504,10 @@ public:
     H2_DEVICE_DISPATCH(
         device,
         {
-          cpu_stream = other.cpu_stream;
-          other.cpu_stream = 0;
+          cpu_stream = std::exchange(other.cpu_stream, 0);
         },
         {
-          gpu_stream = other.gpu_stream;
-          other.gpu_stream = nullptr;
+          gpu_stream = std::exchange(other.gpu_stream, nullptr);
         });
   }
   ComputeStream& operator=(ComputeStream&& other)
@@ -521,12 +516,10 @@ public:
     H2_DEVICE_DISPATCH(
         device,
         {
-          cpu_stream = other.cpu_stream;
-          other.cpu_stream = 0;
+          cpu_stream = std::exchange(other.cpu_stream, 0);
         },
         {
-          gpu_stream = other.gpu_stream;
-          other.gpu_stream = nullptr;
+          gpu_stream = std::exchange(other.gpu_stream, nullptr);
         });
     return *this;
   }

--- a/include/h2/core/sync.hpp
+++ b/include/h2/core/sync.hpp
@@ -239,6 +239,39 @@ public:
     : device(Device::GPU), gpu_event(raw_event) {}
 #endif
 
+  SyncEvent(const SyncEvent&) = default;
+  SyncEvent& operator=(const SyncEvent&) = default;
+
+  SyncEvent(SyncEvent&& other)
+    : device(other.device)
+  {
+    H2_DEVICE_DISPATCH(
+        device,
+        {
+          cpu_event = other.cpu_event;
+          other.cpu_event = 0;
+        },
+        {
+          gpu_event = other.gpu_event;
+          other.gpu_event = nullptr;
+        });
+  }
+  SyncEvent& operator=(SyncEvent&& other)
+  {
+    device = other.device;
+    H2_DEVICE_DISPATCH(
+        device,
+        {
+          cpu_event = other.cpu_event;
+          other.cpu_event = 0;
+        },
+        {
+          gpu_event = other.gpu_event;
+          other.gpu_event = nullptr;
+        });
+    return *this;
+  }
+
   /** Return the device type of the event. */
   Device get_device() const H2_NOEXCEPT { return device; }
 
@@ -256,6 +289,7 @@ public:
   template <Device Dev>
   void wait_for_this() const
   {
+    H2_ASSERT_DEBUG(Dev == device, "Incorrect device");
     H2_DEVICE_DISPATCH_CONST(
       Dev,
       (void) 0,
@@ -266,6 +300,7 @@ public:
   template <Device Dev>
   typename internal::RawSyncEvent<Dev>::type get_event() const H2_NOEXCEPT
   {
+    H2_ASSERT_DEBUG(Dev == device, "Attempt to get raw event for wrong device");
     H2_DEVICE_DISPATCH_CONST(
       Dev,
       return cpu_event,
@@ -348,8 +383,8 @@ inline void destroy_sync_event(SyncEvent& event)
   H2_DEVICE_DISPATCH_CONST(
     Dev,
     (void) event,
-    {
-      internal::release_device_event(event.get_event<Dev>());
+    if (event.gpu_event != nullptr) {
+      internal::release_device_event(event.gpu_event);
       event.gpu_event = nullptr;
     });
 }
@@ -464,6 +499,38 @@ public:
                                internal::get_default_event<Dev>()));
   }
 
+  ComputeStream(const ComputeStream&) = default;
+  ComputeStream& operator=(const ComputeStream&) = default;
+
+  ComputeStream(ComputeStream&& other) : device(other.device)
+  {
+    H2_DEVICE_DISPATCH(
+        device,
+        {
+          cpu_stream = other.cpu_stream;
+          other.cpu_stream = 0;
+        },
+        {
+          gpu_stream = other.gpu_stream;
+          other.gpu_stream = nullptr;
+        });
+  }
+  ComputeStream& operator=(ComputeStream&& other)
+  {
+    device = other.device;
+    H2_DEVICE_DISPATCH(
+        device,
+        {
+          cpu_stream = other.cpu_stream;
+          other.cpu_stream = 0;
+        },
+        {
+          gpu_stream = other.gpu_stream;
+          other.gpu_stream = nullptr;
+        });
+    return *this;
+  }
+
   /** Return the device type of the stream. */
   Device get_device() const H2_NOEXCEPT { return device; }
 
@@ -484,6 +551,7 @@ public:
   template <Device ThisDev, Device EventDev>
   void add_sync_point(const SyncEvent& event) const
   {
+    H2_ASSERT_DEBUG(ThisDev == device, "Incorrect device");
     if constexpr (ThisDev == Device::CPU)
     {
       if constexpr (EventDev == Device::CPU)
@@ -529,6 +597,7 @@ public:
   template <Device ThisDev, Device EventDev>
   void wait_for(const SyncEvent& event) const
   {
+    H2_ASSERT_DEBUG(ThisDev == device, "Incorrect device");
     if constexpr (ThisDev == Device::CPU)
     {
       if constexpr (EventDev == Device::CPU)
@@ -579,6 +648,7 @@ public:
   template <Device ThisDev, Device StreamDev>
   void wait_for(const ComputeStream& other_stream) const
   {
+    H2_ASSERT_DEBUG(ThisDev == device, "Incorrect device");
     if constexpr (ThisDev == Device::CPU)
     {
       if constexpr (StreamDev == Device::CPU)
@@ -626,6 +696,7 @@ public:
   template <Device ThisDev>
   void wait_for_this() const
   {
+    H2_ASSERT_DEBUG(ThisDev == device, "Incorrect device");
     H2_DEVICE_DISPATCH_CONST(
       ThisDev,
       (void) 0,
@@ -636,6 +707,8 @@ public:
   template <Device ThisDev>
   typename internal::RawComputeStream<ThisDev>::type get_stream() const H2_NOEXCEPT
   {
+    H2_ASSERT_DEBUG(ThisDev == device,
+                    "Attempt to get raw stream for wrong device");
     H2_DEVICE_DISPATCH_CONST(
       ThisDev,
       return cpu_stream,
@@ -719,8 +792,8 @@ inline void destroy_compute_stream(ComputeStream& stream)
   H2_DEVICE_DISPATCH_CONST(
     Dev,
     (void) stream,
-    {
-      gpu::destroy(stream.get_stream<Dev>());
+    if (stream.gpu_stream != nullptr) {
+      gpu::destroy(stream.gpu_stream);
       stream.gpu_stream = nullptr;
     });
 }

--- a/include/h2/tensor/copy.hpp
+++ b/include/h2/tensor/copy.hpp
@@ -16,8 +16,8 @@
 #include <h2_config.hpp>
 
 #include <cstring>
+#include <memory>
 #include <type_traits>
-#include "strided_memory.hpp"
 
 #include "h2/tensor/tensor_types.hpp"
 #include "h2/tensor/tensor.hpp"
@@ -140,6 +140,63 @@ void Copy(Tensor<DstT>& dst, const Tensor<SrcT>& src)
   {
     throw H2Exception("Data type conversion in Copy not currently supported");
   }
+}
+
+/**
+ * Return a version of tensor src that is accessible from a device.
+ *
+ * This may return either a copy of the tensor or a view of the
+ * original tensor.
+ *
+ * A view may be returned when the tensor is already on the requested
+ * device; or if the system is a truly unified memory system (like an
+ * APU) where `src`'s device and `dev` share the same physical memory.
+ * In the latter case, the view will have a different device from the
+ * original tensor.
+ *
+ * An optional stream may be provided to control the stream the
+ * returned tensor will be on. If it is not specified, the stream used
+ * will be as follows:
+ * - If `src` is already on `dev`, `src`'s stream will be used.
+ * - Otherwise, `dev`'s default stream will be used.
+ */
+template <typename T>
+std::unique_ptr<Tensor<T>>
+MakeAccessibleOnDevice(Tensor<T>& src,
+                       Device dev,
+                       const std::optional<ComputeStream> stream = std::nullopt)
+{
+  if (src.get_device() == dev)
+  {
+    auto view = src.view();
+    if (stream.has_value())
+    {
+      view->set_stream(stream.value());
+    }
+    return view;
+  }
+
+  ComputeStream real_stream = stream.value_or(ComputeStream{dev});
+#ifdef H2_HAS_GPU
+  if (gpu::is_integrated())
+  {
+    // Return a view with the device changed.
+    return std::make_unique<Tensor<T>>(src, dev, real_stream);
+  }
+  else
+  {
+    // Return a copy.
+    // Create a new tensor on `dev` that has the same size.
+    auto dst = std::make_unique<Tensor<T>>(
+        dev, src.shape(), src.dim_types(), StrictAlloc, real_stream);
+    Copy(*dst, src);
+    return dst;
+  }
+#else  // H2_HAS_GPU
+  // No GPU support, but dev differs from the tensor's device.
+  // This should not happen.
+  throw H2Exception("Unknown device");
+#endif  // H2_HAS_GPU
 }
 
 }

--- a/include/h2/tensor/strided_memory.hpp
+++ b/include/h2/tensor/strided_memory.hpp
@@ -183,6 +183,22 @@ public:
     }
   }
 
+  /**
+   * View an existing memory buffer but associate it with a different
+   * device and stream.
+   */
+  StridedMemory(const StridedMemory<T>& base,
+                Device device,
+                const ComputeStream& stream_)
+      : raw_buffer(base.raw_buffer),
+        mem_offset(base.mem_offset),
+        mem_strides(base.mem_strides),
+        mem_shape(base.mem_shape),
+        mem_device(device),
+        stream(stream_),
+        is_mem_lazy(base.is_lazy())
+  {}
+
   /** Wrap an existing memory buffer. */
   StridedMemory(Device device,
                 T* buffer,

--- a/include/h2/tensor/tensor.hpp
+++ b/include/h2/tensor/tensor.hpp
@@ -84,7 +84,7 @@ public:
   {}
 
   /**
-   * Private constructor for views from different devices.
+   * Internal constructor for views from different devices.
    *
    * Not protected by a passkey because we use it from a free function.
    */

--- a/include/h2/tensor/tensor.hpp
+++ b/include/h2/tensor/tensor.hpp
@@ -83,6 +83,16 @@ public:
     tensor_memory(mem_, coords)
   {}
 
+  /**
+   * Private constructor for views from different devices.
+   *
+   * Not protected by a passkey because we use it from a free function.
+   */
+  Tensor(Tensor<T>& other, Device new_device, const ComputeStream& new_stream)
+      : BaseTensor(ViewType::Mutable, other.shape(), other.dim_types()),
+        tensor_memory(other.tensor_memory, new_device, new_stream)
+  {}
+
   virtual ~Tensor() = default;
 
   /** Output a short description of the tensor. */

--- a/test/unit_test/core/CMakeLists.txt
+++ b/test/unit_test/core/CMakeLists.txt
@@ -8,3 +8,9 @@
 target_sources(SeqCatchTests PRIVATE
   unit_test_sync.cpp
 )
+
+if (H2_HAS_GPU)
+  target_sources(GPUCatchTests PRIVATE
+    unit_test_sync.cpp
+  )
+endif ()

--- a/test/unit_test/core/unit_test_sync.cpp
+++ b/test/unit_test/core/unit_test_sync.cpp
@@ -47,9 +47,9 @@ TEMPLATE_LIST_TEST_CASE("ComputeStream works", "[sync]", AllDevList)
   if constexpr (Dev == Device::GPU)
   {
 #if H2_HAS_CUDA
-    REQUIRE(stream.get_stream() == El::cuda::GetDefaultStream());
+    REQUIRE(stream.get_stream<Device::GPU>() == El::cuda::GetDefaultStream());
 #elif H2_HAS_ROCM
-    REQUIRE(stream.get_stream() == El::hip::GetDefaultStream());
+    REQUIRE(stream.get_stream<Device::GPU>() == El::hip::GetDefaultStream());
 #endif
   }
 #endif
@@ -78,6 +78,19 @@ TEMPLATE_LIST_TEST_CASE("Sync creation routines work", "[sync]", AllDevList)
   REQUIRE_NOTHROW(destroy_sync_event<Dev>(event));
   REQUIRE_NOTHROW([&]() { event = create_new_sync_event(Dev); }());
   REQUIRE_NOTHROW(destroy_sync_event(event));
+}
+
+TEMPLATE_LIST_TEST_CASE("Copying syncs works", "[sync]", AllDevList)
+{
+  constexpr Device Dev = TestType::value;
+
+  ComputeStream stream = create_new_compute_stream<Dev>();
+  ComputeStream stream_copy = stream;
+  REQUIRE(stream.get_stream<Dev>() == stream_copy.get_stream<Dev>());
+
+  SyncEvent event = create_new_sync_event<Dev>();
+  SyncEvent event_copy = event;
+  REQUIRE(event.get_event<Dev>() == event_copy.get_event<Dev>());
 }
 
 TEMPLATE_LIST_TEST_CASE("Sync helpers work", "[sync]", AllDevList)
@@ -187,14 +200,14 @@ TEST_CASE("GPU sync El::SyncInfo conversion works", "[sync]")
       El::CreateNewSyncInfo<Device::GPU>();
   ComputeStream stream{Device::GPU};
   REQUIRE_NOTHROW([&]() { stream = ComputeStream(sync_info); }());
-  REQUIRE(stream.get_stream() == sync_info.Stream());
+  REQUIRE(stream.get_stream<Device::GPU>() == sync_info.Stream());
   El::DestroySyncInfo(sync_info);
 
   // Conversion to El:
   REQUIRE_NOTHROW([&]() {
     sync_info = static_cast<El::SyncInfo<El::Device::GPU>>(stream);
   }());
-  REQUIRE(sync_info.Stream() == stream.get_stream());
+  REQUIRE(sync_info.Stream() == stream.get_stream<Device::GPU>());
 }
 
 TEST_CASE("GPU and CPU syncs interoperate", "[sync]")
@@ -218,6 +231,23 @@ TEST_CASE("GPU and CPU syncs interoperate", "[sync]")
   REQUIRE_NOTHROW([&]() {
     auto multi_sync = create_multi_sync(gpu_stream, cpu_stream);
   }());
+}
+
+TEST_CASE("Moving GPU syncs clears handles", "[sync]")
+{
+  ComputeStream stream = create_new_compute_stream<Device::GPU>();
+  auto raw_stream = stream.get_stream<Device::GPU>();
+  REQUIRE(raw_stream != nullptr);
+  ComputeStream stream2 = std::move(stream);
+  REQUIRE(stream2.get_stream<Device::GPU>() == raw_stream);
+  REQUIRE(stream.get_stream<Device::GPU>() == nullptr);
+
+  SyncEvent event = create_new_sync_event<Device::GPU>();
+  auto raw_event = event.get_event<Device::GPU>();
+  REQUIRE(raw_event != nullptr);
+  SyncEvent event2 = std::move(event);
+  REQUIRE(event2.get_event<Device::GPU>() == raw_event);
+  REQUIRE(event.get_event<Device::GPU>() == nullptr);
 }
 
 #endif  // H2_TEST_WITH_GPU

--- a/test/unit_test/core/unit_test_sync.cpp
+++ b/test/unit_test/core/unit_test_sync.cpp
@@ -93,6 +93,21 @@ TEMPLATE_LIST_TEST_CASE("Copying syncs works", "[sync]", AllDevList)
   REQUIRE(event.get_event<Dev>() == event_copy.get_event<Dev>());
 }
 
+TEMPLATE_LIST_TEST_CASE("Self-moving syncs works", "[sync]", AllDevList)
+{
+  constexpr Device Dev = TestType::value;
+
+  ComputeStream stream = create_new_compute_stream<Dev>();
+  auto raw_stream = stream.get_stream<Dev>();
+  stream = std::move(stream);
+  REQUIRE(stream.get_stream<Dev>() == raw_stream);
+
+  SyncEvent event = create_new_sync_event<Dev>();
+  auto raw_event = event.get_event<Dev>();
+  event = std::move(event);
+  REQUIRE(event.get_event<Dev>() == raw_event);
+}
+
 TEMPLATE_LIST_TEST_CASE("Sync helpers work", "[sync]", AllDevList)
 {
   constexpr Device Dev = TestType::value;

--- a/test/unit_test/core/unit_test_sync.cpp
+++ b/test/unit_test/core/unit_test_sync.cpp
@@ -49,7 +49,7 @@ TEMPLATE_LIST_TEST_CASE("ComputeStream works", "[sync]", AllDevList)
 #if H2_HAS_CUDA
     REQUIRE(stream.get_stream<Device::GPU>() == El::cuda::GetDefaultStream());
 #elif H2_HAS_ROCM
-    REQUIRE(stream.get_stream<Device::GPU>() == El::hip::GetDefaultStream());
+    REQUIRE(stream.get_stream<Device::GPU>() == El::rocm::GetDefaultStream());
 #endif
   }
 #endif

--- a/test/unit_test/tensor/unit_test_copy.cpp
+++ b/test/unit_test/tensor/unit_test_copy.cpp
@@ -34,7 +34,7 @@ TEMPLATE_LIST_TEST_CASE("Buffer copy works", "[tensor][copy]", AllDevPairsList)
     write_ele<DstDev>(dst.buf, i, dst_val);
   }
 
-  REQUIRE_NOTHROW(CopyBuffer(
+  REQUIRE_NOTHROW(copy_buffer(
       dst.buf, dst_stream, src.buf, src_stream, buf_size));
 
   for (std::size_t i = 0; i < buf_size; ++i)
@@ -70,7 +70,7 @@ TEMPLATE_LIST_TEST_CASE("Same-type tensor copy works",
       write_ele<DstDev>(dst_tensor.data(), i, dst_val);
     }
 
-    REQUIRE_NOTHROW(Copy(dst_tensor, src_tensor));
+    REQUIRE_NOTHROW(copy(dst_tensor, src_tensor));
 
     REQUIRE(dst_tensor.shape() == ShapeTuple{4, 6});
     REQUIRE(dst_tensor.dim_types() == DTTuple{DT::Sample, DT::Any});
@@ -103,7 +103,7 @@ TEMPLATE_LIST_TEST_CASE("Same-type tensor copy works",
       write_ele<DstDev>(dst_tensor.data(), i, dst_val);
     }
 
-    REQUIRE_NOTHROW(Copy(dst_tensor, src_tensor));
+    REQUIRE_NOTHROW(copy(dst_tensor, src_tensor));
 
     REQUIRE(dst_tensor.shape() == ShapeTuple{4, 6});
     REQUIRE(dst_tensor.dim_types() == DTTuple{DT::Sample, DT::Any});
@@ -129,7 +129,7 @@ TEMPLATE_LIST_TEST_CASE("Same-type tensor copy works",
     SrcTensorType src_tensor(SrcDev);
     DstTensorType dst_tensor(DstDev, {2, 4}, {DT::Any, DT::Any});
 
-    REQUIRE_NOTHROW(Copy(dst_tensor, src_tensor));
+    REQUIRE_NOTHROW(copy(dst_tensor, src_tensor));
 
     REQUIRE(dst_tensor.is_empty());
   }
@@ -151,7 +151,7 @@ TEMPLATE_LIST_TEST_CASE("Same-type tensor copy works",
       write_ele<SrcDev>(src_tensor.get(i), 0, src_val);
     });
 
-    REQUIRE_NOTHROW(Copy(dst_tensor, src_tensor));
+    REQUIRE_NOTHROW(copy(dst_tensor, src_tensor));
 
     REQUIRE(dst_tensor.shape() == ShapeTuple{4, 6});
     REQUIRE(dst_tensor.dim_types() == DTTuple{DT::Sample, DT::Any});
@@ -180,7 +180,7 @@ TEMPLATE_LIST_TEST_CASE("MakeAccessibleOnDevice works",
 
   SrcTensorType src_tensor(SrcDev, {4, 6}, {DT::Sample, DT::Any});
 
-  auto dst_tensor = MakeAccessibleOnDevice(src_tensor, DstDev);
+  auto dst_tensor = make_accessible_on_device(src_tensor, DstDev);
 
   REQUIRE(dst_tensor->shape() == src_tensor.shape());
   REQUIRE(dst_tensor->dim_types() == src_tensor.dim_types());

--- a/test/unit_test/tensor/unit_test_raw_buffer.cpp
+++ b/test/unit_test/tensor/unit_test_raw_buffer.cpp
@@ -202,6 +202,24 @@ TEMPLATE_LIST_TEST_CASE("Raw buffers are writable",
   }
 }
 
+TEMPLATE_LIST_TEST_CASE("Raw buffer release registration works",
+                        "[tensor][raw_buffer]",
+                        AllDevPairsList)
+{
+  constexpr Device Dev1 = meta::tlist::At<TestType, 0>::value;
+  constexpr Device Dev2 = meta::tlist::At<TestType, 1>::value;
+  using BufType = RawBuffer<DataType>;
+  constexpr std::size_t buf_size = 32;
+
+  ComputeStream stream1{Dev1};
+  ComputeStream stream2{Dev2};
+
+  BufType buf(Dev1, stream1);
+  buf.register_release(stream2);
+
+  buf.release();
+}
+
 TEMPLATE_LIST_TEST_CASE("Raw buffers are printable",
                         "[tensor][raw_buffer]",
                         AllDevList)


### PR DESCRIPTION
(Depends on #125.)

* A number of fixes for sync objects (see a46a97 for details).
* `MakeAccessibleOnDevice`, for either copying a tensor to a device or creating a view of it. On systems with integrated CPU and GPU memory (e.g., APUs), this will enable copy elision.