### PR TITLE
Printing tensors and other miscellanea

### DIFF
--- a/include/h2/core/CMakeLists.txt
+++ b/include/h2/core/CMakeLists.txt
@@ -13,6 +13,7 @@ h2_add_sources_to_target_and_install(
   TARGET H2Core COMPONENT CORE SCOPE INTERFACE
   INSTALL_PREFIX "${H2_CURRENT_INSTALL_PREFIX}"
   SOURCES
+  allocator.hpp
   device.hpp
   sync.hpp
   )

--- a/include/h2/core/allocator.hpp
+++ b/include/h2/core/allocator.hpp
@@ -1,0 +1,133 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+/** @file
+ *
+ * Various raw memory allocators and related utilities.
+ */
+
+#include <h2_config.hpp>
+
+#include <new>
+#include <optional>
+#include <cstddef>
+
+#include "h2/core/device.hpp"
+#include "h2/core/sync.hpp"
+
+#ifdef H2_HAS_GPU
+#include "h2/gpu/memory_utils.hpp"
+#endif
+
+
+namespace h2
+{
+
+namespace internal
+{
+
+// TODO: Use proper memory pools (probably Hydrogen's).
+
+template <typename T, Device Dev>
+struct Allocator
+{
+  static T* allocate(std::size_t size, const ComputeStream& stream);
+  static void deallocate(T* buf, const ComputeStream& stream);
+};
+
+template <typename T>
+struct Allocator<T, Device::CPU>
+{
+  static T* allocate(std::size_t size, const ComputeStream&)
+  {
+    return new T[size];
+  }
+
+  static void deallocate(T* buf, const ComputeStream&)
+  {
+    delete[] buf;
+  }
+};
+
+#ifdef H2_HAS_GPU
+template <typename T>
+struct Allocator<T, Device::GPU>
+{
+  static T* allocate(std::size_t size, const ComputeStream& stream)
+  {
+    T* buf = nullptr;
+    // FIXME: add H2_CHECK_GPU...
+    H2_ASSERT(gpu::default_cub_allocator().DeviceAllocate(
+                  reinterpret_cast<void**>(&buf),
+                  size*sizeof(T),
+                  stream.get_stream<Device::GPU>()) == 0,
+              std::runtime_error,
+              "CUB allocation failed.");
+    return buf;
+  }
+
+  static void deallocate(T* buf, const ComputeStream&)
+  {
+    H2_ASSERT(gpu::default_cub_allocator().DeviceFree(buf) == 0,
+              std::runtime_error,
+              "CUB deallocation failed.");
+  }
+};
+#endif
+
+/**
+ * Helper class to wrap an allocation in RAII semantics.
+ */
+template <typename T, Device Dev>
+class ManagedBuffer
+{
+public:
+  ManagedBuffer(std::size_t size_,
+                const std::optional<ComputeStream> stream_ = std::nullopt)
+    : buf(nullptr), buf_size(size_), stream(stream_.value_or(ComputeStream{Dev}))
+  {
+    if (buf_size)
+    {
+      buf = Allocator<T, Dev>::allocate(buf_size, stream);
+    }
+  }
+
+  ~ManagedBuffer()
+  {
+    if (buf)
+    {
+      Allocator<T, Dev>::deallocate(buf, stream);
+    }
+  }
+
+  ManagedBuffer(const ManagedBuffer&) = delete;
+  ManagedBuffer& operator=(const ManagedBuffer&) = delete;
+
+  ManagedBuffer(ManagedBuffer&&) = default;
+  ManagedBuffer& operator=(ManagedBuffer&&) = default;
+
+  T* data() H2_NOEXCEPT { return buf; }
+
+  const T* data() const H2_NOEXCEPT { return buf; }
+
+  const T* const_data() const H2_NOEXCEPT { return buf; }
+
+  std::size_t size() const H2_NOEXCEPT { return size; }
+
+  const ComputeStream& get_stream() const H2_NOEXCEPT { return stream; }
+
+private:
+  T* buf;
+  std::size_t buf_size;
+  ComputeStream stream;
+};
+
+}  // namespace internal
+
+}  // namespace h2

--- a/include/h2/core/allocator.hpp
+++ b/include/h2/core/allocator.hpp
@@ -115,10 +115,8 @@ public:
   {
     if (buf)
     {
-      try {
-        H2_DEVICE_DISPATCH_SAME(device,
-                                (Allocator<T, Dev>::deallocate(buf, stream)));
-      } catch (...) {}
+      H2_TERMINATE_ON_THROW_DEBUG(H2_DEVICE_DISPATCH_SAME(
+          device, (Allocator<T, Dev>::deallocate(buf, stream))));
     }
   }
 

