### PR TITLE
Add additional paths for finding ROCm HSA runtime

### DIFF
--- a/cmake/config/DiHydrogenConfig.cmake.in
+++ b/cmake/config/DiHydrogenConfig.cmake.in
@@ -60,7 +60,7 @@ endif ()
 if (H2_HAS_ROCM)
   find_dependency(hip)
   find_library(HSA_LIBRARY hsa-runtime64
-    HINTS ${ROCM_PATH}/hsa $ENV{ROCM_PATH}/hsa
+    HINTS ${ROCM_PATH}/hsa $ENV{ROCM_PATH}/hsa ${ROCM_PATH} $ENV{ROCM_PATH}
     PATH_SUFFIXES lib lib64
     DOC "HSA runtime library"
     NO_DEFAULT_PATH)


### PR DESCRIPTION
Starting in ROCm 6.x the location of the HSA runtime library has moved
out of the hsa subdirectory into the top level lib directory.