### PR TITLE
Fix `H2_DEVICE_DISPATCH` for CPU-only Release builds.

### DIFF
--- a/include/h2/core/device.hpp
+++ b/include/h2/core/device.hpp
@@ -124,11 +124,8 @@ using AllDevicesList = h2::meta::TL<CPUDev_t>;
 #else  // H2_DEBUG
 #define H2_DEVICE_DISPATCH(device, cpu_code, gpu_code)  \
   do {                                                  \
-    if ((device) == Device::CPU)                        \
-    {                                                   \
-      constexpr Device Dev = Device::CPU;               \
-      code;                                             \
-    }                                                   \
+    constexpr Device Dev = Device::CPU;                 \
+    cpu_code;                                           \
   } while (0);
 #endif  // H2_DEBUG
 #endif  // H2_HAS_GPU


### PR DESCRIPTION
No `if` because this is the only possible branch and having one confuses the compiler in functions that return.