--- a/include/h2/core/sync.hpp
+++ b/include/h2/core/sync.hpp
@@ -682,6 +682,10 @@ public:
       }
       else if constexpr (StreamDev == Device::GPU)
       {
+        if (gpu_stream == other_stream.gpu_stream)
+        {
+          return;  // No need to sync when these are the same stream.
+        }
         // Add an event and wait on it.
         gpu::DeviceEvent event = internal::get_new_device_event();
         gpu::record_event(event, other_stream.get_stream<Device::GPU>());

--- a/include/h2/tensor/fixed_size_tuple.hpp
+++ b/include/h2/tensor/fixed_size_tuple.hpp
@@ -80,6 +80,27 @@ struct FixedSizeTuple {
   FixedSizeTuple& operator=(const FixedSizeTuple& other) = default;
   FixedSizeTuple& operator=(FixedSizeTuple&& other) = default;
 
+  /**
+   * Construct a tuple from another tuple with data type that is
+   * convertible to T.
+   */
+  template <typename U, typename OtherSizeType, OtherSizeType M>
+  static constexpr FixedSizeTuple
+  convert_from(const FixedSizeTuple<U, OtherSizeType, M>& other)
+  {
+    static_assert(
+        std::is_convertible_v<U, T>,
+        "Cannot construct a tuple from another with unconvertible type");
+    static_assert(N >= M,
+                  "Cannot construct a tuple from another that may be larger");
+    FixedSizeTuple new_tuple;
+    for (SizeType i = 0; i < other.size_; ++i)
+    {
+      new_tuple.append(other[i]);
+    }
+    return new_tuple;
+  }
+
   /** Return the number of valid elements in the tuple. */
   constexpr SizeType size() const H2_NOEXCEPT { return size_; }
 
@@ -93,6 +114,32 @@ struct FixedSizeTuple {
 
   /** Return a constant raw pointer to the tuple. */
   const T* const_data() const H2_NOEXCEPT { return data_.data(); }
+
+  /** Return a reference to the first element in the tuple. */
+  constexpr T& front() H2_NOEXCEPT
+  {
+    H2_ASSERT_DEBUG(size_ > 0, "Cannot access front in empty tuple");
+    return data_[0];
+  }
+
+  constexpr const T& front() const H2_NOEXCEPT
+  {
+    H2_ASSERT_DEBUG(size_ > 0, "Cannot access front in empty tuple");
+    return data_[0];
+  }
+
+  /** Return a reference to the last element in the tuple. */
+  constexpr T& back() H2_NOEXCEPT
+  {
+    H2_ASSERT_DEBUG(size_ > 0, "Cannot access back in empty tuple");
+    return data_[size_ - 1];
+  }
+
+  constexpr const T& back() const H2_NOEXCEPT
+  {
+    H2_ASSERT_DEBUG(size_ > 0, "Cannot access back in empty tuple");
+    return data_[size_ - 1];
+  }
 
   /** Return an iterator to the first element of the tuple. */
   constexpr iterator begin() H2_NOEXCEPT { return data_.begin(); }

--- a/include/h2/tensor/hydrogen_interop/local_tensor_interop.hpp
+++ b/include/h2/tensor/hydrogen_interop/local_tensor_interop.hpp
@@ -51,10 +51,10 @@ auto as_h_mat_impl(BufferT buf, Tensor<T> const& tensor)
     }
     auto const& shape = tensor.shape();
     auto const& strides = tensor.strides();
-    auto const width = safe_as<h_size_type>(last(shape));
+    auto const width = safe_as<h_size_type>(shape.back());
     auto const height =
         safe_as<h_size_type>(product<std::uint64_t>(init(shape)));
-    auto const ldim = safe_as<h_size_type>(last(strides));
+    auto const ldim = safe_as<h_size_type>(strides.back());
     return MatrixType{height, width, buf, ldim};
 }
 

--- a/include/h2/tensor/io.hpp
+++ b/include/h2/tensor/io.hpp
@@ -1,0 +1,100 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+/** @file
+ *
+ * Printing and file I/O for tensors and distributed tensors.
+ */
+
+#include <ostream>
+#include "tensor_types.hpp"
+
+#include "h2/tensor/tensor.hpp"
+#include "h2/tensor/copy.hpp"
+
+
+namespace h2
+{
+
+/** Write tensor to the given stream. */
+template <typename T>
+inline std::ostream& print(std::ostream& os, const Tensor<T>& tensor)
+{
+  if (tensor.is_empty())
+  {
+    os << "[]";
+    return os;
+  }
+  auto cpu_view = make_accessible_on_device(tensor, Device::CPU);
+  // Ensure any copy is completed.
+  cpu_view->get_stream().wait_for(tensor.get_stream());
+
+  std::size_t indent = 0;  // Number of spaces to prepend.
+
+  // Note: We traverse in a row-major order because that makes printing
+  // nicer.
+  ScalarIndexTuple coord{TuplePad<ScalarIndexTuple>(tensor.ndim(), 0)};
+  for (DataIndexType i = 0; i < tensor.numel(); ++i)
+  {
+    // Print opening braces except for inner-most dim.
+    for (; indent < coord.size() - 1; ++indent)
+    {
+      os << std::string(indent, ' ') << "[\n";
+    }
+    // Print inner-most opening brace.
+    if (coord.back() == 0)
+    {
+      os << std::string(indent, ' ') << "[";
+    }
+    os << *(cpu_view->get(coord));
+    // Close inner-most brace.
+    if (coord.back() == tensor.shape().back() - 1)
+    {
+      os << "]";
+      if (tensor.ndim() > 1)
+      {
+        os << "\n";
+      }
+    }
+    else
+    {
+      os << ", ";
+    }
+    // Advance coordinates.
+    coord.back() += 1;
+    for (typename ScalarIndexTuple::size_type dim = coord.size() - 1; dim >= 0;
+         --dim)
+    {
+      if (coord[dim] == tensor.shape(dim))
+      {
+        coord[dim] = 0;
+        if (dim > 0) {
+          coord[dim - 1] += 1;
+        }
+        // Close braces except for the inner-most dimension.
+        if (dim < coord.size() - 1)
+        {
+          --indent;
+          os << std::string(indent, ' ') << "]";
+          // There is a newline unless this is the first dimension.
+          if (dim > 0)
+          {
+            os << "\n";
+          }
+        }
+      }
+    }
+  }
+
+  return os;
+}
+
+
+
+}

--- a/include/h2/tensor/io.hpp
+++ b/include/h2/tensor/io.hpp
@@ -52,7 +52,7 @@ inline std::ostream& print(std::ostream& os, const Tensor<T>& tensor)
     {
       os << std::string(indent, ' ') << "[";
     }
-    os << *(cpu_view->get(coord));
+    os << *(cpu_view->const_get(coord));
     // Close inner-most brace.
     if (coord.back() == tensor.shape().back() - 1)
     {

--- a/include/h2/tensor/raw_buffer.hpp
+++ b/include/h2/tensor/raw_buffer.hpp
@@ -69,7 +69,7 @@ public:
         stream(stream_)
   {}
 
-  ~RawBuffer() { release(); }
+  ~RawBuffer() { H2_TERMINATE_ON_THROW_ALWAYS(release()); }
 
   /** Allocate memory if the buffer is not present. */
   void ensure()

--- a/include/h2/tensor/raw_buffer.hpp
+++ b/include/h2/tensor/raw_buffer.hpp
@@ -257,7 +257,7 @@ struct DeviceBufferPrinter<T, Device::GPU>
     }
     else
     {
-      internal::ManagedBuffer<T, Device::CPU> cpu_buf(size);
+      internal::ManagedBuffer<T> cpu_buf(size, Device::CPU);
       gpu::mem_copy(
           cpu_buf.data(), buf, size, stream.get_stream<Device::GPU>());
       stream.wait_for_this();

--- a/include/h2/tensor/strided_memory.hpp
+++ b/include/h2/tensor/strided_memory.hpp
@@ -466,16 +466,51 @@ template <typename T>
 inline std::ostream& strided_memory_contents(std::ostream& os,
                                              const StridedMemory<T>& mem)
 {
-  DataIndexType size =
+  const DataIndexType size =
       mem.shape().size() ? product<DataIndexType>(mem.shape()) : 0;
-  for (DataIndexType i = 0; i < size; ++i)
+  if (size == 0)
   {
-    os << *mem.get(mem.get_coord(i));
-    if (i != size - 1)
+    return os;  // Skip if empty.
+  }
+  const T* buf = nullptr;
+  internal::ManagedBuffer<T> cpu_buf{Device::CPU};
+  if (mem.get_device() == Device::CPU)
+  {
+    buf = mem.data();
+  }
+#ifdef H2_HAS_GPU
+  else if (mem.get_device() == Device::GPU)
+  {
+    if (gpu::is_integrated())
     {
-      os << ", ";
+      buf = mem.data();
+    }
+    else
+    {
+      std::size_t extent = get_extent_from_strides(mem.shape(), mem.strides());
+      cpu_buf = internal::ManagedBuffer<T>(extent, Device::CPU);
+      gpu::mem_copy(cpu_buf.data(),
+                    mem.const_data(),
+                    extent,
+                    mem.get_stream().template get_stream<Device::GPU>());
+      buf = cpu_buf.data();
     }
   }
+#endif
+  else
+  {
+    throw H2FatalException("Unknown device ", mem.get_device());
+  }
+  mem.get_stream().wait_for_this();  // Ensure all operations have finished.
+
+  // We might try to nicely format this in the future.
+  // We know size > 0 if we are here.
+  ScalarIndexTuple start{TuplePad<ScalarIndexTuple>(mem.shape().size(), 0)};
+  os << buf[mem.get_index(start)];  // Print first entry.
+  start = next_scalar_index(start, mem.shape());
+  for_ndim(mem.shape(), [&](ScalarIndexTuple c) {
+    os << ", " << buf[mem.get_index(c)];
+  }, start);
   return os;
 }
 

--- a/include/h2/tensor/strided_memory.hpp
+++ b/include/h2/tensor/strided_memory.hpp
@@ -161,7 +161,8 @@ public:
     }
     else
     {
-      mem_offset = base.get_index(get_index_range_start(coords));
+      mem_offset =
+          base.get_index(get_index_range_start(coords)) + base.mem_offset;
       mem_shape = get_index_range_shape(coords, base.shape());
       if (mem_shape.is_empty())
       {

--- a/include/h2/tensor/tensor.hpp
+++ b/include/h2/tensor/tensor.hpp
@@ -93,6 +93,13 @@ public:
         tensor_memory(other.tensor_memory, new_device, new_stream)
   {}
 
+  Tensor(const Tensor<T>& other,
+         Device new_device,
+         const ComputeStream& new_stream)
+      : BaseTensor(ViewType::Const, other.shape(), other.dim_types()),
+        tensor_memory(other.tensor_memory, new_device, new_stream)
+  {}
+
   /** Internal constructor for cloning. */
   Tensor(const StridedMemory<T>& mem_,
          const ShapeTuple& shape_,

--- a/include/h2/tensor/tensor.hpp
+++ b/include/h2/tensor/tensor.hpp
@@ -466,6 +466,11 @@ public:
   /** Return a pointer to the tensor at a particular coordinate. */
   T* get(const ScalarIndexTuple& coords)
   {
+    H2_ASSERT_DEBUG(is_index_in_shape(coords, shape()),
+                    "Cannot get index ",
+                    coords,
+                    " in tensor with shape ",
+                    shape());
     return tensor_memory.get(coords);
   }
 
@@ -474,6 +479,11 @@ public:
    */
   const T* get(const ScalarIndexTuple& coords) const
   {
+    H2_ASSERT_DEBUG(is_index_in_shape(coords, shape()),
+                    "Cannot get index ",
+                    coords,
+                    " in tensor with shape ",
+                    shape());
     return tensor_memory.get(coords);
   }
 

--- a/include/h2/tensor/tensor.hpp
+++ b/include/h2/tensor/tensor.hpp
@@ -471,6 +471,10 @@ public:
                     coords,
                     " in tensor with shape ",
                     shape());
+    if (this->tensor_view_type == ViewType::Const)
+    {
+      throw H2Exception("Cannot access non-const buffer of const view");
+    }
     return tensor_memory.get(coords);
   }
 
@@ -485,6 +489,19 @@ public:
                     " in tensor with shape ",
                     shape());
     return tensor_memory.get(coords);
+  }
+
+  /**
+   * Return a constant pointer to the tensor at a particular coordinate.
+   */
+  const T* const_get(const ScalarIndexTuple& coords) const
+  {
+    H2_ASSERT_DEBUG(is_index_in_shape(coords, shape()),
+                    "Cannot get index ",
+                    coords,
+                    " in tensor with shape ",
+                    shape());
+    return tensor_memory.const_get(coords);
   }
 
   ComputeStream get_stream() const H2_NOEXCEPT

