### PR TITLE
Join coverage reports for SeqCatchTests and GPUCatchTests

### DIFF
--- a/.gitlab/build-and-test-common.yml
+++ b/.gitlab/build-and-test-common.yml
@@ -44,5 +44,5 @@
       junit: "${CI_PROJECT_DIR}/*junit.*xml"
       coverage_report:
         coverage_format: cobertura
-        path: "${CI_PROJECT_DIR}/SeqCatchTests-gcovr.xml"
+        path: "${CI_PROJECT_DIR}/coverage-gcovr.xml"
   extends: .build-and-test-base

--- a/.gitlab/build-and-test.sh
+++ b/.gitlab/build-and-test.sh
@@ -207,16 +207,14 @@ then
     echo "~~~~~ $(date)"
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 
-    cmake --build build-h2 -t coverage
-
     # This is beyond obnoxious
     gcovr_prefix=$(dirname $(dirname $(command -v gcovr)))
     python_path=$(ls --color=no -1 -d ${gcovr_prefix}/lib/python*/site-packages)
     echo "python_path=${python_path}"
     PYTHONPATH=${python_path}:${PYTHONPATH} cmake --build build-h2 -t coverage
-    if [[ -e ${build_dir}/build-h2/SeqCatchTests-gcovr.xml ]]
+    if [[ -e ${build_dir}/build-h2/coverage-gcovr.xml ]]
     then
-        cp ${build_dir}/build-h2/SeqCatchTests-gcovr.xml ${project_dir}
+        cp ${build_dir}/build-h2/coverage-gcovr.xml ${project_dir}
     fi
 
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -468,6 +468,10 @@ if (H2_ENABLE_DISTCONV_LEGACY)
   add_subdirectory(legacy)
 endif ()
 
+if (H2_ENABLE_CODE_COVERAGE)
+  finalize_code_coverage()
+endif ()
+
 # Install target stuff
 include (CMakePackageConfigHelpers)
 

--- a/cmake/modules/H2CXXCodeCoverage.cmake
+++ b/cmake/modules/H2CXXCodeCoverage.cmake
@@ -130,7 +130,7 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES "[Cc]lang")
     # NOTE: We need a single exe to pass to lcov. So we make one.
     file(WRITE "${CMAKE_BINARY_DIR}/coverage/tmp/llvm-gcov.sh"
       "#! /bin/bash
-${LLVM_COV_PROGRAM} gcov $@")
+${LLVM_COV_PROGRAM} gcov -m $@")
     file(COPY "${CMAKE_BINARY_DIR}/coverage/tmp/llvm-gcov.sh"
       DESTINATION "${CMAKE_BINARY_DIR}"
       FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE)
@@ -293,7 +293,7 @@ if (H2_HAVE_GCOV_COVERAGE_TOOLS)
       # Generate the HTML reports
       add_custom_target(
         ${_tltgt}-gen-coverage-html
-        COMMAND ${GENHTML_PROGRAM} ${_INFO_OUT_DIR}/${_tltgt}.total.info.final --output-directory ${_HTML_OUT_DIR}
+        COMMAND ${GENHTML_PROGRAM} ${_INFO_OUT_DIR}/${_tltgt}.total.info.final --demangle-cpp --output-directory ${_HTML_OUT_DIR}
         COMMENT "Generating HTML for ${_tltgt} coverage report."
         BYPRODUCTS ${_HTML_OUT_DIR}/index.html
         VERBATIM)

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -93,6 +93,11 @@ add_test(
 if (H2_CODE_COVERAGE)
   add_code_coverage(SeqCatchTests coverage)
   target_link_libraries(SeqCatchTests PRIVATE h2_coverage_flags)
+
+  if (TARGET GPUCatchTests)
+    add_code_coverage(GPUCatchTests coverage)
+    target_link_libraries(GPUCatchTests PRIVATE h2_coverage_flags)
+  endif ()
 endif ()
 
 if (H2_EXTRA_CXX_FLAGS)

--- a/test/unit_test/core/CMakeLists.txt
+++ b/test/unit_test/core/CMakeLists.txt
@@ -7,6 +7,7 @@
 
 target_sources(SeqCatchTests PRIVATE
   unit_test_sync.cpp
+  unit_test_version.cpp
 )
 
 if (H2_HAS_GPU)

--- a/test/unit_test/core/unit_test_version.cpp
+++ b/test/unit_test/core/unit_test_version.cpp
@@ -1,0 +1,19 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "h2_config.hpp"
+#include "h2/Version.hpp"
+
+using namespace h2;
+
+// gotta get that coverage
+TEST_CASE("Version", "[version][core]")
+{
+    REQUIRE(Version() == H2_VERSION);
+}


### PR DESCRIPTION
This is incremental progress on the path to decent coverage reports. It combines the reports for `SeqCatchTests` and `GPUCatchTests` to get a more unified view of our actual coverage.

The notable omission here is the `MPICatchTests`. However, those require setting up CMake to properly run the MPI job (different launch commands on each cluster, etc) and to properly gather the coverage data, which must be split per-process to avoid potential deadlock. Unless there's strong objection, I prefer to defer that to a future PR.