### PR TITLE
A little tidying and simplification of utilities

### DIFF
--- a/include/h2/tensor/tuple_utils.hpp
+++ b/include/h2/tensor/tuple_utils.hpp
@@ -98,81 +98,54 @@ constexpr bool all_of(const FixedSizeTuple<T, SizeType, N>& tuple, Predicate p)
   return true;
 }
 
-/**
- * Return a new tuple that is the result of applying a predicate to
- * each entry of the tuple.
- */
-template <typename T,
-          typename SizeType,
-          SizeType N,
-          typename Predicate>
-constexpr FixedSizeTuple<T, SizeType, N>
-map(const FixedSizeTuple<T, SizeType, N>& tuple, Predicate p)
-{
-  FixedSizeTuple<T, SizeType, N> mapped_tuple(
-      TuplePad<FixedSizeTuple<T, SizeType, N>>(tuple.size()));
-  for (SizeType i = 0; i < tuple.size(); ++i)
-  {
-    mapped_tuple[i] = p(tuple[i]);
-  }
-  return mapped_tuple;
-}
-
-/** Map with a different FixedSizeTuple return type. */
-template <typename NewT,
-          typename T,
-          typename SizeType,
-          SizeType N,
-          typename Predicate>
-constexpr FixedSizeTuple<NewT, SizeType, N>
-map(const FixedSizeTuple<T, SizeType, N>& tuple, Predicate p)
-{
-  FixedSizeTuple<NewT, SizeType, N> mapped_tuple(
-      TuplePad<FixedSizeTuple<NewT, SizeType, N>>(tuple.size()));
-  for (SizeType i = 0; i < tuple.size(); ++i)
-  {
-    mapped_tuple[i] = p(tuple[i]);
-  }
-  return mapped_tuple;
-}
-
-/**
- * Like map, except passes the index of each entry in tuple to the
- * given predicate, rather than the value.
+/** @brief Map a unary function over tuple elements
  *
- * This is primarily useful when your predicate can capture some other
- * object that it needs to interact with.
+ *  This is the classic "map" function ubiquitous in functional
+ *  programming.
+ *
+ *  @param[in] tuple The original tuple
+ *  @param[in] f A unary function of the tuple element type
+ *  @returns A new tuple that is the result of applying a unary
+ *           function to each entry of the tuple.
  */
-template <typename T,
-          typename SizeType,
-          SizeType N,
-          typename Predicate>
-constexpr FixedSizeTuple<T, SizeType, N>
-map_index(const FixedSizeTuple<T, SizeType, N>& tuple, Predicate p)
+template <typename T, typename SizeType, SizeType N, typename UnaryF>
+constexpr auto map(const FixedSizeTuple<T, SizeType, N>& tuple, UnaryF f)
+  -> FixedSizeTuple<std::invoke_result_t<UnaryF, T>, SizeType, N>
 {
-  FixedSizeTuple<T, SizeType, N> mapped_tuple(
-      TuplePad<FixedSizeTuple<T, SizeType, N>>(tuple.size()));
-  for (SizeType i = 0; i < tuple.size(); ++i)
-  {
-    mapped_tuple[i] = p(i);
-  }
-  return mapped_tuple;
-}
-
-/** map_index with a different FixedSizeTuple return type. */
-template <typename NewT,
-          typename T,
-          typename SizeType,
-          SizeType N,
-          typename Predicate>
-constexpr FixedSizeTuple<NewT, SizeType, N>
-map_index(const FixedSizeTuple<T, SizeType, N>& tuple, Predicate p)
-{
+  using NewT = std::invoke_result_t<UnaryF, T>;
   FixedSizeTuple<NewT, SizeType, N> mapped_tuple(
       TuplePad<FixedSizeTuple<NewT, SizeType, N>>(tuple.size()));
   for (SizeType i = 0; i < tuple.size(); ++i)
   {
-    mapped_tuple[i] = p(i);
+    mapped_tuple[i] = f(tuple[i]);
+  }
+  return mapped_tuple;
+}
+
+/** @brief Map a unary function over tuple indices
+ *
+ *  Like map, except passes the index of each entry in tuple to the
+ *  given predicate, rather than the value.
+ *
+ *  This is primarily useful when your predicate can capture some other
+ *  object that it needs to interact with.
+ *
+ *  @param[in] tuple The original tuple
+ *  @param[in] f A unary function of the tuple index type
+ *  @returns A new tuple that is the result of applying a unary
+ *           function to each index in the tuple.
+ */
+template <typename T, typename SizeType, SizeType N, typename IndexF>
+constexpr auto map_index(const FixedSizeTuple<T, SizeType, N>& tuple,
+                         IndexF f)
+  -> FixedSizeTuple<std::invoke_result_t<IndexF, SizeType>, SizeType, N>
+{
+  using NewT = std::invoke_result_t<IndexF, SizeType>;
+  FixedSizeTuple<NewT, SizeType, N> mapped_tuple(
+      TuplePad<FixedSizeTuple<NewT, SizeType, N>>(tuple.size()));
+  for (SizeType i = 0; i < tuple.size(); ++i)
+  {
+    mapped_tuple[i] = f(i);
   }
   return mapped_tuple;
 }

--- a/include/h2/utils/Error.hpp
+++ b/include/h2/utils/Error.hpp
@@ -8,10 +8,10 @@
 #ifndef H2_UTILS_ERROR_HPP_
 #define H2_UTILS_ERROR_HPP_
 
+#include <h2_config.hpp>
+
 #include <stdexcept>
 #include <string>
-
-#include <h2_config.hpp>
 
 /** @file Error.hpp
  *
@@ -50,8 +50,13 @@ H2_DEFINE_FORWARDING_EXCEPTION(H2Exception, std::runtime_error);
  *  @param ... The arguments to pass to the exception.
  */
 #define H2_ASSERT(cond, excptn, ...)                                           \
-    if (!(cond))                                                               \
-        throw excptn(__VA_ARGS__);
+    do                                                                         \
+    {                                                                          \
+        if (!(cond))                                                           \
+        {                                                                      \
+            throw excptn(__VA_ARGS__);                                         \
+        }                                                                      \
+    } while (0)
 
 #ifdef H2_DEBUG
 /** @def H2_ASSERT_DEBUG

--- a/test/static_test/tensor/fixed_size_tuple.cpp
+++ b/test/static_test/tensor/fixed_size_tuple.cpp
@@ -97,7 +97,7 @@ static_assert(!h2::all_of(test_tuple,
 static_assert(h2::map(test_tuple,
                       [](TestFixedSizeTuple::type x) { return x + 1; })
               == TestFixedSizeTuple{2, 3});
-static_assert(h2::map<bool>(test_tuple,
+static_assert(h2::map(test_tuple,
                             [](TestFixedSizeTuple::type x) { return x == 1; })
                   == h2::FixedSizeTuple<bool,
                                         typename TestFixedSizeTuple::size_type,
@@ -108,7 +108,7 @@ static_assert(h2::map_index(test_tuple,
                               return test_tuple[x] + 1;
                             })
               == TestFixedSizeTuple{2, 3});
-static_assert(h2::map_index<bool>(test_tuple,
+static_assert(h2::map_index(test_tuple,
                                   [](TestFixedSizeTuple::size_type x) {
                                     return test_tuple[x] == 1;
                                   })


### PR DESCRIPTION
This infers the result type from the unary functions passed in to remove the need for explicit template syntax at the call site.