--- a/include/h2/tensor/tensor_utils.hpp
+++ b/include/h2/tensor/tensor_utils.hpp
@@ -205,10 +205,76 @@ intersect_index_ranges(const IndexRangeTuple& ir1,
 }
 
 /**
+ * Return true if the given scalar index is a valid index within shape.
+ */
+constexpr inline bool is_index_in_shape(const ScalarIndexTuple& idx,
+                                        const ShapeTuple& shape) H2_NOEXCEPT
+{
+  H2_ASSERT_DEBUG(idx.size() == shape.size(),
+                  "Scalar indices ",
+                  idx,
+                  " and shape ",
+                  shape,
+                  " must be the same size");
+  for (typename ScalarIndexTuple::size_type dim = 0; dim < idx.size(); ++dim)
+  {
+    if (idx[dim] >= shape[dim])
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Return the next index after idx in a given shape.
+ *
+ * This gives the next index in the generalized column-major order.
+ *
+ * If idx is the last index, this will return an index one past the
+ * end.
+ */
+constexpr inline ScalarIndexTuple
+next_scalar_index(const ScalarIndexTuple& idx,
+                  const ShapeTuple& shape) H2_NOEXCEPT
+{
+  H2_ASSERT_DEBUG(idx.size() == shape.size(),
+                  "Scalar indices ",
+                  idx,
+                  " and shape ",
+                  shape,
+                  " must be the same size");
+  H2_ASSERT_DEBUG(!idx.is_empty(), "Cannot get next index from an empty index");
+  H2_ASSERT_DEBUG(is_index_in_shape(idx, shape),
+                  "Cannot get next index from index ",
+                  idx,
+                  " that is not in shape ",
+                  shape);
+  ScalarIndexTuple next_idx = idx;
+  next_idx[0] += 1;
+  for (typename ScalarIndexTuple::size_type dim = 0; dim < idx.size() - 1; ++dim)
+  {
+    if (next_idx[dim] == shape[dim])
+    {
+      next_idx[dim] = 0;
+      next_idx[dim + 1] += 1;
+    }
+  }
+  if (next_idx.back() == shape.back())
+  {
+    // Went past the end.
+    return ScalarIndexTuple::convert_from(shape);
+  }
+  return next_idx;
+}
+
+/**
  * Iterate over an n-dimensional region.
  *
  * The given function f will be called with a `ScalarIndexTuple` for
  * each index position.
+ *
+ * The iteration is done in the generalized column-major order.
  *
  * @todo In the future, we could specialize for specific dimensions.
  */

--- a/include/h2/tensor/tuple_utils.hpp
+++ b/include/h2/tensor/tuple_utils.hpp
@@ -202,14 +202,6 @@ init(FixedSizeTuple<T, SizeType, N> const& in) H2_NOEXCEPT
   return out;
 }
 
-/** @brief Get the last element of the input tuple */
-template <typename T, typename SizeType, SizeType N>
-constexpr T last(FixedSizeTuple<T, SizeType, N> const& in) H2_NOEXCEPT
-{
-  H2_ASSERT_DEBUG(!in.is_empty(), "Cannot get last of empty tuple");
-  return in[in.size() - 1];
-}
-
 /**
  * Return a tuple containing the first n elements of the given tuple.
  */

--- a/include/h2/utils/Error.hpp
+++ b/include/h2/utils/Error.hpp
@@ -11,6 +11,7 @@
 #include <h2_config.hpp>
 
 #include <exception>
+#include <iostream>
 #include <memory>
 #include <string>
 
@@ -170,6 +171,47 @@ H2_DEFINE_FORWARDING_EXCEPTION(H2Exception, H2FatalException);
  * @param ... Message to pass to the exception if the condition fails.
  */
 #define H2_ASSERT_ALWAYS(cond, ...) H2_ASSERT(cond, H2FatalException, __VA_ARGS__)
+
+/**
+ * Execute the given code block and terminate the application if an
+ * exception is thrown.
+ *
+ * This is primarily intended for use in destructors.
+ *
+ * @warning Beware of unprotected commas, you may want to enclose your
+ * code in parens.
+ *
+ * @param code Code to evaluate.
+ */
+#define H2_TERMINATE_ON_THROW_ALWAYS(code)                                     \
+  do                                                                           \
+  {                                                                            \
+    try                                                                        \
+    {                                                                          \
+      code;                                                                    \
+    }                                                                          \
+    catch (const std::exception& e)                                            \
+    {                                                                          \
+      std::cerr << "Caught exception and terminating immediately\n"            \
+                << e.what() << std::endl;                                      \
+      std::terminate();                                                        \
+    }                                                                          \
+  }                                                                            \
+ while (0)
+#ifdef H2_DEBUG
+/**
+ * Behave exactly like H2_TERMINATE_ON_THROW_ALWAYS, except only check
+ * for exceptions in debug mode.
+ */
+#define H2_TERMINATE_ON_THROW_DEBUG(code) H2_TERMINATE_ON_THROW_ALWAYS(code)
+#else
+#define H2_TERMINATE_ON_THROW_DEBUG(code)                                      \
+  do                                                                           \
+  {                                                                            \
+    code;                                                                      \
+  }                                                                            \
+  while (0)
+#endif  // H2_DEBUG
 
 namespace h2
 {

--- a/test/static_test/tensor/fixed_size_tuple.cpp
+++ b/test/static_test/tensor/fixed_size_tuple.cpp
@@ -196,14 +196,6 @@ static_assert(test_sized_tuple_pad3[2] == 0);
 static_assert(test_sized_tuple_pad3[3] == 0);
 }
 
-namespace last_test
-{
-
-constexpr TestFixedSizeTuple test_last{1, 2, 3};
-static_assert(last(test_last) == 3);
-
-} // namespace last_test
-
 namespace init_test
 {
 

--- a/test/static_test/tensor/fixed_size_tuple.cpp
+++ b/test/static_test/tensor/fixed_size_tuple.cpp
@@ -20,6 +20,11 @@ constexpr TestFixedSizeTuple test_tuple;
 static_assert(test_tuple.size() == 0);
 static_assert(test_tuple.is_empty());
 
+constexpr auto converted_tuple =
+    h2::FixedSizeTuple<long long int, std::size_t, 4>::convert_from(test_tuple);
+static_assert(converted_tuple.size() == 0);
+static_assert(converted_tuple.is_empty());
+
 constexpr TestFixedSizeTuple test_tuple2;
 static_assert(test_tuple == test_tuple2);
 
@@ -77,6 +82,14 @@ static_assert(test_tuple == test_tuple2);
 constexpr TestFixedSizeTuple test_tuple3(2, 1);
 static_assert(test_tuple != test_tuple3);
 
+constexpr auto converted_tuple =
+    h2::FixedSizeTuple<long long int, std::size_t, 4>::convert_from(test_tuple);
+static_assert(converted_tuple.size() == 2);
+static_assert(converted_tuple[0] == 1);
+static_assert(converted_tuple[1] == 2);
+static_assert(!converted_tuple.is_empty());
+static_assert(converted_tuple == test_tuple);
+
 static_assert(h2::product<int>(test_tuple) == 2);
 static_assert(h2::inner_product<int>(test_tuple, test_tuple2) == 5);
 static_assert(h2::prefix_product<int>(test_tuple) == TestFixedSizeTuple(1, 1));
@@ -132,6 +145,9 @@ static_assert(test_tuple.begin() + test_tuple.size() == test_tuple.end());
 static_assert(*test_tuple.rbegin() == 2);
 static_assert(*std::next(test_tuple.rbegin()) == 1);
 static_assert(test_tuple.rbegin() + test_tuple.size() == test_tuple.rend());
+
+static_assert(test_tuple.front() == 1);
+static_assert(test_tuple.back() == 2);
 
 constexpr auto test_tuple_copy = test_tuple;
 static_assert(test_tuple_copy.size() == 2);

--- a/test/static_test/tensor/tensor_types.cpp
+++ b/test/static_test/tensor/tensor_types.cpp
@@ -143,3 +143,18 @@ static_assert(intersect_index_ranges(IndexRangeTuple(IRng(0, 1), IRng(0, 2)),
                                      IndexRangeTuple(IRng(0, 1), ALL))
               == IndexRangeTuple(IRng(0, 1), IRng(0, 2)));
 }  // namespace intersect_index_ranges_tests
+
+namespace is_index_in_shape_tests
+{
+static_assert(is_index_in_shape(ScalarIndexTuple{}, ShapeTuple{}));
+static_assert(is_index_in_shape(ScalarIndexTuple{0, 0}, ShapeTuple{2, 2}));
+static_assert(!is_index_in_shape(ScalarIndexTuple{2, 2}, ShapeTuple{2, 2}));
+}  // namespace is_index_in_shape_tests
+
+namespace next_scalar_index_tests
+{
+static_assert(next_scalar_index({0}, {2}) == ScalarIndexTuple{1});
+static_assert(next_scalar_index({0, 0}, {2, 2}) == ScalarIndexTuple{1, 0});
+static_assert(next_scalar_index({1, 0}, {2, 2}) == ScalarIndexTuple{0, 1});
+static_assert(next_scalar_index({1}, {2}) == ScalarIndexTuple{2});
+}  // namespace next_scalar_index_tests

--- a/test/unit_test/core/CMakeLists.txt
+++ b/test/unit_test/core/CMakeLists.txt
@@ -6,12 +6,14 @@
 ################################################################################
 
 target_sources(SeqCatchTests PRIVATE
+  unit_test_allocator.cpp
   unit_test_sync.cpp
   unit_test_version.cpp
 )
 
 if (H2_HAS_GPU)
   target_sources(GPUCatchTests PRIVATE
+    unit_test_allocator.cpp
     unit_test_sync.cpp
   )
 endif ()

--- a/test/unit_test/core/unit_test_allocator.cpp
+++ b/test/unit_test/core/unit_test_allocator.cpp
@@ -1,0 +1,51 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+
+#include "h2/core/allocator.hpp"
+#include "../tensor/utils.hpp"
+
+using namespace h2;
+
+
+TEMPLATE_LIST_TEST_CASE("Allocation and deallocation works",
+                        "[allocator]",
+                        AllDevList)
+{
+  constexpr Device Dev = TestType::value;
+
+  ComputeStream stream{Dev};
+
+  DataType* buf = h2::internal::Allocator<DataType, Dev>::allocate(8, stream);
+  REQUIRE(buf != nullptr);
+
+  // Ensure a second allocation gets a new buffer.
+  DataType* buf2 = h2::internal::Allocator<DataType, Dev>::allocate(8, stream);
+  REQUIRE(buf2 != nullptr);
+  REQUIRE(buf != buf2);
+
+  REQUIRE_NOTHROW(
+      h2::internal::Allocator<DataType, Dev>::deallocate(buf, stream));
+  REQUIRE_NOTHROW(
+      h2::internal::Allocator<DataType, Dev>::deallocate(buf2, stream));
+}
+
+TEMPLATE_LIST_TEST_CASE("Zero-size allocation and deallocation works",
+                        "[allocator]",
+                        AllDevList)
+{
+  constexpr Device Dev = TestType::value;
+
+  ComputeStream stream{Dev};
+
+  // Should succeed, but can't say anything about the pointer.
+  DataType* buf = h2::internal::Allocator<DataType, Dev>::allocate(0, stream);
+  REQUIRE_NOTHROW(
+      h2::internal::Allocator<DataType, Dev>::deallocate(buf, stream));
+}

--- a/test/unit_test/tensor/CMakeLists.txt
+++ b/test/unit_test/tensor/CMakeLists.txt
@@ -8,6 +8,7 @@
 target_sources(SeqCatchTests PRIVATE
   unit_test_copy.cpp
   unit_test_dist_utils_nompi.cpp
+  unit_test_io.cpp
   unit_test_raw_buffer.cpp
   unit_test_strided_memory.cpp
   unit_test_tensor.cpp
@@ -17,6 +18,7 @@ target_sources(SeqCatchTests PRIVATE
 if (H2_HAS_GPU)
   target_sources(GPUCatchTests PRIVATE
     unit_test_copy.cpp
+    unit_test_io.cpp
     unit_test_raw_buffer.cpp
     unit_test_strided_memory.cpp
     unit_test_tensor.cpp

--- a/test/unit_test/tensor/unit_test_hydrogen_interop.cpp
+++ b/test/unit_test/tensor/unit_test_hydrogen_interop.cpp
@@ -219,7 +219,7 @@ TEMPLATE_LIST_TEST_CASE("Hydrogen to DiHydrogen conversion",
         for (int row = 0; row < m; ++row)
         {
             INFO("ROW=" << row);
-            CHECK(tensor.get({row}) == mat.LockedBuffer(row, 0));
+            CHECK(tensor.const_get({row}) == mat.LockedBuffer(row, 0));
         }
     }
 
@@ -258,7 +258,7 @@ TEMPLATE_LIST_TEST_CASE("Hydrogen to DiHydrogen conversion",
         for (int col = 0; col < n; ++col)
         {
             INFO("COL=" << col);
-            CHECK(tensor.get({col}) == mat.LockedBuffer(0, col));
+            CHECK(tensor.const_get({col}) == mat.LockedBuffer(0, col));
         }
     }
 
@@ -299,7 +299,7 @@ TEMPLATE_LIST_TEST_CASE("Hydrogen to DiHydrogen conversion",
             for (int row = 0; row < m; ++row)
             {
                 INFO("ROW=" << row << ", COL=" << col);
-                CHECK(tensor.get({row, col}) == mat.LockedBuffer(row, col));
+                CHECK(tensor.const_get({row, col}) == mat.LockedBuffer(row, col));
             }
     }
 
@@ -340,7 +340,7 @@ TEMPLATE_LIST_TEST_CASE("Hydrogen to DiHydrogen conversion",
             for (int row = 0; row < m; ++row)
             {
                 INFO("ROW=" << row << ", COL=" << col);
-                CHECK(tensor.get({row, col}) == mat.LockedBuffer(row, col));
+                CHECK(tensor.const_get({row, col}) == mat.LockedBuffer(row, col));
             }
     }
 }

--- a/test/unit_test/tensor/unit_test_io.cpp
+++ b/test/unit_test/tensor/unit_test_io.cpp
@@ -1,0 +1,107 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+
+#include <sstream>
+
+#include "h2/tensor/tensor.hpp"
+#include "h2/tensor/io.hpp"
+#include "utils.hpp"
+
+using namespace h2;
+
+
+TEMPLATE_LIST_TEST_CASE("Printing tensors works", "[tensor][io]", AllDevList)
+{
+  constexpr Device Dev = TestType::value;
+  using TensorType = Tensor<DataType>;
+
+  SECTION("Printing an empty tensor works")
+  {
+    TensorType tensor{Dev};
+    std::stringstream ss;
+    print(ss, tensor);
+    REQUIRE(ss.str() == "[]");
+  }
+
+  SECTION("Printing a 1D tensor works")
+  {
+    TensorType tensor{Dev, {4}, {DT::Any}};
+    for (DataIndexType i = 0; i < tensor.numel(); ++i)
+    {
+      write_ele<Dev>(
+          tensor.data(), i, static_cast<DataType>(i), tensor.get_stream());
+    }
+    std::stringstream ss;
+    print(ss, tensor);
+    REQUIRE(ss.str() == "[0, 1, 2, 3]");
+  }
+
+  SECTION("Printing a 2D tensor works")
+  {
+    TensorType tensor{Dev, {2, 4}, {DT::Any, DT::Any}};
+    for (DataIndexType i = 0; i < tensor.numel(); ++i)
+    {
+      write_ele<Dev>(
+          tensor.data(), i, static_cast<DataType>(i), tensor.get_stream());
+    }
+    std::stringstream ss;
+    print(ss, tensor);
+    const char* expected = "[\n"
+                           " [0, 2, 4, 6]\n"
+                           " [1, 3, 5, 7]\n"
+                           "]";
+    REQUIRE(ss.str() == expected);
+  }
+
+  SECTION("Printing a 3D tensor works")
+  {
+    TensorType tensor{Dev, {2, 2, 4}, {DT::Any, DT::Any, DT::Any}};
+    for (DataIndexType i = 0; i < tensor.numel(); ++i)
+    {
+      write_ele<Dev>(
+          tensor.data(), i, static_cast<DataType>(i), tensor.get_stream());
+    }
+    std::stringstream ss;
+    print(ss, tensor);
+    const char* expected = "[\n"
+                           " [\n"
+                           "  [0, 4, 8, 12]\n"
+                           "  [2, 6, 10, 14]\n"
+                           " ]\n"
+                           " [\n"
+                           "  [1, 5, 9, 13]\n"
+                           "  [3, 7, 11, 15]\n"
+                           " ]\n"
+                           "]";
+    REQUIRE(ss.str() == expected);
+  }
+
+  SECTION("Printing single-element tensors works")
+  {
+    const char* expected[] = {
+      "[1]",
+      "[\n [1]\n]",
+      "[\n [\n  [1]\n ]\n]",
+      "[\n [\n  [\n   [1]\n  ]\n ]\n]",
+      "[\n [\n  [\n   [\n    [1]\n   ]\n  ] \n]\n]"
+    };
+    for (typename ShapeTuple::type ndims = 1; ndims <= 3; ++ndims)
+    {
+      TensorType tensor{Dev,
+                        ShapeTuple{TuplePad<ShapeTuple>(ndims, 1)},
+                        DTTuple{TuplePad<DTTuple>(ndims, DT::Any)}};
+      write_ele<Dev>(
+          tensor.data(), 0, static_cast<DataType>(1), tensor.get_stream());
+      std::stringstream ss;
+      print(ss, tensor);
+      REQUIRE(ss.str() == expected[ndims - 1]);
+    }
+  }
+}

--- a/test/unit_test/tensor/unit_test_io.cpp
+++ b/test/unit_test/tensor/unit_test_io.cpp
@@ -104,4 +104,46 @@ TEMPLATE_LIST_TEST_CASE("Printing tensors works", "[tensor][io]", AllDevList)
       REQUIRE(ss.str() == expected[ndims - 1]);
     }
   }
+
+  SECTION("Printing a contiguous view works")
+  {
+    TensorType tensor{Dev, {2, 2, 4}, {DT::Any, DT::Any, DT::Any}};
+    for (DataIndexType i = 0; i < tensor.numel(); ++i)
+    {
+      write_ele<Dev>(
+          tensor.data(), i, static_cast<DataType>(i), tensor.get_stream());
+    }
+    auto view = tensor.view();
+    std::stringstream ss;
+    print(ss, *view);
+    const char* expected = "[\n"
+                           " [\n"
+                           "  [0, 4, 8, 12]\n"
+                           "  [2, 6, 10, 14]\n"
+                           " ]\n"
+                           " [\n"
+                           "  [1, 5, 9, 13]\n"
+                           "  [3, 7, 11, 15]\n"
+                           " ]\n"
+                           "]";
+    REQUIRE(ss.str() == expected);
+  }
+
+  SECTION("Printing a sub-view works")
+  {
+    TensorType tensor{Dev, {2, 4}, {DT::Any, DT::Any}};
+    for (DataIndexType i = 0; i < tensor.numel(); ++i)
+    {
+      write_ele<Dev>(
+          tensor.data(), i, static_cast<DataType>(i), tensor.get_stream());
+    }
+    auto view = tensor.view({ALL, IRng(1, 3)});
+    std::stringstream ss;
+    print(ss, *view);
+    const char* expected = "[\n"
+                           " [2, 4]\n"
+                           " [3, 5]\n"
+                           "]";
+    REQUIRE(ss.str() == expected);
+  }
 }

