### PR TITLE
Miscellaneous H2 tensor improvements

### DIFF
--- a/include/h2/tensor/copy.hpp
+++ b/include/h2/tensor/copy.hpp
@@ -47,6 +47,10 @@ void copy_buffer(T* dst,
 {
   H2_ASSERT_DEBUG(count == 0 || (dst != nullptr && src != nullptr),
                   "Null buffers");
+  // TODO: Debug check: Assert buffers do not overlap.
+  static_assert(
+      std::is_trivially_copyable_v<T>,
+      "Attempt to copy a buffer with a type that is not trivially copyable");
   const Device src_dev = src_stream.get_device();
   const Device dst_dev = dst_stream.get_device();
   if (src_dev == Device::CPU && dst_dev == Device::CPU)

--- a/include/h2/tensor/dist_tensor.hpp
+++ b/include/h2/tensor/dist_tensor.hpp
@@ -125,6 +125,22 @@ public:
 
   virtual ~DistTensor() = default;
 
+  /**
+   * Disable copy construction.
+   *
+   * Using it leads to ambiguity in mutable vs const views. Create a
+   * view or copy explicitly instead.
+   */
+  DistTensor(const DistTensor&) = delete;
+
+  /**
+   * Disable copy assignment.
+   *
+   * Using it leads to ambiguity in mutable vs const views. Create a
+   * view or copy explicitly instead.
+   */
+  DistTensor& operator=(const DistTensor&) = delete;
+
   /** Output a short description of the tensor. */
   void short_describe(std::ostream& os) const override
   {

--- a/include/h2/tensor/dist_tensor.hpp
+++ b/include/h2/tensor/dist_tensor.hpp
@@ -141,6 +141,12 @@ public:
    */
   DistTensor& operator=(const DistTensor&) = delete;
 
+  /** Move construction */
+  DistTensor(DistTensor&&) = default;
+
+  /** Move assignment */
+  DistTensor& operator=(DistTensor&&) = default;
+
   /** Output a short description of the tensor. */
   void short_describe(std::ostream& os) const override
   {

--- a/include/h2/tensor/tensor.hpp
+++ b/include/h2/tensor/tensor.hpp
@@ -111,6 +111,12 @@ public:
    */
   Tensor& operator=(const Tensor&) = delete;
 
+  /** Move construction */
+  Tensor(Tensor&&) = default;
+
+  /** Move assignment */
+  Tensor& operator=(Tensor&&) = default;
+
   /** Output a short description of the tensor. */
   void short_describe(std::ostream& os) const override
   {

--- a/include/h2/tensor/tensor.hpp
+++ b/include/h2/tensor/tensor.hpp
@@ -95,6 +95,22 @@ public:
 
   virtual ~Tensor() = default;
 
+  /**
+   * Disable copy construction.
+   *
+   * Using it leads to ambiguity in mutable vs const views. Create a
+   * view or copy explicitly instead.
+   */
+  Tensor(const Tensor&) = delete;
+
+  /**
+   * Disable copy assignment.
+   *
+   * Using it leads to ambiguity in mutable vs const views. Create a
+   * view or copy explicitly instead.
+   */
+  Tensor& operator=(const Tensor&) = delete;
+
   /** Output a short description of the tensor. */
   void short_describe(std::ostream& os) const override
   {

--- a/test/unit_test/tensor/unit_test_dist_tensor.cpp
+++ b/test/unit_test/tensor/unit_test_dist_tensor.cpp
@@ -98,7 +98,7 @@ TEMPLATE_LIST_TEST_CASE("Distributed tensor metadata is sane",
         REQUIRE_FALSE(tensor.is_const_view());
         REQUIRE(tensor.get_view_type() == ViewType::None);
         REQUIRE(tensor.get_device() == TestType::value);
-        typename DistTensorType::local_tensor_type local_tensor =
+        typename DistTensorType::local_tensor_type& local_tensor =
             tensor.local_tensor();
         REQUIRE(local_tensor.shape() == local_shape);
         if (is_local_empty)
@@ -156,7 +156,7 @@ TEMPLATE_LIST_TEST_CASE("Distributed tensor metadata is sane",
         REQUIRE_FALSE(tensor.is_const_view());
         REQUIRE(tensor.get_view_type() == ViewType::None);
         REQUIRE(tensor.get_device() == TestType::value);
-        typename DistTensorType::local_tensor_type local_tensor =
+        typename DistTensorType::local_tensor_type& local_tensor =
             tensor.local_tensor();
         REQUIRE(local_tensor.shape() == local_shape);
         REQUIRE(local_tensor.dim_types() == tensor_dim_types);
@@ -216,7 +216,7 @@ TEMPLATE_LIST_TEST_CASE("Distributed tensor metadata is sane",
         REQUIRE_FALSE(tensor.is_const_view());
         REQUIRE(tensor.get_view_type() == ViewType::None);
         REQUIRE(tensor.get_device() == TestType::value);
-        typename DistTensorType::local_tensor_type local_tensor =
+        typename DistTensorType::local_tensor_type& local_tensor =
             tensor.local_tensor();
         REQUIRE(local_tensor.shape() == local_shape);
         if (is_local_empty)
@@ -298,7 +298,7 @@ TEMPLATE_LIST_TEST_CASE("Distributed tensor metadata is sane",
         REQUIRE_FALSE(tensor.is_const_view());
         REQUIRE(tensor.get_view_type() == ViewType::None);
         REQUIRE(tensor.get_device() == TestType::value);
-        typename DistTensorType::local_tensor_type local_tensor =
+        typename DistTensorType::local_tensor_type& local_tensor =
             tensor.local_tensor();
         REQUIRE(local_tensor.shape() == local_shape);
         if (is_local_empty)
@@ -382,7 +382,7 @@ TEMPLATE_LIST_TEST_CASE("Empty distributed tensor metadata is sane",
       REQUIRE_FALSE(tensor.is_const_view());
       REQUIRE(tensor.get_view_type() == ViewType::None);
       REQUIRE(tensor.get_device() == TestType::value);
-      typename DistTensorType::local_tensor_type local_tensor =
+      typename DistTensorType::local_tensor_type& local_tensor =
           tensor.local_tensor();
       REQUIRE(local_tensor.shape() == ShapeTuple{});
       REQUIRE(local_tensor.dim_types() == DTTuple{});
@@ -463,7 +463,7 @@ TEMPLATE_LIST_TEST_CASE("Resizing distributed tensors works",
         REQUIRE_FALSE(tensor.is_empty());
         REQUIRE(tensor.local_numel() == new_local_numel);
         REQUIRE(tensor.is_local_empty() == is_local_empty);
-        typename DistTensorType::local_tensor_type local_tensor =
+        typename DistTensorType::local_tensor_type& local_tensor =
           tensor.local_tensor();
         REQUIRE(local_tensor.shape() == new_local_shape);
         if (is_local_empty)
@@ -505,7 +505,7 @@ TEMPLATE_LIST_TEST_CASE("Resizing distributed tensors works",
         REQUIRE(tensor.is_empty());
         REQUIRE(tensor.local_numel() == 0);
         REQUIRE(tensor.is_local_empty());
-        typename DistTensorType::local_tensor_type local_tensor =
+        typename DistTensorType::local_tensor_type& local_tensor =
           tensor.local_tensor();
         REQUIRE(local_tensor.shape() == ShapeTuple{});
         REQUIRE(local_tensor.dim_types() == DTTuple{});
@@ -557,7 +557,7 @@ TEMPLATE_LIST_TEST_CASE("Resizing distributed tensors works",
         REQUIRE_FALSE(tensor.is_empty());
         REQUIRE(tensor.local_numel() == new_local_numel);
         REQUIRE(tensor.is_local_empty() == is_local_empty);
-        typename DistTensorType::local_tensor_type local_tensor =
+        typename DistTensorType::local_tensor_type& local_tensor =
           tensor.local_tensor();
         REQUIRE(local_tensor.shape() == new_local_shape);
         if (is_local_empty)
@@ -598,7 +598,7 @@ TEMPLATE_LIST_TEST_CASE("Writing to distributed tensors works",
         DistTTuple tensor_dist(TuplePad<DistTTuple>(grid.ndim(), dist));
         DistTensorType tensor = DistTensorType(
             Dev, tensor_shape, tensor_dim_types, grid, tensor_dist);
-        typename DistTensorType::local_tensor_type local_tensor =
+        typename DistTensorType::local_tensor_type& local_tensor =
           tensor.local_tensor();
 
         DataType* buf = tensor.data();
@@ -671,7 +671,7 @@ TEMPLATE_LIST_TEST_CASE(
       REQUIRE(tensor.get_view_type() == ViewType::Mutable);
       REQUIRE(tensor.data() == buf.buf);
 
-      typename DistTensorType::local_tensor_type local_tensor =
+      typename DistTensorType::local_tensor_type& local_tensor =
           tensor.local_tensor();
       REQUIRE(local_tensor.shape() == tensor_local_shape);
       REQUIRE(local_tensor.strides() == tensor_local_strides);
@@ -711,7 +711,7 @@ TEMPLATE_LIST_TEST_CASE("Viewing distributed tensors works",
           DistTTuple tensor_dist(TuplePad<DistTTuple>(grid.ndim(), dist));
           DistTensorType tensor = DistTensorType(
               Dev, tensor_shape, tensor_dim_types, grid, tensor_dist);
-          typename DistTensorType::local_tensor_type local_tensor =
+          typename DistTensorType::local_tensor_type& local_tensor =
             tensor.local_tensor();
 
           DataType* buf = tensor.data();
@@ -732,7 +732,7 @@ TEMPLATE_LIST_TEST_CASE("Viewing distributed tensors works",
           REQUIRE(view->get_view_type() == ViewType::Mutable);
           REQUIRE(view->data() == tensor.data());
 
-          typename DistTensorType::local_tensor_type local_view =
+          typename DistTensorType::local_tensor_type& local_view =
               view->local_tensor();
           REQUIRE(local_view.shape() == local_tensor.shape());
           REQUIRE(local_view.dim_types() == local_tensor.dim_types());
@@ -767,7 +767,7 @@ TEMPLATE_LIST_TEST_CASE("Viewing distributed tensors works",
           DistTTuple tensor_dist(TuplePad<DistTTuple>(grid.ndim(), dist));
           DistTensorType tensor = DistTensorType(
               Dev, tensor_shape, tensor_dim_types, grid, tensor_dist);
-          typename DistTensorType::local_tensor_type local_tensor =
+          typename DistTensorType::local_tensor_type& local_tensor =
             tensor.local_tensor();
 
           DataType* buf = tensor.data();
@@ -788,7 +788,7 @@ TEMPLATE_LIST_TEST_CASE("Viewing distributed tensors works",
           REQUIRE(view->get_view_type() == ViewType::Const);
           REQUIRE(view->const_data() == tensor.data());
 
-          typename DistTensorType::local_tensor_type local_view =
+          typename DistTensorType::local_tensor_type& local_view =
               view->local_tensor();
           REQUIRE(local_view.shape() == local_tensor.shape());
           REQUIRE(local_view.dim_types() == local_tensor.dim_types());
@@ -823,7 +823,7 @@ TEMPLATE_LIST_TEST_CASE("Viewing distributed tensors works",
           DistTTuple tensor_dist(TuplePad<DistTTuple>(grid.ndim(), dist));
           DistTensorType tensor = DistTensorType(
               Dev, tensor_shape, tensor_dim_types, grid, tensor_dist);
-          typename DistTensorType::local_tensor_type local_tensor =
+          typename DistTensorType::local_tensor_type& local_tensor =
             tensor.local_tensor();
 
           DataType* buf = tensor.data();
@@ -903,7 +903,7 @@ TEMPLATE_LIST_TEST_CASE("Viewing distributed tensors works",
             REQUIRE(view->data() == local_tensor.get(local_start));
           }
 
-          typename DistTensorType::local_tensor_type local_view =
+          typename DistTensorType::local_tensor_type& local_view =
               view->local_tensor();
           REQUIRE(local_view.shape() == local_shape);
           REQUIRE(local_view.numel() == local_numel);
@@ -979,7 +979,7 @@ TEMPLATE_LIST_TEST_CASE("Viewing distributed tensors works",
           DistTTuple tensor_dist(TuplePad<DistTTuple>(grid.ndim(), dist));
           DistTensorType tensor = DistTensorType(
               Dev, tensor_shape, tensor_dim_types, grid, tensor_dist);
-          typename DistTensorType::local_tensor_type local_tensor =
+          typename DistTensorType::local_tensor_type& local_tensor =
             tensor.local_tensor();
 
           DataType* buf = tensor.data();
@@ -1001,7 +1001,7 @@ TEMPLATE_LIST_TEST_CASE("Viewing distributed tensors works",
           REQUIRE(view->get_view_type() == ViewType::Mutable);
           REQUIRE(view->data() == tensor.data());
 
-          typename DistTensorType::local_tensor_type local_view =
+          typename DistTensorType::local_tensor_type& local_view =
               view->local_tensor();
           REQUIRE(local_view.shape() == local_tensor.shape());
           REQUIRE(local_view.dim_types() == local_tensor.dim_types());
@@ -1036,7 +1036,7 @@ TEMPLATE_LIST_TEST_CASE("Viewing distributed tensors works",
           DistTTuple tensor_dist(TuplePad<DistTTuple>(grid.ndim(), dist));
           DistTensorType tensor = DistTensorType(
               Dev, tensor_shape, tensor_dim_types, grid, tensor_dist);
-          typename DistTensorType::local_tensor_type local_tensor =
+          typename DistTensorType::local_tensor_type& local_tensor =
             tensor.local_tensor();
 
           DataType* buf = tensor.data();
@@ -1078,7 +1078,7 @@ TEMPLATE_LIST_TEST_CASE("Viewing distributed tensors works",
           DistTTuple tensor_dist(TuplePad<DistTTuple>(grid.ndim(), dist));
           DistTensorType tensor = DistTensorType(
               Dev, tensor_shape, tensor_dim_types, grid, tensor_dist);
-          typename DistTensorType::local_tensor_type local_tensor =
+          typename DistTensorType::local_tensor_type& local_tensor =
             tensor.local_tensor();
 
           DataType* buf = tensor.data();
@@ -1141,7 +1141,7 @@ TEMPLATE_LIST_TEST_CASE("Empty distributed tensor views work",
           REQUIRE(view->get_view_type() == ViewType::Mutable);
           REQUIRE(view->data() == nullptr);
 
-          typename DistTensorType::local_tensor_type local_view =
+          typename DistTensorType::local_tensor_type& local_view =
               view->local_tensor();
           REQUIRE(local_view.shape() == ShapeTuple{});
           REQUIRE(local_view.dim_types() == DTTuple{});
@@ -1187,7 +1187,7 @@ TEMPLATE_LIST_TEST_CASE("Empty distributed tensor views work",
           REQUIRE(view->get_view_type() == ViewType::Mutable);
           REQUIRE(view->data() == nullptr);
 
-          typename DistTensorType::local_tensor_type local_view =
+          typename DistTensorType::local_tensor_type& local_view =
               view->local_tensor();
           REQUIRE(local_view.shape() == ShapeTuple{});
           REQUIRE(local_view.dim_types() == DTTuple{});

--- a/test/unit_test/tensor/unit_test_dist_tensor.cpp
+++ b/test/unit_test/tensor/unit_test_dist_tensor.cpp
@@ -321,6 +321,41 @@ TEMPLATE_LIST_TEST_CASE("Distributed tensor metadata is sane",
   }
 }
 
+TEMPLATE_LIST_TEST_CASE("Base distributed tensor metadata is sane",
+                        "[dist-tensor]",
+                        AllDevList)
+{
+  constexpr Device Dev = TestType::value;
+  using DistTensorType = DistTensor<DataType>;
+
+  Comm& comm = get_comm_or_skip(1);
+  ProcessorGrid grid = ProcessorGrid(comm, ShapeTuple{1});
+  std::unique_ptr<BaseDistTensor> tensor =
+      std::make_unique<DistTensorType>(Dev,
+                                       ShapeTuple{8},
+                                       DTTuple{DT::Any},
+                                       grid,
+                                       DistTTuple{Distribution::Block});
+  REQUIRE(tensor->shape() == ShapeTuple{8});
+  REQUIRE(tensor->dim_types() == DTTuple{DT::Any});
+  REQUIRE(tensor->local_shape() == ShapeTuple{8});
+  REQUIRE(tensor->proc_grid() == grid);
+  REQUIRE(tensor->distribution() == DistTTuple{Distribution::Block});
+  REQUIRE(tensor->shape(0) == 8);
+  REQUIRE(tensor->dim_type(0) == DT::Any);
+  REQUIRE(tensor->distribution(0) == Distribution::Block);
+  REQUIRE(tensor->local_shape(0) == 8);
+  REQUIRE(tensor->ndim() == 1);
+  REQUIRE(tensor->numel() == 8);
+  REQUIRE_FALSE(tensor->is_empty());
+  REQUIRE(tensor->local_numel() == 8);
+  REQUIRE_FALSE(tensor->is_local_empty());
+  REQUIRE_FALSE(tensor->is_view());
+  REQUIRE_FALSE(tensor->is_const_view());
+  REQUIRE(tensor->get_view_type() == ViewType::None);
+  REQUIRE(tensor->get_device() == TestType::value);
+}
+
 TEMPLATE_LIST_TEST_CASE("Empty distributed tensor metadata is sane",
                         "[dist-tensor]",
                         AllDevList)

--- a/test/unit_test/tensor/unit_test_hydrogen_interop.cpp
+++ b/test/unit_test/tensor/unit_test_hydrogen_interop.cpp
@@ -126,35 +126,35 @@ TEST_CASE("is_chw_packed predicate", "[tensor][utilities]")
         CHECK_FALSE(tensor.is_contiguous());
         CHECK_FALSE(is_chw_packed(tensor));
 
-        TensorType tensor2 = TensorType{
+        tensor = TensorType{
             Dev,
             mock_data,
             {7, 6, 5, 4, 3},
             {h2::DT::Any, h2::DT::Any, h2::DT::Any, h2::DT::Any, h2::DT::Any},
             {1, 8, 48, 240, 960},
             h2::ComputeStream{Dev}};
-        CHECK_FALSE(tensor2.is_contiguous());
-        CHECK_FALSE(is_chw_packed(tensor2));
+        CHECK_FALSE(tensor.is_contiguous());
+        CHECK_FALSE(is_chw_packed(tensor));
 
-        TensorType tensor3 = TensorType{
+        tensor = TensorType{
             Dev,
             mock_data,
             {7, 6, 5, 4, 3},
             {h2::DT::Any, h2::DT::Any, h2::DT::Any, h2::DT::Any, h2::DT::Any},
             {1, 7, 43, 215, 860},
             h2::ComputeStream{Dev}};
-        CHECK_FALSE(tensor3.is_contiguous());
-        CHECK_FALSE(is_chw_packed(tensor3));
+        CHECK_FALSE(tensor.is_contiguous());
+        CHECK_FALSE(is_chw_packed(tensor));
 
-        TensorType tensor4 = TensorType{
+        tensor = TensorType{
             Dev,
             mock_data,
             {7, 6, 5, 4, 3},
             {h2::DT::Any, h2::DT::Any, h2::DT::Any, h2::DT::Any, h2::DT::Any},
             {1, 7, 42, 211, 844},
             h2::ComputeStream{Dev}};
-        CHECK_FALSE(tensor4.is_contiguous());
-        CHECK_FALSE(is_chw_packed(tensor4));
+        CHECK_FALSE(tensor.is_contiguous());
+        CHECK_FALSE(is_chw_packed(tensor));
     }
 }
 

--- a/test/unit_test/tensor/unit_test_hydrogen_interop.cpp
+++ b/test/unit_test/tensor/unit_test_hydrogen_interop.cpp
@@ -126,35 +126,35 @@ TEST_CASE("is_chw_packed predicate", "[tensor][utilities]")
         CHECK_FALSE(tensor.is_contiguous());
         CHECK_FALSE(is_chw_packed(tensor));
 
-        tensor = TensorType{
+        TensorType tensor2 = TensorType{
             Dev,
             mock_data,
             {7, 6, 5, 4, 3},
             {h2::DT::Any, h2::DT::Any, h2::DT::Any, h2::DT::Any, h2::DT::Any},
             {1, 8, 48, 240, 960},
             h2::ComputeStream{Dev}};
-        CHECK_FALSE(tensor.is_contiguous());
-        CHECK_FALSE(is_chw_packed(tensor));
+        CHECK_FALSE(tensor2.is_contiguous());
+        CHECK_FALSE(is_chw_packed(tensor2));
 
-        tensor = TensorType{
+        TensorType tensor3 = TensorType{
             Dev,
             mock_data,
             {7, 6, 5, 4, 3},
             {h2::DT::Any, h2::DT::Any, h2::DT::Any, h2::DT::Any, h2::DT::Any},
             {1, 7, 43, 215, 860},
             h2::ComputeStream{Dev}};
-        CHECK_FALSE(tensor.is_contiguous());
-        CHECK_FALSE(is_chw_packed(tensor));
+        CHECK_FALSE(tensor3.is_contiguous());
+        CHECK_FALSE(is_chw_packed(tensor3));
 
-        tensor = TensorType{
+        TensorType tensor4 = TensorType{
             Dev,
             mock_data,
             {7, 6, 5, 4, 3},
             {h2::DT::Any, h2::DT::Any, h2::DT::Any, h2::DT::Any, h2::DT::Any},
             {1, 7, 42, 211, 844},
             h2::ComputeStream{Dev}};
-        CHECK_FALSE(tensor.is_contiguous());
-        CHECK_FALSE(is_chw_packed(tensor));
+        CHECK_FALSE(tensor4.is_contiguous());
+        CHECK_FALSE(is_chw_packed(tensor4));
     }
 }
 

--- a/test/unit_test/tensor/unit_test_tensor.cpp
+++ b/test/unit_test/tensor/unit_test_tensor.cpp
@@ -8,6 +8,8 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_template_test_macros.hpp>
 
+#include <memory>
+
 #include "h2/tensor/tensor.hpp"
 #include "h2/utils/typename.hpp"
 #include "utils.hpp"
@@ -185,13 +187,62 @@ TEMPLATE_LIST_TEST_CASE("Tensor metadata is sane", "[tensor]", AllDevList)
   REQUIRE_FALSE(const_tensor.is_empty());
   REQUIRE(const_tensor.is_contiguous());
   REQUIRE_FALSE(const_tensor.is_view());
-  REQUIRE_FALSE(tensor.is_const_view());
-  REQUIRE(tensor.get_view_type() == ViewType::None);
+  REQUIRE_FALSE(const_tensor.is_const_view());
+  REQUIRE(const_tensor.get_view_type() == ViewType::None);
   REQUIRE(const_tensor.get_device() == TestType::value);
   REQUIRE(const_tensor.data() != nullptr);
   REQUIRE(const_tensor.const_data() != nullptr);
   REQUIRE(const_tensor.get({0, 0}) == const_tensor.data());
   REQUIRE_FALSE(const_tensor.is_lazy());
+}
+
+TEMPLATE_LIST_TEST_CASE("Base tensor metadata is sane",
+                        "[tensor]",
+                        AllDevList)
+{
+  constexpr Device Dev = TestType::value;
+  using TensorType = Tensor<DataType>;
+
+  std::unique_ptr<BaseTensor> tensor = std::make_unique<TensorType>(
+      Dev, ShapeTuple{4, 6}, DTTuple{DT::Sample, DT::Any});
+  REQUIRE(tensor->shape() == ShapeTuple{4, 6});
+  REQUIRE(tensor->shape(0) == 4);
+  REQUIRE(tensor->shape(1) == 6);
+  REQUIRE(tensor->dim_types() == DTTuple{DT::Sample, DT::Any});
+  REQUIRE(tensor->dim_type(0) == DT::Sample);
+  REQUIRE(tensor->dim_type(1) == DT::Any);
+  REQUIRE(tensor->strides() == StrideTuple{1, 4});
+  REQUIRE(tensor->stride(0) == 1);
+  REQUIRE(tensor->stride(1) == 4);
+  REQUIRE(tensor->ndim() == 2);
+  REQUIRE(tensor->numel() == 4*6);
+  REQUIRE_FALSE(tensor->is_empty());
+  REQUIRE(tensor->is_contiguous());
+  REQUIRE_FALSE(tensor->is_view());
+  REQUIRE_FALSE(tensor->is_const_view());
+  REQUIRE(tensor->get_view_type() == ViewType::None);
+  REQUIRE(tensor->get_device() == TestType::value);
+
+  std::unique_ptr<const BaseTensor> const_tensor =
+      std::make_unique<const TensorType>(
+          Dev, ShapeTuple{4, 6}, DTTuple{DT::Sample, DT::Any});
+  REQUIRE(const_tensor->shape() == ShapeTuple{4, 6});
+  REQUIRE(const_tensor->shape(0) == 4);
+  REQUIRE(const_tensor->shape(1) == 6);
+  REQUIRE(const_tensor->dim_types() == DTTuple{DT::Sample, DT::Any});
+  REQUIRE(const_tensor->dim_type(0) == DT::Sample);
+  REQUIRE(const_tensor->dim_type(1) == DT::Any);
+  REQUIRE(const_tensor->strides() == StrideTuple{1, 4});
+  REQUIRE(const_tensor->stride(0) == 1);
+  REQUIRE(const_tensor->stride(1) == 4);
+  REQUIRE(const_tensor->ndim() == 2);
+  REQUIRE(const_tensor->numel() == 4*6);
+  REQUIRE_FALSE(const_tensor->is_empty());
+  REQUIRE(const_tensor->is_contiguous());
+  REQUIRE_FALSE(const_tensor->is_view());
+  REQUIRE_FALSE(const_tensor->is_const_view());
+  REQUIRE(const_tensor->get_view_type() == ViewType::None);
+  REQUIRE(const_tensor->get_device() == TestType::value);
 }
 
 TEMPLATE_LIST_TEST_CASE("Empty tensor metadata is sane", "[tensor]", AllDevList)


### PR DESCRIPTION
* Adds some unit tests for metadata on `BaseTensor` and `BaseDistTensor`.
* Add a sanity check to prevent copying non-trivial types (it is unsafe to do so with `memcpy`-like methods).
* Disable tensor copy construction/assignment as it causes ambiguities for views. Explicitly enable default move construction/assignment to ensure this works.