### PR TITLE
Add missing header for ROCm debug build

### DIFF
--- a/legacy/include/distconv/tensor/tensor_base.hpp
+++ b/legacy/include/distconv/tensor/tensor_base.hpp
@@ -17,6 +17,10 @@
 #define TENSOR_FUNC_DECL
 #endif
 
+#if defined(__HIP__) && !defined(NDEBUG)
+#include <hip/hip_runtime.h>
+#endif
+
 namespace distconv {
 namespace tensor {
 


### PR DESCRIPTION
The device-side `assert` macro is defined in `hip/hip_runtime.h`. So we need to include that. See the [AMD Documentation](https://rocm.docs.amd.com/projects/HIP/en/latest/reference/kernel_language.html#assert) for more details.