### PR TITLE
Add declaration for explicit specialization of from_string

### DIFF
--- a/include/h2/utils/strings.hpp
+++ b/include/h2/utils/strings.hpp
@@ -81,6 +81,9 @@ inline std::string str_tolower(std::string str)
 template <typename T>
 inline T from_string(const std::string& str);
 
+template <>
+inline unsigned int from_string<unsigned int>(const std::string&);
+
 inline std::string from_string(std::string&& str)
 {
   return std::move(str);


### PR DESCRIPTION
This was failing with Clang 16 on Lassen and Clang 19git on macos.