### PR TITLE
Remove Catch2 test cases from CTest

### DIFF
--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -83,8 +83,12 @@ set_target_properties(SeqCatchTests
   CXX_EXTENSIONS OFF
   CXX_STANDARD_REQUIRED ON)
 
-# Not 100% sold on this
-catch_discover_tests(SeqCatchTests)
+# Add the test. Outputs to console (for CTest's default logging) and
+# in JUnit format for ease of CI integration
+add_test(
+  NAME "Sequential Catch2 Tests"
+  COMMAND $<TARGET_FILE:SeqCatchTests> -r console -r JUnit::out=seq.xml
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 if (H2_CODE_COVERAGE)
   add_code_coverage(SeqCatchTests coverage)


### PR DESCRIPTION
The old version required the SeqCatchTests binary to be runable at build time, which was not always the case (the current code still isn't cross-comile-safe, but we don't cross-compile ever). Moreover, the failures we saw from this were often false positives (e.g., `LD_LIBRARY_PATH` was incomplete during the build phase but wouldn't be under normal circumstances).

The new version just integrates the entire `SeqCatchTests` driver with CTest. This means it shows as a single CTest test, but it doesn't have to run at build time. The test will generate "the usual" stdout/stderr for integration with CTest's default logging and it will output an XML in JUnit format to make CI integration easier. The XML output will be written to `<build_dir>/test/unit_test/seq.xml`.