### PR TITLE
Clone and initial copy support for DistTensor

### DIFF
--- a/include/h2/tensor/CMakeLists.txt
+++ b/include/h2/tensor/CMakeLists.txt
@@ -14,6 +14,7 @@ h2_add_sources_to_target_and_install(
   INSTALL_PREFIX "${H2_CURRENT_INSTALL_PREFIX}"
   SOURCES
   copy.hpp
+  copy_buffer.hpp
   dist_tensor_base.hpp
   dist_tensor.hpp
   dist_types.hpp

--- a/include/h2/tensor/copy.hpp
+++ b/include/h2/tensor/copy.hpp
@@ -15,73 +15,20 @@
 
 #include <h2_config.hpp>
 
-#include <cstring>
 #include <memory>
 #include <type_traits>
 
+#include "h2/tensor/copy_buffer.hpp"
 #include "h2/tensor/tensor_types.hpp"
 #include "h2/tensor/tensor.hpp"
 #include "h2/tensor/dist_tensor.hpp"
 
 #ifdef H2_HAS_GPU
 #include "h2/gpu/runtime.hpp"
-#include "h2/gpu/memory_utils.hpp"
 #endif
 
 namespace h2
 {
-
-// Low-level copy routines operating on buffers (raw pointers):
-
-/**
- * Copy count elements from src to dst.
- *
- * If GPU buffers are involved, this will be asynchronous.
- */
-template <typename T>
-void copy_buffer(T* dst,
-                 const ComputeStream& dst_stream,
-                 const T* src,
-                 const ComputeStream& src_stream,
-                 std::size_t count)
-{
-  H2_ASSERT_DEBUG(count == 0 || (dst != nullptr && src != nullptr),
-                  "Null buffers");
-  // TODO: Debug check: Assert buffers do not overlap.
-  static_assert(
-      std::is_trivially_copyable_v<T>,
-      "Attempt to copy a buffer with a type that is not trivially copyable");
-  const Device src_dev = src_stream.get_device();
-  const Device dst_dev = dst_stream.get_device();
-  if (src_dev == Device::CPU && dst_dev == Device::CPU)
-  {
-    std::memcpy(dst, src, count * sizeof(T));
-  }
-#ifdef H2_HAS_GPU
-  else if (src_dev == Device::GPU && dst_dev == Device::GPU)
-  {
-    auto stream = create_multi_sync(dst_stream, src_stream);
-    gpu::mem_copy<T>(dst, src, count, dst_stream.get_stream<Device::GPU>());
-  }
-  else if (src_dev == Device::CPU && dst_dev == Device::GPU)
-  {
-    // No sync needed in this case: The CPU is always synchronized and
-    // the copy will be enqueued on the destination GPU stream.
-    gpu::mem_copy<T>(dst, src, count, dst_stream.get_stream<Device::GPU>());
-  }
-  else if (src_dev == Device::GPU && dst_dev == Device::CPU)
-  {
-    // No sync needed: Ditto.
-    gpu::mem_copy<T>(dst, src, count, src_stream.get_stream<Device::GPU>());
-  }
-#endif
-  else
-  {
-    throw H2Exception("Unknown device combination ", src_dev, " and ", dst_dev);
-  }
-}
-
-// General copy routines:
 
 namespace internal
 {

--- a/include/h2/tensor/copy_buffer.hpp
+++ b/include/h2/tensor/copy_buffer.hpp
@@ -55,7 +55,7 @@ void copy_buffer(T* dst,
   else if (src_dev == Device::GPU && dst_dev == Device::GPU)
   {
     auto stream = create_multi_sync(dst_stream, src_stream);
-    gpu::mem_copy<T>(dst, src, count, dst_stream.get_stream<Device::GPU>());
+    gpu::mem_copy<T>(dst, src, count, stream.get_stream<Device::GPU>());
   }
   else if (src_dev == Device::CPU && dst_dev == Device::GPU)
   {

--- a/include/h2/tensor/copy_buffer.hpp
+++ b/include/h2/tensor/copy_buffer.hpp
@@ -55,7 +55,7 @@ void copy_buffer(T* dst,
   else if (src_dev == Device::GPU && dst_dev == Device::GPU)
   {
     auto stream = create_multi_sync(dst_stream, src_stream);
-    gpu::mem_copy<T>(dst, src, count, stream.get_stream<Device::GPU>());
+    gpu::mem_copy<T>(dst, src, count, dst_stream.get_stream<Device::GPU>());
   }
   else if (src_dev == Device::CPU && dst_dev == Device::GPU)
   {

--- a/include/h2/tensor/copy_buffer.hpp
+++ b/include/h2/tensor/copy_buffer.hpp
@@ -1,0 +1,78 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+/** @file
+ *
+ * Low-level routines to copy raw buffers.
+ */
+
+
+#include <h2_config.hpp>
+
+#include <cstring>
+#include <type_traits>
+
+#include "h2/core/sync.hpp"
+
+#ifdef H2_HAS_GPU
+#include "h2/gpu/memory_utils.hpp"
+#endif
+
+namespace h2
+{
+
+/**
+ * Copy count elements from src to dst.
+ *
+ * If GPU buffers are involved, this will be asynchronous.
+ */
+template <typename T>
+void copy_buffer(T* dst,
+                 const ComputeStream& dst_stream,
+                 const T* src,
+                 const ComputeStream& src_stream,
+                 std::size_t count)
+{
+  H2_ASSERT_DEBUG(count == 0 || (dst != nullptr && src != nullptr),
+                  "Null buffers");
+  // TODO: Debug check: Assert buffers do not overlap.
+  static_assert(
+      std::is_trivially_copyable_v<T>,
+      "Attempt to copy a buffer with a type that is not trivially copyable");
+  const Device src_dev = src_stream.get_device();
+  const Device dst_dev = dst_stream.get_device();
+  if (src_dev == Device::CPU && dst_dev == Device::CPU)
+  {
+    std::memcpy(dst, src, count * sizeof(T));
+  }
+#ifdef H2_HAS_GPU
+  else if (src_dev == Device::GPU && dst_dev == Device::GPU)
+  {
+    auto stream = create_multi_sync(dst_stream, src_stream);
+    gpu::mem_copy<T>(dst, src, count, dst_stream.get_stream<Device::GPU>());
+  }
+  else if (src_dev == Device::CPU && dst_dev == Device::GPU)
+  {
+    // No sync needed in this case: The CPU is always synchronized and
+    // the copy will be enqueued on the destination GPU stream.
+    gpu::mem_copy<T>(dst, src, count, dst_stream.get_stream<Device::GPU>());
+  }
+  else if (src_dev == Device::GPU && dst_dev == Device::CPU)
+  {
+    // No sync needed: Ditto.
+    gpu::mem_copy<T>(dst, src, count, src_stream.get_stream<Device::GPU>());
+  }
+#endif
+  else
+  {
+    throw H2Exception("Unknown device combination ", src_dev, " and ", dst_dev);
+  }
+}
+
+}  // namespace h2

--- a/include/h2/tensor/dist_tensor.hpp
+++ b/include/h2/tensor/dist_tensor.hpp
@@ -123,6 +123,22 @@ public:
                      Passkey<DistTensor<T>>{})
   {}
 
+  /** Internal constructor for cloning. */
+  DistTensor(Tensor<T>& local_tensor_clone,
+             const ShapeTuple& shape_,
+             const DimensionTypeTuple& dim_types_,
+             ProcessorGrid grid_,
+             const DistributionTypeTuple& dist_types_,
+             Passkey<DistTensor<T>>)
+      : BaseDistTensor(ViewType::None,
+                       shape_,
+                       dim_types_,
+                       grid_,
+                       dist_types_,
+                       local_tensor_clone.shape()),
+        tensor_local(std::move(local_tensor_clone))
+  {}
+
   virtual ~DistTensor() = default;
 
   /**
@@ -146,6 +162,22 @@ public:
 
   /** Move assignment */
   DistTensor& operator=(DistTensor&&) = default;
+
+  /**
+   * Return an exact copy of this tensor.
+   *
+   *
+   */
+  std::unique_ptr<DistTensor<T>> clone() const
+  {
+    auto local_tensor_clone = tensor_local.clone();
+    return std::make_unique<DistTensor<T>>(*local_tensor_clone,
+                                           shape(),
+                                           dim_types(),
+                                           proc_grid(),
+                                           distribution(),
+                                           Passkey<DistTensor<T>>{});
+  }
 
   /** Output a short description of the tensor. */
   void short_describe(std::ostream& os) const override

--- a/test/unit_test/tensor/CMakeLists.txt
+++ b/test/unit_test/tensor/CMakeLists.txt
@@ -25,6 +25,7 @@ if (H2_HAS_GPU)
 endif ()
 
 target_sources(MPICatchTests PRIVATE
+  unit_test_dist_copy.cpp
   unit_test_dist_tensor.cpp
   unit_test_hydrogen_interop_distmat.cpp
   unit_test_proc_grid.cpp

--- a/test/unit_test/tensor/unit_test_copy.cpp
+++ b/test/unit_test/tensor/unit_test_copy.cpp
@@ -30,8 +30,8 @@ TEMPLATE_LIST_TEST_CASE("Buffer copy works", "[tensor][copy]", AllDevPairsList)
 
   for (std::size_t i = 0; i < buf_size; ++i)
   {
-    write_ele<SrcDev>(src.buf, i, src_val);
-    write_ele<DstDev>(dst.buf, i, dst_val);
+    write_ele<SrcDev>(src.buf, i, src_val, src_stream);
+    write_ele<DstDev>(dst.buf, i, dst_val, dst_stream);
   }
 
   REQUIRE_NOTHROW(copy_buffer(
@@ -40,9 +40,9 @@ TEMPLATE_LIST_TEST_CASE("Buffer copy works", "[tensor][copy]", AllDevPairsList)
   for (std::size_t i = 0; i < buf_size; ++i)
   {
     // Source is unchanged:
-    REQUIRE(read_ele<SrcDev>(src.buf, i) == src_val);
+    REQUIRE(read_ele<SrcDev>(src.buf, i, src_stream) == src_val);
     // Destination has the source value:
-    REQUIRE(read_ele<DstDev>(dst.buf, i) == src_val);
+    REQUIRE(read_ele<DstDev>(dst.buf, i, dst_stream) == src_val);
   }
 }
 
@@ -66,8 +66,8 @@ TEMPLATE_LIST_TEST_CASE("Same-type tensor copy works",
 
     for (std::size_t i = 0; i < src_tensor.numel(); ++i)
     {
-      write_ele<SrcDev>(src_tensor.data(), i, src_val);
-      write_ele<DstDev>(dst_tensor.data(), i, dst_val);
+      write_ele<SrcDev>(src_tensor.data(), i, src_val, src_tensor.get_stream());
+      write_ele<DstDev>(dst_tensor.data(), i, dst_val, dst_tensor.get_stream());
     }
 
     REQUIRE_NOTHROW(copy(dst_tensor, src_tensor));
@@ -84,8 +84,10 @@ TEMPLATE_LIST_TEST_CASE("Same-type tensor copy works",
 
     for (std::size_t i = 0; i < src_tensor.numel(); ++i)
     {
-      REQUIRE(read_ele<SrcDev>(src_tensor.data(), i) == src_val);
-      REQUIRE(read_ele<DstDev>(dst_tensor.data(), i) == src_val);
+      REQUIRE(read_ele<SrcDev>(src_tensor.data(), i, src_tensor.get_stream())
+              == src_val);
+      REQUIRE(read_ele<DstDev>(dst_tensor.data(), i, dst_tensor.get_stream())
+              == src_val);
     }
   }
 
@@ -96,11 +98,11 @@ TEMPLATE_LIST_TEST_CASE("Same-type tensor copy works",
 
     for (std::size_t i = 0; i < src_tensor.numel(); ++i)
     {
-      write_ele<SrcDev>(src_tensor.data(), i, src_val);
+      write_ele<SrcDev>(src_tensor.data(), i, src_val, src_tensor.get_stream());
     }
     for (std::size_t i = 0; i < dst_tensor.numel(); ++i)
     {
-      write_ele<DstDev>(dst_tensor.data(), i, dst_val);
+      write_ele<DstDev>(dst_tensor.data(), i, dst_val, dst_tensor.get_stream());
     }
 
     REQUIRE_NOTHROW(copy(dst_tensor, src_tensor));
@@ -116,11 +118,13 @@ TEMPLATE_LIST_TEST_CASE("Same-type tensor copy works",
 
     for (std::size_t i = 0; i < src_tensor.numel(); ++i)
     {
-      REQUIRE(read_ele<SrcDev>(src_tensor.data(), i) == src_val);
+      REQUIRE(read_ele<SrcDev>(src_tensor.data(), i, src_tensor.get_stream())
+              == src_val);
     }
     for (std::size_t i = 0; i < src_tensor.numel(); ++i)
     {
-      REQUIRE(read_ele<DstDev>(dst_tensor.data(), i) == src_val);
+      REQUIRE(read_ele<DstDev>(dst_tensor.data(), i, dst_tensor.get_stream())
+              == src_val);
     }
   }
 
@@ -145,10 +149,10 @@ TEMPLATE_LIST_TEST_CASE("Same-type tensor copy works",
 
     for (std::size_t i = 0; i < src_tensor.numel(); ++i)
     {
-      write_ele<DstDev>(dst_tensor.data(), i, dst_val);
+      write_ele<DstDev>(dst_tensor.data(), i, dst_val, dst_tensor.get_stream());
     }
     for_ndim(src_tensor.shape(), [&](const ScalarIndexTuple& i) {
-      write_ele<SrcDev>(src_tensor.get(i), 0, src_val);
+      write_ele<SrcDev>(src_tensor.get(i), 0, src_val, src_tensor.get_stream());
     });
 
     REQUIRE_NOTHROW(copy(dst_tensor, src_tensor));
@@ -163,8 +167,10 @@ TEMPLATE_LIST_TEST_CASE("Same-type tensor copy works",
     REQUIRE(src_tensor.data() != dst_tensor.data());
 
     for_ndim(src_tensor.shape(), [&](const ScalarIndexTuple& i) {
-      REQUIRE(read_ele<SrcDev>(src_tensor.get(i)) == src_val);
-      REQUIRE(read_ele<DstDev>(dst_tensor.get(i)) == src_val);
+      REQUIRE(read_ele<SrcDev>(src_tensor.get(i), src_tensor.get_stream())
+              == src_val);
+      REQUIRE(read_ele<DstDev>(dst_tensor.get(i), dst_tensor.get_stream())
+              == src_val);
     });
   }
 }

--- a/test/unit_test/tensor/unit_test_dist_copy.cpp
+++ b/test/unit_test/tensor/unit_test_dist_copy.cpp
@@ -1,0 +1,178 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+
+#include "h2/tensor/tensor.hpp"
+#include "h2/tensor/copy.hpp"
+#include "utils.hpp"
+#include "../mpi_utils.hpp"
+
+using namespace h2;
+
+TEMPLATE_LIST_TEST_CASE("Same-type distributed tensor copy works",
+                        "[dist-tensor][dist-copy]",
+                        AllDevPairsList)
+{
+  constexpr Device SrcDev = meta::tlist::At<TestType, 0>::value;
+  constexpr Device DstDev = meta::tlist::At<TestType, 1>::value;
+  using SrcTensorType = DistTensor<DataType>;
+  using DstTensorType = DistTensor<DataType>;
+  constexpr DataType src_val = static_cast<DataType>(1);
+  constexpr DataType dst_val = static_cast<DataType>(2);
+
+  SECTION("Copying into an existing tensor works without resizing")
+  {
+    for_comms([&](Comm& comm) {
+      for_grid_shapes([&](ShapeTuple grid_shape) {
+        for (Distribution dist : {Distribution::Block,
+                                  Distribution::Replicated,
+                                  Distribution::Single})
+        {
+          ProcessorGrid grid = ProcessorGrid(comm, grid_shape);
+          ShapeTuple tensor_shape(8, 5, 12);
+          tensor_shape.set_size(grid.ndim());
+          DTTuple tensor_dim_types(TuplePad<DTTuple>(grid.ndim(), DT::Any));
+          DistTTuple tensor_dist(TuplePad<DistTTuple>(grid.ndim(), dist));
+          SrcTensorType src_tensor = SrcTensorType(
+              SrcDev, tensor_shape, tensor_dim_types, grid, tensor_dist);
+          DstTensorType dst_tensor = DstTensorType(
+              DstDev, tensor_shape, tensor_dim_types, grid, tensor_dist);
+
+          for (DataIndexType i = 0; i < src_tensor.local_numel(); ++i)
+          {
+            write_ele<SrcDev>(src_tensor.data(), i, src_val);
+          }
+          for (DataIndexType i = 0; i < dst_tensor.local_numel(); ++i)
+          {
+            write_ele<DstDev>(dst_tensor.data(), i, dst_val);
+          }
+
+          DataType* dst_orig_data = dst_tensor.data();
+
+          REQUIRE_NOTHROW(copy(dst_tensor, src_tensor));
+
+          REQUIRE(dst_tensor.shape() == tensor_shape);
+          REQUIRE(dst_tensor.local_shape() == src_tensor.local_shape());
+          REQUIRE(dst_tensor.dim_types() == tensor_dim_types);
+          REQUIRE(dst_tensor.distribution() == tensor_dist);
+          REQUIRE(dst_tensor.numel() == src_tensor.numel());
+          REQUIRE_FALSE(dst_tensor.is_empty());
+          REQUIRE(dst_tensor.is_local_empty() == src_tensor.is_local_empty());
+          REQUIRE_FALSE(dst_tensor.is_view());
+          if (src_tensor.is_local_empty())
+          {
+            REQUIRE(dst_tensor.data() == nullptr);
+          }
+          else
+          {
+            REQUIRE(dst_tensor.data() != src_tensor.data());
+          }
+          REQUIRE(dst_tensor.data() == dst_orig_data);
+
+          for (DataIndexType i = 0; i < src_tensor.local_numel(); ++i)
+          {
+            REQUIRE(read_ele<SrcDev>(src_tensor.data(), i) == src_val);
+            REQUIRE(read_ele<DstDev>(dst_tensor.data(), i) == src_val);
+          }
+        }
+      }, comm);
+    });
+  }
+
+  SECTION("Copying into a different-sized tensor works")
+  {
+    for_comms([&](Comm& comm) {
+      for_grid_shapes([&](ShapeTuple grid_shape) {
+        for (Distribution src_dist : {Distribution::Block,
+                                      Distribution::Replicated,
+                                      Distribution::Single})
+        {
+          for (Distribution dst_dist : {Distribution::Block,
+                                        Distribution::Replicated,
+                                        Distribution::Single})
+          {
+            ProcessorGrid grid = ProcessorGrid(comm, grid_shape);
+            ShapeTuple src_tensor_shape(8, 5, 12);
+            src_tensor_shape.set_size(grid.ndim());
+            ShapeTuple dst_tensor_shape(2, 19, 4);
+            dst_tensor_shape.set_size(grid.ndim());
+            DTTuple tensor_dim_types(TuplePad<DTTuple>(grid.ndim(), DT::Any));
+            DistTTuple src_tensor_dist(
+                TuplePad<DistTTuple>(grid.ndim(), src_dist));
+            DistTTuple dst_tensor_dist(
+                TuplePad<DistTTuple>(grid.ndim(), dst_dist));
+            SrcTensorType src_tensor = SrcTensorType(
+              SrcDev, src_tensor_shape, tensor_dim_types, grid, src_tensor_dist);
+            DstTensorType dst_tensor = DstTensorType(
+              DstDev, dst_tensor_shape, tensor_dim_types, grid, dst_tensor_dist);
+
+            for (DataIndexType i = 0; i < src_tensor.local_numel(); ++i)
+            {
+              write_ele<SrcDev>(src_tensor.data(), i, src_val);
+            }
+            for (DataIndexType i = 0; i < dst_tensor.local_numel(); ++i)
+            {
+              write_ele<DstDev>(dst_tensor.data(), i, dst_val);
+            }
+
+            REQUIRE_NOTHROW(copy(dst_tensor, src_tensor));
+
+            REQUIRE(dst_tensor.shape() == src_tensor_shape);
+            REQUIRE(dst_tensor.local_shape() == src_tensor.local_shape());
+            REQUIRE(dst_tensor.dim_types() == tensor_dim_types);
+            REQUIRE(dst_tensor.distribution() == src_tensor_dist);
+            REQUIRE(dst_tensor.numel() == src_tensor.numel());
+            REQUIRE_FALSE(dst_tensor.is_empty());
+            REQUIRE(dst_tensor.is_local_empty() == src_tensor.is_local_empty());
+            REQUIRE_FALSE(dst_tensor.is_view());
+            if (src_tensor.is_local_empty())
+            {
+              REQUIRE(dst_tensor.data() == nullptr);
+            }
+            else
+            {
+              REQUIRE(dst_tensor.data() != src_tensor.data());
+            }
+
+            for (DataIndexType i = 0; i < src_tensor.local_numel(); ++i)
+            {
+              REQUIRE(read_ele<SrcDev>(src_tensor.data(), i) == src_val);
+              REQUIRE(read_ele<DstDev>(dst_tensor.data(), i) == src_val);
+            }
+          }
+        }
+      }, comm);
+    });
+  }
+
+  SECTION("Copying an empty tensor works")
+  {
+    for_comms([&](Comm& comm) {
+      for_grid_shapes([&](ShapeTuple grid_shape) {
+        for (Distribution dist : {Distribution::Block,
+                                  Distribution::Replicated,
+                                  Distribution::Single})
+        {
+          ProcessorGrid grid = ProcessorGrid(comm, grid_shape);
+          ShapeTuple tensor_shape(8, 5, 12);
+          tensor_shape.set_size(grid.ndim());
+          DTTuple tensor_dim_types(TuplePad<DTTuple>(grid.ndim(), DT::Any));
+          DistTTuple tensor_dist(TuplePad<DistTTuple>(grid.ndim(), dist));
+          SrcTensorType src_tensor = SrcTensorType(SrcDev, grid);
+          DstTensorType dst_tensor = DstTensorType(
+              DstDev, tensor_shape, tensor_dim_types, grid, tensor_dist);
+
+          REQUIRE_NOTHROW(copy(dst_tensor, src_tensor));
+
+          REQUIRE(dst_tensor.is_empty());
+        }
+      }, comm);
+    });
+  }
+}

--- a/test/unit_test/tensor/unit_test_dist_copy.cpp
+++ b/test/unit_test/tensor/unit_test_dist_copy.cpp
@@ -46,11 +46,13 @@ TEMPLATE_LIST_TEST_CASE("Same-type distributed tensor copy works",
 
           for (DataIndexType i = 0; i < src_tensor.local_numel(); ++i)
           {
-            write_ele<SrcDev>(src_tensor.data(), i, src_val);
+            write_ele<SrcDev>(
+              src_tensor.data(), i, src_val, src_tensor.get_stream());
           }
           for (DataIndexType i = 0; i < dst_tensor.local_numel(); ++i)
           {
-            write_ele<DstDev>(dst_tensor.data(), i, dst_val);
+            write_ele<DstDev>(
+              dst_tensor.data(), i, dst_val, dst_tensor.get_stream());
           }
 
           DataType* dst_orig_data = dst_tensor.data();
@@ -77,8 +79,12 @@ TEMPLATE_LIST_TEST_CASE("Same-type distributed tensor copy works",
 
           for (DataIndexType i = 0; i < src_tensor.local_numel(); ++i)
           {
-            REQUIRE(read_ele<SrcDev>(src_tensor.data(), i) == src_val);
-            REQUIRE(read_ele<DstDev>(dst_tensor.data(), i) == src_val);
+            REQUIRE(
+              read_ele<SrcDev>(src_tensor.data(), i, src_tensor.get_stream())
+              == src_val);
+            REQUIRE(
+              read_ele<DstDev>(dst_tensor.data(), i, dst_tensor.get_stream())
+              == src_val);
           }
         }
       }, comm);
@@ -114,11 +120,13 @@ TEMPLATE_LIST_TEST_CASE("Same-type distributed tensor copy works",
 
             for (DataIndexType i = 0; i < src_tensor.local_numel(); ++i)
             {
-              write_ele<SrcDev>(src_tensor.data(), i, src_val);
+              write_ele<SrcDev>(
+                src_tensor.data(), i, src_val, src_tensor.get_stream());
             }
             for (DataIndexType i = 0; i < dst_tensor.local_numel(); ++i)
             {
-              write_ele<DstDev>(dst_tensor.data(), i, dst_val);
+              write_ele<DstDev>(
+                dst_tensor.data(), i, dst_val, dst_tensor.get_stream());
             }
 
             REQUIRE_NOTHROW(copy(dst_tensor, src_tensor));
@@ -142,8 +150,12 @@ TEMPLATE_LIST_TEST_CASE("Same-type distributed tensor copy works",
 
             for (DataIndexType i = 0; i < src_tensor.local_numel(); ++i)
             {
-              REQUIRE(read_ele<SrcDev>(src_tensor.data(), i) == src_val);
-              REQUIRE(read_ele<DstDev>(dst_tensor.data(), i) == src_val);
+              REQUIRE(
+                read_ele<SrcDev>(src_tensor.data(), i, src_tensor.get_stream())
+                == src_val);
+              REQUIRE(
+                read_ele<DstDev>(dst_tensor.data(), i, dst_tensor.get_stream())
+                == src_val);
             }
           }
         }

--- a/test/unit_test/tensor/unit_test_dist_tensor.cpp
+++ b/test/unit_test/tensor/unit_test_dist_tensor.cpp
@@ -604,12 +604,13 @@ TEMPLATE_LIST_TEST_CASE("Writing to distributed tensors works",
         DataType* buf = tensor.data();
         for (DataIndexType i = 0; i < tensor.local_numel(); ++i)
         {
-          write_ele<Dev>(buf, i, static_cast<DataType>(i));
+          write_ele<Dev>(buf, i, static_cast<DataType>(i), tensor.get_stream());
         }
 
         DataIndexType idx = 0;
         for_ndim(local_tensor.shape(), [&](ScalarIndexTuple c) {
-          REQUIRE(read_ele<Dev>(local_tensor.get(c)) == idx);
+          REQUIRE(read_ele<Dev>(local_tensor.get(c), tensor.get_stream())
+                  == idx);
           ++idx;
         });
       }
@@ -645,7 +646,8 @@ TEMPLATE_LIST_TEST_CASE(
       DeviceBuf<DataType, Dev> buf(buf_size);
       for (std::size_t i = 0; i < buf_size; ++i)
       {
-        write_ele<Dev>(buf.buf, i, static_cast<DataType>(i));
+        write_ele<Dev>(
+          buf.buf, i, static_cast<DataType>(i), ComputeStream{Dev});
       }
 
       DistTensorType tensor(Dev,
@@ -677,11 +679,13 @@ TEMPLATE_LIST_TEST_CASE(
       REQUIRE(local_tensor.strides() == tensor_local_strides);
       for (std::size_t i = 0; i < local_tensor.numel(); ++i)
       {
-        REQUIRE(read_ele<Dev>(local_tensor.data(), i) == i);
+        REQUIRE(read_ele<Dev>(local_tensor.data(), i, tensor.get_stream())
+                == i);
       }
       DataIndexType idx = 0;
       for_ndim(local_tensor.shape(), [&](ScalarIndexTuple c) {
-        REQUIRE(read_ele<Dev>(local_tensor.get(c)) == idx);
+        REQUIRE(read_ele<Dev>(local_tensor.get(c), tensor.get_stream())
+                == idx);
         ++idx;
       });
     }, comm, 0, 3);
@@ -717,7 +721,8 @@ TEMPLATE_LIST_TEST_CASE("Viewing distributed tensors works",
           DataType* buf = tensor.data();
           for (DataIndexType i = 0; i < tensor.local_numel(); ++i)
           {
-            write_ele<Dev>(buf, i, static_cast<DataType>(i));
+            write_ele<Dev>(
+              buf, i, static_cast<DataType>(i), tensor.get_stream());
           }
 
           std::unique_ptr<DistTensorType> view = tensor.view();
@@ -744,7 +749,7 @@ TEMPLATE_LIST_TEST_CASE("Viewing distributed tensors works",
 
           for (DataIndexType i = 0; i < view->local_numel(); ++i)
           {
-            REQUIRE(read_ele<Dev>(view->data(), i) == i);
+            REQUIRE(read_ele<Dev>(view->data(), i, view->get_stream()) == i);
           }
         }
       }, comm, 0, 3);
@@ -773,7 +778,8 @@ TEMPLATE_LIST_TEST_CASE("Viewing distributed tensors works",
           DataType* buf = tensor.data();
           for (DataIndexType i = 0; i < tensor.local_numel(); ++i)
           {
-            write_ele<Dev>(buf, i, static_cast<DataType>(i));
+            write_ele<Dev>(
+              buf, i, static_cast<DataType>(i), tensor.get_stream());
           }
 
           std::unique_ptr<DistTensorType> view = tensor.const_view();
@@ -800,7 +806,8 @@ TEMPLATE_LIST_TEST_CASE("Viewing distributed tensors works",
 
           for (DataIndexType i = 0; i < view->local_numel(); ++i)
           {
-            REQUIRE(read_ele<Dev>(view->const_data(), i) == i);
+            REQUIRE(read_ele<Dev>(view->const_data(), i, view->get_stream())
+                    == i);
           }
         }
       }, comm, 0, 3);
@@ -829,7 +836,8 @@ TEMPLATE_LIST_TEST_CASE("Viewing distributed tensors works",
           DataType* buf = tensor.data();
           for (DataIndexType i = 0; i < tensor.local_numel(); ++i)
           {
-            write_ele<Dev>(buf, i, static_cast<DataType>(i));
+            write_ele<Dev>(
+              buf, i, static_cast<DataType>(i), tensor.get_stream());
           }
 
           IndexRangeTuple view_indices({IRng(0, 4), IRng(2, 4), IRng(1, 2)});
@@ -985,7 +993,8 @@ TEMPLATE_LIST_TEST_CASE("Viewing distributed tensors works",
           DataType* buf = tensor.data();
           for (DataIndexType i = 0; i < tensor.local_numel(); ++i)
           {
-            write_ele<Dev>(buf, i, static_cast<DataType>(i));
+            write_ele<Dev>(
+              buf, i, static_cast<DataType>(i), tensor.get_stream());
           }
 
           std::unique_ptr<DistTensorType> orig_view = tensor.view();
@@ -1013,7 +1022,7 @@ TEMPLATE_LIST_TEST_CASE("Viewing distributed tensors works",
 
           for (DataIndexType i = 0; i < view->local_numel(); ++i)
           {
-            REQUIRE(read_ele<Dev>(view->data(), i) == i);
+            REQUIRE(read_ele<Dev>(view->data(), i, view->get_stream()) == i);
           }
         }
       }, comm, 0, 3);
@@ -1042,7 +1051,8 @@ TEMPLATE_LIST_TEST_CASE("Viewing distributed tensors works",
           DataType* buf = tensor.data();
           for (DataIndexType i = 0; i < tensor.local_numel(); ++i)
           {
-            write_ele<Dev>(buf, i, static_cast<DataType>(i));
+            write_ele<Dev>(
+              buf, i, static_cast<DataType>(i), tensor.get_stream());
           }
 
           std::unique_ptr<DistTensorType> view = tensor.view();
@@ -1084,7 +1094,8 @@ TEMPLATE_LIST_TEST_CASE("Viewing distributed tensors works",
           DataType* buf = tensor.data();
           for (DataIndexType i = 0; i < tensor.local_numel(); ++i)
           {
-            write_ele<Dev>(buf, i, static_cast<DataType>(i));
+            write_ele<Dev>(
+              buf, i, static_cast<DataType>(i), tensor.get_stream());
           }
 
           std::unique_ptr<DistTensorType> view = tensor.view();

--- a/test/unit_test/tensor/unit_test_raw_buffer.cpp
+++ b/test/unit_test/tensor/unit_test_raw_buffer.cpp
@@ -175,7 +175,7 @@ TEMPLATE_LIST_TEST_CASE("Raw buffers are writable",
   DataType* raw_buf = buf.data();
   for (std::size_t i = 0; i < buf_size; ++i)
   {
-    write_ele<Dev>(raw_buf, i, static_cast<DataType>(i));
+    write_ele<Dev>(raw_buf, i, static_cast<DataType>(i), buf.get_stream());
   }
 
   // Ensure on already allocated data should not change anything.
@@ -184,7 +184,7 @@ TEMPLATE_LIST_TEST_CASE("Raw buffers are writable",
   REQUIRE(buf.data() == raw_buf);
   for (std::size_t i = 0; i < buf_size; ++i)
   {
-    REQUIRE(read_ele<Dev>(raw_buf, i) == i);
+    REQUIRE(read_ele<Dev>(raw_buf, i, buf.get_stream()) == i);
   }
 
   // Release then ensure should be sane, but has no guarantees about
@@ -198,7 +198,7 @@ TEMPLATE_LIST_TEST_CASE("Raw buffers are writable",
   raw_buf = buf.data();
   for (std::size_t i = 0; i < buf_size; ++i)
   {
-    write_ele<Dev>(raw_buf, i, static_cast<DataType>(i));
+    write_ele<Dev>(raw_buf, i, static_cast<DataType>(i), buf.get_stream());
   }
 }
 

--- a/test/unit_test/tensor/unit_test_strided_memory.cpp
+++ b/test/unit_test/tensor/unit_test_strided_memory.cpp
@@ -614,6 +614,170 @@ TEMPLATE_LIST_TEST_CASE("StridedMemory views across devices work",
 
 #endif  // H2_TEST_WITH_GPU
 
+TEMPLATE_LIST_TEST_CASE("Cloning StridedMemory works",
+                        "[tensor][strided_memory]",
+                        AllDevList)
+{
+  constexpr Device Dev = TestType::value;
+  using MemType = StridedMemory<DataType>;
+
+  SECTION("Cloning an empty StridedMemory")
+  {
+    MemType mem(Dev, false, ComputeStream{Dev});
+    MemType clone = mem.clone();
+    REQUIRE(clone.data() == nullptr);
+    REQUIRE(clone.size() == mem.size());
+    REQUIRE(clone.get_device() == Dev);
+    REQUIRE(clone.strides() == StrideTuple{});
+    REQUIRE(clone.shape() == ShapeTuple{});
+    REQUIRE(clone.is_lazy() == mem.is_lazy());
+  }
+
+  SECTION("Cloning a regular StridedMemory")
+  {
+    MemType mem(Dev, ShapeTuple{3, 7}, false, ComputeStream{Dev});
+    for (std::size_t i = 0; i < product<std::size_t>(mem.shape()); ++i)
+    {
+      write_ele<Dev>(mem.data(), i, static_cast<DataType>(i));
+    }
+    MemType clone = mem.clone();
+    REQUIRE(clone.data() != nullptr);
+    REQUIRE(clone.data() != mem.data());
+    REQUIRE(clone.size() == mem.size());
+    REQUIRE(clone.get_device() == Dev);
+    REQUIRE(clone.strides() == mem.strides());
+    REQUIRE(clone.shape() == mem.shape());
+    REQUIRE(clone.is_lazy() == mem.is_lazy());
+    for (std::size_t i = 0; i < product<std::size_t>(clone.shape()); ++i)
+    {
+      REQUIRE(read_ele<Dev>(clone.data(), i) == i);
+    }
+  }
+
+  SECTION("Cloning a lazy StridedMemory after ensure")
+  {
+    MemType mem(Dev, ShapeTuple{3, 7}, true, ComputeStream{Dev});
+    mem.ensure();
+    MemType clone = mem.clone();
+    REQUIRE(clone.data() != nullptr);
+    REQUIRE(clone.data() != mem.data());
+    REQUIRE(clone.size() == mem.size());
+    REQUIRE(clone.get_device() == Dev);
+    REQUIRE(clone.strides() == mem.strides());
+    REQUIRE(clone.shape() == mem.shape());
+    REQUIRE(clone.is_lazy() == mem.is_lazy());
+  }
+
+  SECTION("Cloning a lazy StridedMemory before ensure")
+  {
+    MemType mem(Dev, ShapeTuple{3, 7}, true, ComputeStream{Dev});
+    MemType clone = mem.clone();
+    REQUIRE(clone.is_lazy());
+    REQUIRE(clone.data() == nullptr);
+    clone.ensure();
+    REQUIRE(clone.data() != nullptr);
+    REQUIRE(mem.data() == nullptr);
+    REQUIRE(clone.size() == mem.size());
+    REQUIRE(clone.get_device() == Dev);
+    REQUIRE(clone.strides() == mem.strides());
+    REQUIRE(clone.shape() == mem.shape());
+    REQUIRE(clone.is_lazy() == mem.is_lazy());
+  }
+
+  SECTION("Cloning a contiguous StridedMemory view")
+  {
+    MemType base_mem(Dev, ShapeTuple{3, 7, 3}, false, ComputeStream{Dev});
+    for (std::size_t i = 0; i < product<std::size_t>(base_mem.shape()); ++i)
+    {
+      write_ele<Dev>(base_mem.data(), i, static_cast<DataType>(i));
+    }
+    MemType mem(base_mem, {ALL, ALL, ALL});
+    MemType clone = mem.clone();
+    REQUIRE(clone.data() != nullptr);
+    REQUIRE(clone.data() != mem.data());
+    REQUIRE(clone.size() == mem.size());
+    REQUIRE(clone.get_device() == Dev);
+    REQUIRE(clone.strides() == mem.strides());
+    REQUIRE(clone.shape() == mem.shape());
+    REQUIRE(clone.is_lazy() == mem.is_lazy());
+    for (std::size_t i = 0; i < product<std::size_t>(clone.shape()); ++i)
+    {
+      REQUIRE(read_ele<Dev>(clone.data(), i) == i);
+    }
+  }
+
+  // Not checking size() because the buffer may change.
+  SECTION("Cloning a contiguous, offset StridedMemory view")
+  {
+    MemType base_mem(Dev, ShapeTuple{3, 7, 3}, false, ComputeStream{Dev});
+    for (std::size_t i = 0; i < product<std::size_t>(base_mem.shape()); ++i)
+    {
+      write_ele<Dev>(base_mem.data(), i, static_cast<DataType>(i));
+    }
+    MemType mem(base_mem, {ALL, ALL, IRng(1)});
+    MemType clone = mem.clone();
+    REQUIRE(clone.data() != nullptr);
+    REQUIRE(clone.data() != mem.data());
+    REQUIRE(clone.get_device() == Dev);
+    REQUIRE(clone.strides() == mem.strides());
+    REQUIRE(clone.shape() == mem.shape());
+    REQUIRE(clone.is_lazy() == mem.is_lazy());
+    for (DimType j = 0; j < clone.shape(1); ++j)
+    {
+      for (DimType i = 0; i < clone.shape(0); ++i)
+      {
+        REQUIRE(read_ele<Dev>(clone.get({i, j}))
+                == base_mem.get_index({i, j, 1}));
+      }
+    }
+  }
+
+  SECTION("Cloning a non-contiguous StridedMemory view")
+  {
+    MemType base_mem(Dev, ShapeTuple{3, 7, 3}, false, ComputeStream{Dev});
+    for (std::size_t i = 0; i < product<std::size_t>(base_mem.shape()); ++i)
+    {
+      write_ele<Dev>(base_mem.data(), i, static_cast<DataType>(i));
+    }
+    MemType mem(base_mem, {IRng(1), ALL, ALL});
+    MemType clone = mem.clone();
+    REQUIRE(clone.data() != nullptr);
+    REQUIRE(clone.data() != mem.data());
+    REQUIRE(clone.get_device() == Dev);
+    REQUIRE(clone.strides() == mem.strides());
+    REQUIRE(clone.shape() == mem.shape());
+    REQUIRE(clone.is_lazy() == mem.is_lazy());
+    for (DimType k = 0; k < clone.shape(1); ++k)
+    {
+      for (DimType j = 0; j < clone.shape(0); ++j)
+      {
+        REQUIRE(read_ele<Dev>(clone.get({j, k}))
+                == base_mem.get_index({1, j, k}));
+      }
+    }
+  }
+
+  SECTION("Cloning a StridedMemory wrapping an external buffer")
+  {
+    constexpr std::size_t buf_size = 4 * 6;
+    DeviceBuf<DataType, Dev> buf(buf_size);
+    for (std::size_t i = 0; i < buf_size; ++i)
+    {
+      write_ele<Dev>(buf.buf, i, static_cast<DataType>(i));
+    }
+
+    MemType mem(
+        Dev, buf.buf, ShapeTuple{4, 6}, StrideTuple{1, 4}, ComputeStream{Dev});
+    MemType clone = mem.clone();
+    REQUIRE(clone.data() != nullptr);
+    REQUIRE(clone.data() != mem.data());
+    REQUIRE(clone.get_device() == Dev);
+    REQUIRE(clone.strides() == mem.strides());
+    REQUIRE(clone.shape() == mem.shape());
+    REQUIRE(clone.is_lazy() == mem.is_lazy());
+  }
+}
+
 TEMPLATE_LIST_TEST_CASE("StridedMemory is printable",
                         "[tensor][strided_memory]",
                         AllDevList)

--- a/test/unit_test/tensor/unit_test_strided_memory.cpp
+++ b/test/unit_test/tensor/unit_test_strided_memory.cpp
@@ -245,7 +245,7 @@ TEMPLATE_LIST_TEST_CASE("StridedMemory writing works",
   DataType* buf = mem.data();
   for (std::size_t i = 0; i < product<std::size_t>(mem.shape()); ++i)
   {
-    write_ele<Dev>(buf, i, static_cast<DataType>(i));
+    write_ele<Dev>(buf, i, static_cast<DataType>(i), mem.get_stream());
   }
 
   DataIndexType idx = 0;
@@ -255,8 +255,9 @@ TEMPLATE_LIST_TEST_CASE("StridedMemory writing works",
     {
       for (DimType i = 0; i < mem.shape(0); ++i)
       {
-        REQUIRE(read_ele<Dev>(mem.get({i, j, k})) == idx);
-        REQUIRE(read_ele<Dev>(mem.const_get({i, j, k})) == idx);
+        REQUIRE(read_ele<Dev>(mem.get({i, j, k}), mem.get_stream()) == idx);
+        REQUIRE(read_ele<Dev>(mem.const_get({i, j, k}), mem.get_stream())
+                == idx);
         ++idx;
       }
     }
@@ -296,7 +297,8 @@ TEMPLATE_LIST_TEST_CASE("StridedMemory views work",
       MemType(Dev, ShapeTuple{3, 7, 3}, false, ComputeStream{Dev});
   for (std::size_t i = 0; i < product<std::size_t>(base_mem.shape()); ++i)
   {
-    write_ele<Dev>(base_mem.data(), i, static_cast<DataType>(i));
+    write_ele<Dev>(
+      base_mem.data(), i, static_cast<DataType>(i), base_mem.get_stream());
   }
 
   SECTION("Viewing a subtensor with all three dimensions nontrivial")
@@ -314,10 +316,13 @@ TEMPLATE_LIST_TEST_CASE("StridedMemory views work",
         DataIndexType idx = 0;
         for (DimType i = 0; i < mem.shape(0); ++i)
         {
-          REQUIRE(read_ele<Dev>(mem.get({i, j, k}))
+          REQUIRE(read_ele<Dev>(mem.get({i, j, k}), mem.get_stream())
                   == base_mem.get_index({i + 1, j, k + 1}));
           // Large enough to not be a real index.
-          write_ele<Dev>(mem.get({i, j, k}), 0, static_cast<DataType>(1337));
+          write_ele<Dev>(mem.get({i, j, k}),
+                         0,
+                         static_cast<DataType>(1337),
+                         mem.get_stream());
           ++idx;
         }
       }
@@ -333,11 +338,13 @@ TEMPLATE_LIST_TEST_CASE("StridedMemory views work",
         {
           if (i >= 1 && i < 3 && k >= 1 && k < 3)
           {
-            REQUIRE(read_ele<Dev>(base_mem.get({i, j, k})) == 1337);
+            REQUIRE(read_ele<Dev>(
+                      base_mem.get({i, j, k}), base_mem.get_stream()) == 1337);
           }
           else
           {
-            REQUIRE(read_ele<Dev>(base_mem.get({i, j, k})) == idx);
+            REQUIRE(read_ele<Dev>(
+                      base_mem.get({i, j, k}), base_mem.get_stream()) == idx);
           }
           ++idx;
         }
@@ -356,7 +363,7 @@ TEMPLATE_LIST_TEST_CASE("StridedMemory views work",
     {
       for (DimType j = 0; j < mem.shape(0); ++j)
       {
-        REQUIRE(read_ele<Dev>(mem.get({j, k}))
+        REQUIRE(read_ele<Dev>(mem.get({j, k}), mem.get_stream())
                 == base_mem.get_index({1, j, k + 1}));
       }
     }
@@ -373,7 +380,7 @@ TEMPLATE_LIST_TEST_CASE("StridedMemory views work",
     {
       for (DimType i = 0; i < mem.shape(0); ++i)
       {
-        REQUIRE(read_ele<Dev>(mem.get({i, 0, k}))
+        REQUIRE(read_ele<Dev>(mem.get({i, 0, k}), mem.get_stream())
                               == base_mem.get_index({i, 1, k}));
       }
     }
@@ -386,7 +393,8 @@ TEMPLATE_LIST_TEST_CASE("StridedMemory views work",
     REQUIRE(mem.size() == base_mem.size());
     REQUIRE(mem.data() == (base_mem.data() + base_mem.get_index({1, 0, 0})));
     REQUIRE_FALSE(mem.is_lazy());
-    REQUIRE(read_ele<Dev>(mem.get({0})) == base_mem.get_index({1, 0, 0}));
+    REQUIRE(read_ele<Dev>(mem.get({0}), mem.get_stream())
+            == base_mem.get_index({1, 0, 0}));
   }
   SECTION("Views with totally empty coordinates work")
   {
@@ -638,7 +646,7 @@ TEMPLATE_LIST_TEST_CASE("Cloning StridedMemory works",
     MemType mem(Dev, ShapeTuple{3, 7}, false, ComputeStream{Dev});
     for (std::size_t i = 0; i < product<std::size_t>(mem.shape()); ++i)
     {
-      write_ele<Dev>(mem.data(), i, static_cast<DataType>(i));
+      write_ele<Dev>(mem.data(), i, static_cast<DataType>(i), mem.get_stream());
     }
     MemType clone = mem.clone();
     REQUIRE(clone.data() != nullptr);
@@ -650,7 +658,7 @@ TEMPLATE_LIST_TEST_CASE("Cloning StridedMemory works",
     REQUIRE(clone.is_lazy() == mem.is_lazy());
     for (std::size_t i = 0; i < product<std::size_t>(clone.shape()); ++i)
     {
-      REQUIRE(read_ele<Dev>(clone.data(), i) == i);
+      REQUIRE(read_ele<Dev>(clone.data(), i, clone.get_stream()) == i);
     }
   }
 
@@ -689,10 +697,12 @@ TEMPLATE_LIST_TEST_CASE("Cloning StridedMemory works",
     MemType base_mem(Dev, ShapeTuple{3, 7, 3}, false, ComputeStream{Dev});
     for (std::size_t i = 0; i < product<std::size_t>(base_mem.shape()); ++i)
     {
-      write_ele<Dev>(base_mem.data(), i, static_cast<DataType>(i));
+      write_ele<Dev>(
+        base_mem.data(), i, static_cast<DataType>(i), base_mem.get_stream());
     }
     MemType mem(base_mem, {ALL, ALL, ALL});
     MemType clone = mem.clone();
+    clone.get_stream().wait_for_this();
     REQUIRE(clone.data() != nullptr);
     REQUIRE(clone.data() != mem.data());
     REQUIRE(clone.size() == mem.size());
@@ -702,7 +712,7 @@ TEMPLATE_LIST_TEST_CASE("Cloning StridedMemory works",
     REQUIRE(clone.is_lazy() == mem.is_lazy());
     for (std::size_t i = 0; i < product<std::size_t>(clone.shape()); ++i)
     {
-      REQUIRE(read_ele<Dev>(clone.data(), i) == i);
+      REQUIRE(read_ele<Dev>(clone.data(), i, clone.get_stream()) == i);
     }
   }
 
@@ -712,7 +722,8 @@ TEMPLATE_LIST_TEST_CASE("Cloning StridedMemory works",
     MemType base_mem(Dev, ShapeTuple{3, 7, 3}, false, ComputeStream{Dev});
     for (std::size_t i = 0; i < product<std::size_t>(base_mem.shape()); ++i)
     {
-      write_ele<Dev>(base_mem.data(), i, static_cast<DataType>(i));
+      write_ele<Dev>(
+        base_mem.data(), i, static_cast<DataType>(i), base_mem.get_stream());
     }
     MemType mem(base_mem, {ALL, ALL, IRng(1)});
     MemType clone = mem.clone();
@@ -726,7 +737,7 @@ TEMPLATE_LIST_TEST_CASE("Cloning StridedMemory works",
     {
       for (DimType i = 0; i < clone.shape(0); ++i)
       {
-        REQUIRE(read_ele<Dev>(clone.get({i, j}))
+        REQUIRE(read_ele<Dev>(clone.get({i, j}), clone.get_stream())
                 == base_mem.get_index({i, j, 1}));
       }
     }
@@ -737,7 +748,8 @@ TEMPLATE_LIST_TEST_CASE("Cloning StridedMemory works",
     MemType base_mem(Dev, ShapeTuple{3, 7, 3}, false, ComputeStream{Dev});
     for (std::size_t i = 0; i < product<std::size_t>(base_mem.shape()); ++i)
     {
-      write_ele<Dev>(base_mem.data(), i, static_cast<DataType>(i));
+      write_ele<Dev>(
+        base_mem.data(), i, static_cast<DataType>(i), base_mem.get_stream());
     }
     MemType mem(base_mem, {IRng(1), ALL, ALL});
     MemType clone = mem.clone();
@@ -751,7 +763,7 @@ TEMPLATE_LIST_TEST_CASE("Cloning StridedMemory works",
     {
       for (DimType j = 0; j < clone.shape(0); ++j)
       {
-        REQUIRE(read_ele<Dev>(clone.get({j, k}))
+        REQUIRE(read_ele<Dev>(clone.get({j, k}), clone.get_stream())
                 == base_mem.get_index({1, j, k}));
       }
     }
@@ -763,7 +775,7 @@ TEMPLATE_LIST_TEST_CASE("Cloning StridedMemory works",
     DeviceBuf<DataType, Dev> buf(buf_size);
     for (std::size_t i = 0; i < buf_size; ++i)
     {
-      write_ele<Dev>(buf.buf, i, static_cast<DataType>(i));
+      write_ele<Dev>(buf.buf, i, static_cast<DataType>(i), ComputeStream{Dev});
     }
 
     MemType mem(

--- a/test/unit_test/tensor/unit_test_tensor.cpp
+++ b/test/unit_test/tensor/unit_test_tensor.cpp
@@ -798,6 +798,39 @@ TEMPLATE_LIST_TEST_CASE("Making tensors contiguous works",
   }
 }
 
+TEMPLATE_LIST_TEST_CASE("Cloning tensors works",
+                        "[tensor]",
+                        AllDevList)
+{
+  constexpr Device Dev = TestType::value;
+  using TensorType = Tensor<DataType>;
+
+  TensorType tensor = TensorType(Dev, {4, 6}, {DT::Sample, DT::Any});
+  for (DataIndexType i = 0; i < tensor.numel(); ++i)
+  {
+    write_ele<Dev>(tensor.data(), i, static_cast<DataType>(i));
+  }
+
+  SECTION("Cloning an entire tensor works")
+  {
+    std::unique_ptr<TensorType> clone = tensor.clone();
+    REQUIRE(clone->shape() == tensor.shape());
+    REQUIRE(clone->dim_types() == tensor.dim_types());
+    REQUIRE(clone->strides() == tensor.strides());
+    REQUIRE(clone->ndim() == tensor.ndim());
+    REQUIRE(clone->numel() == tensor.numel());
+    REQUIRE(clone->is_empty() == tensor.is_empty());
+    REQUIRE_FALSE(clone->is_view());
+    REQUIRE_FALSE(clone->is_const_view());
+    REQUIRE(clone->get_view_type() == ViewType::None);
+    REQUIRE(clone->is_contiguous() == tensor.is_contiguous());
+    REQUIRE(clone->get_device() == tensor.get_device());
+    REQUIRE(clone->is_lazy() == tensor.is_lazy());
+    REQUIRE(clone->data() != nullptr);
+    REQUIRE(clone->data() != tensor.data());
+  }
+}
+
 TEMPLATE_LIST_TEST_CASE("Tensors are printable", "[tensor]", AllDevList)
 {
   constexpr Device Dev = TestType::value;


### PR DESCRIPTION
(Depends on #138.)

This adds a `clone` method to both `Tensor` and `DistTensor` to create a new tensor that is otherwise identical to the caller. (Essentially this is a shorthand for creating an empty tensor and then copying the source to it.)

This also adds `copy` support for `DistTensor`s (with some cases not implemented). Note "copy" here essentially means to replace the existing destination with the source. This does not involve a notion of redistribution.

One thing we may revisit: Whether `copy` should replace the destination's processor grid with the source's. Right now it simply requires them to be congruent, but this could lead to surprising results down the line where communication is not necessarily ordered between the two tensors if the grids do not have identical underlying communicators.