--- a/test/unit_test/tensor/unit_test_raw_buffer.cpp
+++ b/test/unit_test/tensor/unit_test_raw_buffer.cpp
@@ -304,5 +304,4 @@ TEMPLATE_LIST_TEST_CASE("Raw buffer contents print",
 
     REQUIRE(ss.str() == expected_ss.str());
   }
-
 }

--- a/test/unit_test/tensor/unit_test_tensor.cpp
+++ b/test/unit_test/tensor/unit_test_tensor.cpp
@@ -16,28 +16,28 @@
 
 using namespace h2;
 
-TEST_CASE("last(FixedSizeTuple)", "[utilities]")
+TEST_CASE("FixedSizeTuple::back", "[utilities]")
 {
-    using TupleType = h2::FixedSizeTuple<int, unsigned, 8U>;
+  using TupleType = h2::FixedSizeTuple<int, unsigned, 8U>;
 #ifdef H2_DEBUG
-    SECTION("last of a zero-element (empty) tuple is error")
-    {
-        TupleType x;
-        CHECK_THROWS(h2::last(x));
-    }
+  SECTION("back of a zero-element (empty) tuple is error")
+  {
+    TupleType x;
+    CHECK_THROWS(x.back());
+  }
 #endif
 
-    SECTION("last of a single-element tuple returns only element")
-    {
-        TupleType x = {1};
-        CHECK(h2::last(x) == 1);
-    }
+  SECTION("back of a single-element tuple returns only element")
+  {
+    TupleType x = {1};
+    CHECK(x.back() == 1);
+  }
 
-    SECTION("last of multi-element tuple returns last element")
-    {
-        TupleType x = {1, 2, 3, 4, 5};
-        CHECK(h2::last(x) == 5);
-    }
+  SECTION("back of multi-element tuple returns last element")
+  {
+    TupleType x = {1, 2, 3, 4, 5};
+    CHECK(x.back() == 5);
+  }
 }
 
 TEST_CASE("init(FixedSizeTuple)", "[utilities]")

--- a/test/unit_test/tensor/unit_test_tensor.cpp
+++ b/test/unit_test/tensor/unit_test_tensor.cpp
@@ -93,6 +93,17 @@ TEST_CASE("for_ndim", "[tensor]")
     });
   }
 
+  SECTION("1 with start")
+  {
+    ShapeTuple shape{4};
+    std::vector<ScalarIndexTuple> v = {{1}, {2}, {3}};
+    DataIndexType i = 0;
+    for_ndim(shape, [&](ScalarIndexTuple c) {
+      REQUIRE(c == v[i]);
+      ++i;
+    }, {1});
+  }
+
   SECTION("2d")
   {
     ShapeTuple shape{4, 2};
@@ -103,6 +114,17 @@ TEST_CASE("for_ndim", "[tensor]")
       REQUIRE(c == v[i]);
       ++i;
     });
+  }
+
+  SECTION("2d with start")
+  {
+    ShapeTuple shape{4, 2};
+    std::vector<ScalarIndexTuple> v = {{2, 1}, {3, 1}};
+    DataIndexType i = 0;
+    for_ndim(shape, [&](ScalarIndexTuple c) {
+      REQUIRE(c == v[i]);
+      ++i;
+    }, {2, 1});
   }
 
   SECTION("3d")
@@ -121,6 +143,25 @@ TEST_CASE("for_ndim", "[tensor]")
       REQUIRE(c == v[i]);
       ++i;
     });
+  }
+
+  SECTION("3d with start")
+  {
+    ShapeTuple shape{2, 2, 2};
+    std::vector<ScalarIndexTuple> v = {{1, 0, 1}, {0, 1, 1}, {1, 1, 1}};
+    DataIndexType i = 0;
+    for_ndim(shape, [&](ScalarIndexTuple c) {
+      REQUIRE(c == v[i]);
+      ++i;
+    }, {1, 0, 1});
+  }
+
+  SECTION("Out-of-range start works")
+  {
+    ShapeTuple shape{4, 2};
+    for_ndim(shape,
+             [&](ScalarIndexTuple c) { FAIL("Should not be executed"); },
+             {4, 2});
   }
 }
 

--- a/test/unit_test/tensor/unit_test_tensor.cpp
+++ b/test/unit_test/tensor/unit_test_tensor.cpp
@@ -210,6 +210,7 @@ TEMPLATE_LIST_TEST_CASE("Tensor metadata is sane", "[tensor]", AllDevList)
   REQUIRE(tensor.data() != nullptr);
   REQUIRE(tensor.const_data() != nullptr);
   REQUIRE(tensor.get({0, 0}) == tensor.data());
+  REQUIRE(tensor.const_get({0, 0}) == tensor.data());
   REQUIRE_FALSE(tensor.is_lazy());
 
   const TensorType const_tensor =
@@ -234,6 +235,7 @@ TEMPLATE_LIST_TEST_CASE("Tensor metadata is sane", "[tensor]", AllDevList)
   REQUIRE(const_tensor.data() != nullptr);
   REQUIRE(const_tensor.const_data() != nullptr);
   REQUIRE(const_tensor.get({0, 0}) == const_tensor.data());
+  REQUIRE(const_tensor.const_get({0, 0}) == const_tensor.data());
   REQUIRE_FALSE(const_tensor.is_lazy());
 }
 
@@ -332,6 +334,7 @@ TEMPLATE_LIST_TEST_CASE("Single element tensor metadata is sane",
   REQUIRE(tensor.data() != nullptr);
   REQUIRE(tensor.const_data() != nullptr);
   REQUIRE(tensor.get({0}) == tensor.data());
+  REQUIRE(tensor.const_get({0}) == tensor.data());
   REQUIRE_FALSE(tensor.is_lazy());
 }
 
@@ -528,7 +531,9 @@ TEMPLATE_LIST_TEST_CASE("Viewing tensors works", "[tensor]", AllDevList)
     REQUIRE(view->is_const_view());
     REQUIRE(view->get_view_type() == ViewType::Const);
     REQUIRE(view->const_data() == tensor.data());
+    REQUIRE(view->const_get({0, 0}) == tensor.data());
     REQUIRE_THROWS(view->data());
+    REQUIRE_THROWS(view->get({0, 0}));
     REQUIRE(view->is_contiguous());
   }
   SECTION("Viewing a (1, ALL) subtensor works")


### PR DESCRIPTION
This adds full support for printing `Tensor`s, `StridedMemory`, and `RawBuffer`s. (`DistTensor` will be separate because we need to deal with multiple processors printing, or aggregate to a `Single` distribution.)

As part of this, there were a number of minor feature additions and other code changes.