### PR TITLE
Dynamic (runtime) dispatch

### DIFF
--- a/.gitlab/build-and-test-lassen.yml
+++ b/.gitlab/build-and-test-lassen.yml
@@ -29,13 +29,13 @@ include:
 clang-16-0-6-gcc-11-2-1-cuda-12-2-2-lassen:
   variables:
     COMPILER_FAMILY: clang
-    MODULES: "clang/16.0.6-gcc-11.2.1 spectrum-mpi/rolling-release cuda/12.2.2 cmake/3.29.2 python/3.8.2"
+    MODULES: "clang/16.0.6-gcc-11.2.1 spectrum-mpi/rolling-release cuda/12.2.2 cmake/3.29.2 python/3.11.5"
   extends: .build-and-test-on-lassen
 
 clang-16-0-6-gcc-11-2-1-cuda-12-2-2-distconv-lassen:
   variables:
     COMPILER_FAMILY: clang
-    MODULES: "clang/16.0.6-gcc-11.2.1 spectrum-mpi/rolling-release cuda/12.2.2 cmake/3.29.2 python/3.8.2"
+    MODULES: "clang/16.0.6-gcc-11.2.1 spectrum-mpi/rolling-release cuda/12.2.2 cmake/3.29.2 python/3.11.5"
     WITH_DISTCONV: "1"
   extends: .build-and-test-on-lassen
   rules:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,6 +372,13 @@ else ()
   set(H2_HAS_MPI FALSE)
 endif ()
 
+# Python is needed during the build process to preprocess files.
+find_package(Python3 3.9 REQUIRED COMPONENTS Interpreter)
+message(STATUS "Using ${Python3_EXECUTABLE} for preprocessing")
+
+# Decide where to put preprocessed files.
+set(H2_PREPROCESSED_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/preprocessed")
+
 # Decide where to put generated include files.
 set(CMAKE_GENERATED_INCLUDE_DIRECTORY
   "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_INCLUDEDIR}")
@@ -397,6 +404,44 @@ add_library(H2Core
 
 add_subdirectory(include/h2)
 add_subdirectory(src)
+
+# Preprocess all source files for dynamic dispatch.
+set(H2_DISPATCH_GEN_SCRIPT "${CMAKE_SOURCE_DIR}/scripts/dispatch_gen.py")
+if (NOT EXISTS "${H2_DISPATCH_GEN_SCRIPT}")
+  message(FATAL_ERROR
+    "Could not find dispatch generation script ${H2_DISPATCH_GEN_SCRIPT}")
+endif ()
+get_target_property(SOURCES_TO_PREPROCESS H2Core SOURCES)
+set(PREPROCESSED_SOURCES "")
+foreach (SOURCE_FILE ${SOURCES_TO_PREPROCESS})
+  if (SOURCE_FILE MATCHES ".*h2_config\\.hpp$")
+    # Skip h2_config.hpp.
+    list(APPEND PREPROCESSED_SOURCES ${SOURCE_FILE})
+    continue()
+  endif ()
+
+  cmake_path(RELATIVE_PATH SOURCE_FILE BASE_DIRECTORY ${CMAKE_SOURCE_DIR} OUTPUT_VARIABLE SOURCE_FILE_REL)
+  set(PREPROCESSED_SOURCE_FILE
+    "${H2_PREPROCESSED_OUTPUT_DIRECTORY}/${SOURCE_FILE_REL}")
+  #message(STATUS "Preprocessing: ${SOURCE_FILE_REL} -> ${PREPROCESSED_SOURCE_FILE}")
+  cmake_path(REMOVE_FILENAME PREPROCESSED_SOURCE_FILE OUTPUT_VARIABLE OUTPUT_DIR)
+  file(MAKE_DIRECTORY ${OUTPUT_DIR})
+
+  add_custom_command(
+    OUTPUT ${PREPROCESSED_SOURCE_FILE}
+    COMMAND ${Python3_EXECUTABLE} ${H2_DISPATCH_GEN_SCRIPT}
+    "--infile" ${SOURCE_FILE} "--outfile" ${PREPROCESSED_SOURCE_FILE}
+    DEPENDS ${SOURCE_FILE} ${H2_DISPATCH_GEN_SCRIPT}
+    COMMENT "Preprocessing ${SOURCE_FILE} -> ${PREPROCESSED_SOURCE_FILE}"
+  )
+
+  list(APPEND PREPROCESSED_SOURCES ${PREPROCESSED_SOURCE_FILE})
+endforeach ()
+add_custom_target(H2Core_preprocess ALL DEPENDS ${PREPROCESSED_SOURCES})
+add_dependencies(H2Core H2Core_preprocess)
+# Replace the sources with preprocessed ones.
+set_target_properties(H2Core PROPERTIES SOURCES "")
+target_sources(H2Core PRIVATE ${PREPROCESSED_SOURCES})
 
 # If using ROCm, set the appropriate property for all .cu files.
 if (H2_HAS_GPU AND H2_ENABLE_ROCM)

--- a/include/h2/core/dispatch.hpp
+++ b/include/h2/core/dispatch.hpp
@@ -339,17 +339,29 @@ get_native_dispatch_key(const TypeInfoHavers&... args)
   return get_native_dispatch_key(tokens);
 }
 
+/** Add a dispatch entry to the dispatch table for the name and key. */
 void add_dispatch_entry(const std::string& name,
                         const DispatchKeyT& dispatch_key,
                         const DispatchFunctionEntry& dispatch_entry);
 
+/** Return true if a dispatch entry exists for the name and key. */
 bool has_dispatch_entry(const std::string& name,
                         const DispatchKeyT& dispatch_key);
 
+/**
+ * Return the dispatch entry for name and key.
+ *
+ * Throws if the entry is not present.
+ */
 const DispatchFunctionEntry&
 get_dispatch_entry(const std::string& name,
                    const DispatchKeyT& dispatch_key);
 
+/**
+ * Call the dispatch entry for name and key with the given arguments.
+ *
+ * Throws if the entry is not present.
+ */
 template <typename... Args>
 void call_dispatch_entry(const std::string& name,
                          const DispatchKeyT& dispatch_key,
@@ -366,12 +378,12 @@ get_dispatch_key(const std::array<TypeInfo::TokenType, N>& tokens)
 {
   static_assert(N <= max_dispatch_types,
                 "Attempt to get dispatch key for too many types");
-  DispatchKeyT dispatch_key = N << internal::dispatch_key_top_byte_shift;
+  DispatchKeyT dispatch_key = N << dispatch_key_top_byte_shift;
   // Shift tokens, with the first being leftmost, to construct the key.
   for (std::size_t i = 0; i < N; ++i)
   {
     dispatch_key |= tokens[i]
-                    << (internal::dispatch_bits_per_compute_type * (N - 1 - i));
+                    << (dispatch_bits_per_compute_type * (N - 1 - i));
   }
   return dispatch_key;
 }

--- a/include/h2/core/dispatch.hpp
+++ b/include/h2/core/dispatch.hpp
@@ -15,9 +15,11 @@
 #include <h2_config.hpp>
 
 #include <type_traits>
+#include <utility>
 
 #include "h2/core/types.hpp"
 #include "h2/core/device.hpp"
+#include "h2/utils/IntegerMath.hpp"
 
 
 /**
@@ -128,7 +130,147 @@
 namespace h2
 {
 
-//
+namespace internal
+{
+
+/**
+ * An entry in a dynamic dispatch table.
+ *
+ * This holds a function pointer (which will be dispatched to) and a
+ * function pointer to a "trampoline" caller which can reconstruct the
+ * true types of the function from a void*[] argument list.
+ */
+struct DispatchFunctionEntry
+{
+  void* func_ptr;
+  void (*caller)(void*, void**);
+};
+
+/**
+ * Wrapper to facilitate calling a type-erased function pointer.
+ *
+ * This is intended for use with `DispatchFunctionEntry`, which should
+ * hold the original function pointer and a function pointer to the
+ * `call` method of this class with the correct arguments.
+ */
+template <typename Ret, typename... Args>
+struct DispatchFunctionWrapper
+{
+  using FuncT = Ret (*)(Args...);
+  /** Call f (a function pointer) with the given arguments. */
+  static void call(void* f, void** args)
+  {
+    FuncT func = reinterpret_cast<FuncT>(f);
+    call_impl(func, args, std::index_sequence_for<Args...>{});
+  }
+
+private:
+  /** Helper to invoke func with args, expanding it appropriately. */
+  template <std::size_t... I>
+  static void call_impl(FuncT func, void** args, std::index_sequence<I...>)
+  {
+    // TODO:
+    // It is technically undefined behavior to cast from a void* to any
+    // type other than what the original type was. In the common case
+    // where we have a function taking a BaseTensor and an
+    // implementation taking a Tensor<T> (which is what the BaseTensor
+    // really is), we should cast to BaseTensor first and then downcast
+    // to Tensor<T> (possibly with dynamic_cast for extra safety).
+    func(*reinterpret_cast<std::remove_reference_t<Args>*>(args[I])...);
+  }
+};
+
+/** Call the function in the dispatch entry with args. */
+template <typename... Args>
+void dispatch_call(DispatchFunctionEntry& func, Args&&... args)
+{
+  void* func_args[] = {(void*) &args...};
+  func.caller(func.func_ptr, func_args);
+}
+
+
+/** Number of bits needed to uniquely represent all compute types. */
+constexpr std::size_t dispatch_bits_per_compute_type =
+    ceillog2(NumComputeTypes);
+
+/** Helper to construct a dispatch key with sanity checking. */
+template <unsigned int num_types>
+struct DispatchKeyT_impl
+{
+  /** Number of bits needed to represent the dispatch key. */
+  static constexpr unsigned int num_bits =
+      dispatch_bits_per_compute_type * num_types;
+  /** Number of bytes needed to represent the dispatch key. */
+  static constexpr unsigned int num_bytes = byteceil(num_bits);
+  static_assert(
+      num_bytes <= 8,
+      "Cannot create a dispatch key that would require more than8 bytes");
+  /** Type to use for the dispatch key. */
+  using type = typename UTypeForBytes<num_bytes>::type;
+};
+
+/** Type for a dispatch key that dispatches over num_types types. */
+template <unsigned int num_types>
+using DispatchKeyT = typename DispatchKeyT_impl<num_types>::type;
+
+// TODO: Handle case where it's not a compute type.
+// TODO: Versions with TypeInfo(const?).
+
+/**
+ * Extract the `TypeInfo` from something.
+ *
+ * The "something" (x) must be either a `TypeInfo` already or something
+ * that has a `get_type_info` method.
+ */
+template <typename TypeInfoHaver>
+inline TypeInfo get_type_info(const TypeInfoHaver& x)
+{
+  return x.get_type_info();
+}
+
+template <>
+inline TypeInfo get_type_info<TypeInfo>(const TypeInfo& tinfo)
+{
+  return tinfo;
+}
+
+/** True if all arguments have a runtime type that is a compute type. */
+template <typename... TypeInfoHavers>
+bool all_h2_compute_types(const TypeInfoHavers&... args)
+{
+  return (is_h2_type(get_type_info(args)) && ...);
+}
+
+/**
+ * Get the type token for x, which must meet the same requirements as
+ * in `get_type_info`.
+ */
+template <typename TypeInfoHaver>
+inline TypeInfo::TokenType get_type_token(const TypeInfoHaver& x)
+{
+  return get_type_info(x).get_token();
+}
+
+/**
+ * Return the dispatch key for dispatching over args.
+ */
+template <typename... TypeInfoHavers>
+constexpr DispatchKeyT<sizeof...(TypeInfoHavers)>
+get_dispatch_key(const TypeInfoHavers&... args)
+{
+  std::array<TypeInfo::TokenType, sizeof...(TypeInfoHavers)> tokens = {
+      {get_type_token(args)...}};
+  DispatchKeyT<sizeof...(TypeInfoHavers)> dispatch_key = 0;
+  // Shift tokens, with the first being leftmost, to construct the key.
+  for (std::size_t i = 0; i < sizeof...(args); ++i)
+  {
+    dispatch_key |= tokens[i] << (dispatch_bits_per_compute_type
+                                  * (sizeof...(TypeInfoHavers) - 1 - i));
+  }
+  return dispatch_key;
+}
+
+}  // namespace internal
 
 }  // namespace h2
 

--- a/include/h2/core/types.hpp
+++ b/include/h2/core/types.hpp
@@ -120,8 +120,10 @@ struct TypeInfo
   using TokenType = std::uint8_t;
   /** Max value for a token. */
   static constexpr TokenType max_token = std::numeric_limits<TokenType>::max();
+  /** Minimum value for user-defined tokens. */
+  static constexpr TokenType min_user_token = 32;
 
-  /** Helper to construct H2TypeInfo with a given token and type. */
+  /** Helper to construct TypeInfo with a given token and type. */
   template <typename T>
   static TypeInfo make(TokenType token_)
   {
@@ -161,19 +163,19 @@ private:
   const std::type_info* type_info;
 };
 
-/** Equality for H2TypeInfo. */
+/** Equality for TypeInfo. */
 inline bool operator==(const TypeInfo& t1, const TypeInfo& t2)
 {
   return *t1.get_type_info() == *t2.get_type_info();
 }
 
-/** Inequality for H2TypeInfo. */
+/** Inequality for TypeInfo. */
 inline bool operator!=(const TypeInfo& t1, const TypeInfo& t2)
 {
   return *t1.get_type_info() != *t2.get_type_info();
 }
 
-/** Get the H2TypeInfo for a given type. */
+/** Get the TypeInfo for a given type. */
 template <typename T>
 inline TypeInfo get_h2_type()
 {
@@ -187,9 +189,20 @@ inline TypeInfo get_h2_type()
   }
 }
 
-inline bool is_h2_type(const TypeInfo& ti)
+/** True if a type is a native H2 compute type. */
+inline bool is_h2_compute_type(const TypeInfo& ti)
 {
-  return ti.get_token() < 4;
+  return ti.get_token() < NumComputeTypes;
+}
+
+/**
+ * True if a type is a compute type.
+ *
+ * This is any type that has a token other than the max token.
+ */
+inline bool is_compute_type(const TypeInfo& ti)
+{
+  return ti.get_token() < TypeInfo::max_token;
 }
 
 }  // namespace h2

--- a/include/h2/core/types.hpp
+++ b/include/h2/core/types.hpp
@@ -108,6 +108,9 @@ using IntegralComputeTypes = meta::TL<std::int32_t, std::uint32_t>;
 using ComputeTypes =
     meta::tlist::Append<FloatComputeTypes, IntegralComputeTypes>;
 
+/** Number of compute types. */
+constexpr unsigned long NumComputeTypes = meta::tlist::Length<ComputeTypes>;
+
 // Wrap types for runtime dispatch:
 
 /** Manage runtime type information for H2. */
@@ -174,28 +177,19 @@ inline bool operator!=(const TypeInfo& t1, const TypeInfo& t2)
 template <typename T>
 inline TypeInfo get_h2_type()
 {
-  return TypeInfo::make<T>(TypeInfo::max_token);
+  if constexpr (IsH2ComputeType_v<T>)
+  {
+    return TypeInfo::make<T>(meta::tlist::Find<ComputeTypes, T>);
+  }
+  else
+  {
+    return TypeInfo::make<T>(TypeInfo::max_token);
+  }
 }
 
-template <>
-inline TypeInfo get_h2_type<float>()
+inline bool is_h2_type(const TypeInfo& ti)
 {
-  return TypeInfo::make<float>(0);
-}
-template <>
-inline TypeInfo get_h2_type<double>()
-{
-  return TypeInfo::make<double>(1);
-}
-template <>
-inline TypeInfo get_h2_type<std::int32_t>()
-{
-  return TypeInfo::make<std::int32_t>(2);
-}
-template <>
-inline TypeInfo get_h2_type<std::uint32_t>()
-{
-  return TypeInfo::make<std::uint32_t>(3);
+  return ti.get_token() < 4;
 }
 
 }  // namespace h2

--- a/include/h2/tensor/CMakeLists.txt
+++ b/include/h2/tensor/CMakeLists.txt
@@ -13,6 +13,7 @@ h2_add_sources_to_target_and_install(
   TARGET H2Core COMPONENT CORE SCOPE INTERFACE
   INSTALL_PREFIX "${H2_CURRENT_INSTALL_PREFIX}"
   SOURCES
+  base_utils.hpp
   copy.hpp
   copy_buffer.hpp
   dist_tensor_base.hpp

--- a/include/h2/tensor/base_utils.hpp
+++ b/include/h2/tensor/base_utils.hpp
@@ -1,0 +1,65 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+/** @file
+ *
+ * Helper routines for working with Base(Dist)Tensors.
+ *
+ * These are intended to help smooth over components of the API where
+ * runtime types are involved and we cannot easily use standard
+ * polymorphism.
+ *
+ * These use H2's dynamic dispatch infrastructure and therefore only
+ * support compute types.
+ */
+
+#include "h2/tensor/tensor_base.hpp"
+#include "h2/tensor/dist_tensor_base.hpp"
+
+namespace h2
+{
+namespace base
+{
+
+/**
+ * Create a new Tensor with type given in tinfo and other arguments
+ * as in the Tensor constructor.
+ */
+std::unique_ptr<BaseTensor>
+make_tensor(const TypeInfo& tinfo,
+            Device device,
+            const ShapeTuple& shape,
+            const DimensionTypeTuple& dim_types,
+            const StrideTuple& strides = {},
+            TensorAllocationStrategy alloc_type = StrictAlloc,
+            const std::optional<ComputeStream> stream = std::nullopt);
+
+/** Create a view of tensor. */
+std::unique_ptr<BaseTensor> view(BaseTensor& tensor);
+
+/** Create a subview of tensor. */
+std::unique_ptr<BaseTensor> view(BaseTensor& tensor,
+                                 const IndexRangeTuple& coords);
+
+/** Create a constant view of tensor. */
+std::unique_ptr<BaseTensor> view(const BaseTensor& tensor);
+
+/** Create a constant subview of tensor. */
+std::unique_ptr<BaseTensor> view(const BaseTensor& tensor,
+                                 const IndexRangeTuple& coords);
+
+/** Create a constant view of tensor. */
+std::unique_ptr<BaseTensor> const_view(const BaseTensor& tensor);
+
+/** Create a constant subview of tensor. */
+std::unique_ptr<BaseTensor> const_view(const BaseTensor& tensor,
+                                       const IndexRangeTuple& coords);
+
+}  // namespace base
+}  // namespace h2

--- a/include/h2/tensor/copy.hpp
+++ b/include/h2/tensor/copy.hpp
@@ -320,4 +320,11 @@ std::unique_ptr<Tensor<DstT>> cast(const Tensor<SrcT>& src)
   return dst;
 }
 
-}
+/** Version of `cast` for `BaseTensor`s. */
+template <typename DstT>
+std::unique_ptr<Tensor<DstT>> cast(BaseTensor& src);
+
+/** Fully runtime version of `cast`. */
+std::unique_ptr<BaseTensor> cast(const TypeInfo& type, BaseTensor& src);
+
+}  // namespace h2

--- a/include/h2/tensor/tensor.hpp
+++ b/include/h2/tensor/tensor.hpp
@@ -397,7 +397,7 @@ public:
    *
    * The `coords` given may omit dimensions on the right. In this case,
    * they are assumed to have their full range. However, if `coords` is
-   * fully empty, the view iwll be empty.
+   * fully empty, the view will be empty.
    *
    * If dimensions in `coords` are given as scalars, these dimensions
    * are eliminated from the tensor. If all dimensions are eliminated,

--- a/include/h2/utils/CMakeLists.txt
+++ b/include/h2/utils/CMakeLists.txt
@@ -22,4 +22,5 @@ h2_add_sources_to_target_and_install(
   passkey.hpp
   strings.hpp
   typename.hpp
+  unique_ptr_cast.hpp
   )

--- a/include/h2/utils/IntegerMath.hpp
+++ b/include/h2/utils/IntegerMath.hpp
@@ -84,6 +84,18 @@ struct IntegerTraits<uint64_t>
     static constexpr int nbits = 64;
 };
 
+/** @brief Determine a type that will store the given number of bytes. */
+template <int Bytes>
+struct UTypeForBytes;
+template <> struct UTypeForBytes<1> { using type = std::uint8_t; };
+template <> struct UTypeForBytes<2> { using type = std::uint16_t; };
+template <> struct UTypeForBytes<3> { using type = std::uint32_t; };
+template <> struct UTypeForBytes<4> { using type = std::uint32_t; };
+template <> struct UTypeForBytes<5> { using type = std::uint64_t; };
+template <> struct UTypeForBytes<6> { using type = std::uint64_t; };
+template <> struct UTypeForBytes<7> { using type = std::uint64_t; };
+template <> struct UTypeForBytes<8> { using type = std::uint64_t; };
+
 template <typename IType>
 using SType = typename IntegerTraits<IType>::signed_type;
 
@@ -105,11 +117,10 @@ inline constexpr bool IsUnsigned = meta::EqV<UType<IType>, IType>();
  *  function to return 0 when `d=0`.
  */
 template <typename IType, typename = meta::EnableWhen<IsUnsigned<IType>>>
-H2_GPU_FORCE_INLINE H2_GPU_HOST_DEVICE auto ceillog2(IType const& d)
+constexpr H2_GPU_FORCE_INLINE H2_GPU_HOST_DEVICE auto ceillog2(IType const& d)
 {
-    static constexpr auto nbits = NBits<IType>;
     int ell = 0;
-    for (ell = 0; ell < nbits; ++ell)
+    for (ell = 0; ell < NBits<IType>; ++ell)
         if ((static_cast<IType>(1) << ell) >= d)
             break;
     return ell;
@@ -117,9 +128,17 @@ H2_GPU_FORCE_INLINE H2_GPU_HOST_DEVICE auto ceillog2(IType const& d)
 
 /** @brief Determine if n is a power of 2. */
 template <typename IType, typename = meta::EnableWhen<IsUnsigned<IType>>>
-H2_GPU_FORCE_INLINE H2_GPU_HOST_DEVICE auto ispow2(IType const& d)
+constexpr H2_GPU_FORCE_INLINE H2_GPU_HOST_DEVICE auto ispow2(IType const& d)
 {
     return (d & (d - 1)) == 0;
+}
+
+/** @brief Determine the minimum number of bytes needed to store bits. */
+template <typename IType, typename = meta::EnableWhen<IsUnsigned<IType>>>
+constexpr H2_GPU_FORCE_INLINE H2_GPU_HOST_DEVICE auto
+byteceil(IType const& bits)
+{
+  return (bits / 8) + (bits % 8 > 0);
 }
 
 /** @brief Computes the upper 32 bits of `x*y`. */

--- a/include/h2/utils/unique_ptr_cast.hpp
+++ b/include/h2/utils/unique_ptr_cast.hpp
@@ -35,4 +35,14 @@ std::unique_ptr<DerivedT> downcast_uptr(std::unique_ptr<BaseT>& p)
   return std::unique_ptr<DerivedT>(static_cast<DerivedT*>(p.release()));
 }
 
+template <typename DerivedT, typename BaseT>
+std::unique_ptr<const DerivedT> downcast_uptr(std::unique_ptr<const BaseT>& p)
+{
+  static_assert(
+      std::is_base_of_v<BaseT, DerivedT>,
+      "Cannot cast a unique_ptr from a base class to a non-derived class");
+  return std::unique_ptr<const DerivedT>(
+      static_cast<const DerivedT*>(p.release()));
+}
+
 }  // namespace h2

--- a/include/h2/utils/unique_ptr_cast.hpp
+++ b/include/h2/utils/unique_ptr_cast.hpp
@@ -1,0 +1,38 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+/** @file
+ *
+ * Utilities for working with `std::unique_ptr`s.
+ */
+
+
+#include <memory>
+#include <type_traits>
+
+
+namespace h2
+{
+
+/**
+ * Cast a unique_ptr to a base class to a unique_ptr to a derived class
+ * of the base.
+ *
+ * The input unique_pointer will be invalidated.
+ */
+template <typename DerivedT, typename BaseT>
+std::unique_ptr<DerivedT> downcast_uptr(std::unique_ptr<BaseT>& p)
+{
+  static_assert(
+      std::is_base_of_v<BaseT, DerivedT>,
+      "Cannot cast a unique_ptr from a base class to a non-derived class");
+  return std::unique_ptr<DerivedT>(static_cast<DerivedT*>(p.release()));
+}
+
+}  // namespace h2

--- a/scripts/dispatch_gen.py
+++ b/scripts/dispatch_gen.py
@@ -1,0 +1,305 @@
+"""Generate runtime dispatch infrastructure for DiHydrogen."""
+
+import itertools
+import argparse
+import re
+import os.path
+
+
+
+# Compute types present in H2.
+# The index of each type in this list must match the index in the
+# h2::ComputeTypes type list.
+H2_COMPUTE_TYPES = ['float', 'double', 'std::int32_t', 'std::uint32_t']
+# Number of bits per token.
+H2_BITS_PER_COMPUTE_TYPE = (len(H2_COMPUTE_TYPES) - 1).bit_length()
+
+# Regex for matching dispatch arguments.
+# TODO: This will not handle any arguments that are string literals.
+H2_ARG_REGEX = re.compile(r'"([a-zA-Z0-9_\[\]()<>{}&*:\' ]+)"')
+
+
+def dispatch_table_str(
+        name: str, device: str, entries: list[str], indent: int = 0) -> str:
+    """Generate a dispatch table containing the entries."""
+    indent_str = ' ' * indent
+    table = indent_str + f'static std::array<::h2::internal::DispatchFunctionEntry, {len(entries)}> _dispatch_table_{name}_{device} = {{{{\n'
+    for entry in entries:
+        table += indent_str + f'{{{entry}}},\n'
+    table += indent_str + '}};\n'
+    return table
+
+
+def dispatch_entry_str(
+        impl_name: str, arg_strs: list[str], indent: int = 0) -> str:
+    """Generate an entry for a dispatch table."""
+    arg_list_str = ', '.join(arg_strs)
+    indent_str = ' ' * indent
+    entry = (
+        f'{indent_str}reinterpret_cast<void*>(\n'
+        f'{indent_str}    static_cast<void (*)({arg_list_str})>({impl_name})),\n'
+        f'{indent_str}&::h2::internal::DispatchFunctionWrapper<void, {arg_list_str}>::call'
+    )
+    return entry
+
+
+def do_dispatch_str(
+        table_name: str,
+        device: str,
+        dispatch_name: str,
+        dispatch_on: list[str],
+        args: list[str],
+        indent: int = 0) -> str:
+    """Generate a do_dispatch call."""
+    dispatch_args = ', '.join(dispatch_on)
+    dispatch_on_str = f'::h2::DispatchOn<{len(dispatch_on)}>({dispatch_args})'
+    args_str = ', '.join(args)
+    indent_str = ' ' * indent
+    dispatch_str = (
+        f'{indent_str}::h2::do_dispatch(_dispatch_table_{table_name}_{device}, '
+        f'"{dispatch_name}", {dispatch_on_str}, {args_str})'
+    )
+    return dispatch_str
+
+
+def device_dispatch_str(
+        get_device_str: str,
+        table_name: str,
+        dispatch_name: str,
+        dispatch_on: list[str],
+        cpu_args: list[str],
+        gpu_args: list[str],
+        indent: int = 0) -> str:
+    """Generate a H2_DEVICE_DISPATCH dispatch block."""
+    indent_str = ' ' * indent
+    prefix_padding = ' ' * len('H2_DEVICE_DISPATCH(')
+    cpu_dispatch = do_dispatch_str(
+        table_name, 'cpu', dispatch_name + '_cpu', dispatch_on, cpu_args)
+    gpu_dispatch = do_dispatch_str(
+        table_name, 'gpu', dispatch_name + '_gpu', dispatch_on, gpu_args)
+    dispatch_str = (
+        f'{indent_str}H2_DEVICE_DISPATCH({get_device_str},\n'
+        f'{indent_str}{prefix_padding}{cpu_dispatch},\n'
+        f'{indent_str}{prefix_padding}{gpu_dispatch});\n'
+    )
+    return dispatch_str
+
+
+def get_dispatch_types_in_order(num_types: int) -> list[tuple[str, ...]]:
+    """Generate a list of dispatch type sets, in the order they should
+    appear in the dispatch table."""
+    return [types
+            for types in itertools.product(*([H2_COMPUTE_TYPES]*num_types))]
+
+
+def get_dispatch_token_for_type(type_name: str) -> int:
+    """Return the dispatch token for a type."""
+    return H2_COMPUTE_TYPES.index(type_name)
+
+
+def get_dispatch_token_for_types(types: tuple[str, ...]) -> int:
+    """Return the token used to dispatch on types."""
+    types_token = 0
+    shift_start = len(types) - 1
+    for i, type_name in enumerate(types):
+        t_token = get_dispatch_token_for_type(type_name)
+        types_token |= t_token << H2_BITS_PER_COMPUTE_TYPE*(shift_start-i)
+    return types_token
+
+
+def get_dispatch_tokens_in_order(num_types: int) -> list[int]:
+    """Generate a list of dispatch tokens in type order."""
+    return [get_dispatch_token_for_types(types)
+            for types in get_dispatch_types_in_order(num_types)]
+
+
+def generate_dispatch_table(
+        num_types: int,
+        table_name: str,
+        impl_name: str,
+        device: str,
+        arg_strs: list[str],
+        indent: int = 0) -> str:
+    """Generate a complete dispatch table.
+
+    arg_strs and impl_name may contain format keys like '{T1}', ...,
+    which will be replaced with the corresponding dispatch type.
+    """
+    entries = []
+    for types in get_dispatch_types_in_order(num_types):
+        format_dict = {f'T{i+1}': t for i, t in enumerate(types)}
+        this_impl_name = impl_name.format(**format_dict)
+        entry_args = [arg.format(**format_dict) for arg in arg_strs]
+        entries.append(dispatch_entry_str(
+            this_impl_name, entry_args, indent=2))
+    return dispatch_table_str(table_name, device, entries, indent=indent)
+
+
+def parse_name_line(line: str) -> str:
+    """Return the base name for dispatch tables."""
+    line = line.strip()
+    name = line[len('// H2_DISPATCH_NAME: '):]
+    return name
+
+
+def parse_num_types_line(line: str) -> int:
+    """Return the number of types to dispatch on."""
+    line = line.strip()
+    num_types = int(line[len('// H2_DISPATCH_NUM_TYPES: '):])
+    return num_types
+
+
+def parse_init_line(orig_line: str) -> tuple[str, str, list[str]]:
+    """Extract table generation information (name, device, arguments)."""
+    line = orig_line.strip()
+    line = line[len('// H2_DISPATCH_INIT'):]
+    if line.startswith(':'):
+        device = 'none'
+        line = line[len(': '):]
+    elif line.startswith('_CPU:'):
+        device = 'cpu'
+        line = line[len('_CPU: '):]
+    elif line.startswith('_GPU'):
+        device = 'gpu'
+        line = line[len('_GPU: '):]
+    else:
+        raise RuntimeError(f'Do not know how to parse "{orig_line}"')
+
+    name = line[:line.index('(')]
+    line = line[len(name) + 1:-1]
+    args = H2_ARG_REGEX.findall(line)
+
+    return name, device, args
+
+
+def parse_get_device_line(line: str) -> str:
+    """Extract the code to get the device to dispatch on."""
+    line = line.strip()
+    line = line[len('// H2_DISPATCH_GET_DEVICE: "'):-1]
+    return line
+
+
+def parse_dispatch_on_line(line: str) -> list[str]:
+    """Extract the arguments to dispatch on."""
+    line = line.strip()
+    line = line[len('// H2_DISPATCH_ON: '):]
+    args = H2_ARG_REGEX.findall(line)
+    return args
+
+
+def parse_dispatch_args_line(orig_line: str) -> dict[str, list[str]]:
+    """Extract the arguments pass to the dispatched function."""
+    line = orig_line.strip()
+    line = line[len('// H2_DISPATCH_ARGS'):]
+    if line.startswith(':'):
+        device = 'none'
+        line = line[len(': '):]
+    elif line.startswith('_CPU:'):
+        device = 'cpu'
+        line = line[len('_CPU: '):]
+    elif line.startswith('_GPU'):
+        device = 'gpu'
+        line = line[len('_GPU: '):]
+    else:
+        raise RuntimeError(f'Do not know how to parse "{orig_line}"')
+
+    args = H2_ARG_REGEX.findall(line)
+    return {device: args}
+
+
+def process_file(infile: str, outfile: str) -> None:
+    """Generate dispatch code for infile and write to outfile."""
+    with open(infile, 'r') as f:
+        source_lines = f.readlines()
+
+    out_lines = []
+    name = None
+    num_types = None
+    get_device = None
+    dispatch_on_args = None
+    dispatch_args = {}
+    for line in source_lines:
+        start = line.lstrip()
+        if start.startswith('// H2_DISPATCH_NAME'):
+            name = parse_name_line(line)
+        elif start.startswith('// H2_DISPATCH_NUM_TYPES'):
+            num_types = parse_num_types_line(line)
+        elif start.startswith('// H2_DISPATCH_INIT'):
+            impl_name, device, args = parse_init_line(line)
+            if name is None or num_types is None:
+                raise RuntimeError(
+                    'Name or num types not specified before dispatch')
+            indent = len(line) - len(start)
+            dispatch_table = generate_dispatch_table(
+                num_types,
+                name,
+                impl_name,
+                device,
+                args,
+                indent=indent)
+            if device == 'gpu':
+                dispatch_table = ('#ifdef H2_HAS_GPU\n'
+                                  + dispatch_table
+                                  + '#endif  // H2_HAS_GPU\n')
+            dispatch_table = ('// BEGIN GENERATED DISPATCH TABLE\n'
+                              + dispatch_table
+                              + '// END GENERATED DISPATCH TABLE\n')
+            out_lines.append(dispatch_table)
+        elif start.startswith('// H2_DISPATCH_GET_DEVICE'):
+            get_device = parse_get_device_line(line)
+        elif start.startswith('// H2_DISPATCH_ON'):
+            dispatch_on_args = parse_dispatch_on_line(line)
+        elif start.startswith('// H2_DISPATCH_ARGS'):
+            dispatch_args.update(parse_dispatch_args_line(line))
+        elif start.startswith('// H2_DO_DISPATCH'):
+            indent = len(line) - len(start)
+            if len(dispatch_args) == 1:
+                # No H2_DEVICE_DISPATCH.
+                dispatch_str = do_dispatch_str(
+                    name,
+                    device,
+                    name,
+                    dispatch_on_args,
+                    dispatch_args[device],
+                    indent=indent)
+                dispatch_str += ';\n'
+            elif len(dispatch_args) > 1:
+                if not get_device:
+                    raise RuntimeError(
+                        'Cannot dispatch to multiple devices without a GET_DEVICE')
+                dispatch_str = device_dispatch_str(
+                    get_device,
+                    name,
+                    name,
+                    dispatch_on_args,
+                    dispatch_args['cpu'],
+                    dispatch_args['gpu'],
+                    indent=indent)
+            else:
+                raise RuntimeError('No dispatch arguments found')
+            dispatch_str = ('// BEGIN GENERATED DISPATCH CALL\n'
+                            + dispatch_str
+                            + '// END GENERATED DISPATCH CALL\n')
+            out_lines.append(dispatch_str)
+            # Clear things out.
+            name = None
+            num_types = None
+            get_device = None
+            dispatch_on_args = None
+            dispatch_args = {}
+        else:
+            out_lines.append(line)
+
+    with open(outfile, 'w') as f:
+        f.writelines(out_lines)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Post-process files and generate dispatch code')
+    parser.add_argument('--infile', type=str, help='Input file to postprocess')
+    parser.add_argument('--outfile', type=str, help='Output file')
+    args = parser.parse_args()
+    if not os.path.isfile(args.infile):
+        raise ValueError(f'Input file {args.infile} does not exist')
+    process_file(args.infile, args.outfile)

--- a/scripts/dispatch_gen.py
+++ b/scripts/dispatch_gen.py
@@ -249,6 +249,12 @@ def process_file(infile: str, outfile: str) -> None:
             get_device = parse_get_device_line(line)
         elif start.startswith('// H2_DISPATCH_ON'):
             dispatch_on_args = parse_dispatch_on_line(line)
+            if len(dispatch_on_args) != num_types:
+                raise RuntimeError(
+                    'Dispatch generation error:'
+                    f' expected number of types {num_types}'
+                    ' does not match number of dispatch arguments:'
+                    f' {len(dispatch_on_args)} ({dispatch_on_args})')
         elif start.startswith('// H2_DISPATCH_ARGS'):
             dispatch_args.update(parse_dispatch_args_line(line))
         elif start.startswith('// H2_DO_DISPATCH'):

--- a/src/core/dispatch.cpp
+++ b/src/core/dispatch.cpp
@@ -12,7 +12,7 @@ namespace
 {
 
 using KeyToEntryMap =
-    std::unordered_map<MaxDispatchKeyT, DispatchFunctionEntry>;
+    std::unordered_map<DispatchKeyT, DispatchFunctionEntry>;
 // Dispatch table with dynamic registration.
 // Maps from names to a lookup table of dispatch keys -> dispatch entries.
 std::unordered_map<std::string, KeyToEntryMap> dispatch_table;
@@ -20,7 +20,7 @@ std::unordered_map<std::string, KeyToEntryMap> dispatch_table;
 }  // anonymous namespace
 
 void add_dispatch_entry(const std::string& name,
-                        const MaxDispatchKeyT& dispatch_key,
+                        const DispatchKeyT& dispatch_key,
                         const DispatchFunctionEntry& dispatch_entry)
 {
   if (dispatch_table.count(name) == 0)
@@ -31,14 +31,14 @@ void add_dispatch_entry(const std::string& name,
 }
 
 bool has_dispatch_entry(const std::string& name,
-                        const MaxDispatchKeyT& dispatch_key)
+                        const DispatchKeyT& dispatch_key)
 {
   return (dispatch_table.count(name) > 0)
          && (dispatch_table[name].count(dispatch_key) > 0);
 }
 
 const DispatchFunctionEntry&
-get_dispatch_entry(const std::string& name, const MaxDispatchKeyT& dispatch_key)
+get_dispatch_entry(const std::string& name, const DispatchKeyT& dispatch_key)
 {
   if (!has_dispatch_entry(name, dispatch_key))
   {
@@ -54,7 +54,7 @@ get_dispatch_entry(const std::string& name, const MaxDispatchKeyT& dispatch_key)
 }  // namespace internal
 
 void dispatch_unregister(const std::string& name,
-                         const internal::MaxDispatchKeyT& dispatch_key)
+                         const internal::DispatchKeyT& dispatch_key)
 {
   if (internal::has_dispatch_entry(name, dispatch_key))
   {

--- a/src/core/dispatch.cpp
+++ b/src/core/dispatch.cpp
@@ -1,5 +1,68 @@
 #include "h2/core/dispatch.hpp"
 
+#include <unordered_map>
+
+
+namespace h2
+{
+namespace internal
+{
+
+namespace
+{
+
+using KeyToEntryMap =
+    std::unordered_map<MaxDispatchKeyT, DispatchFunctionEntry>;
+// Dispatch table with dynamic registration.
+// Maps from names to a lookup table of dispatch keys -> dispatch entries.
+std::unordered_map<std::string, KeyToEntryMap> dispatch_table;
+
+}  // anonymous namespace
+
+void add_dispatch_entry(const std::string& name,
+                        const MaxDispatchKeyT& dispatch_key,
+                        const DispatchFunctionEntry& dispatch_entry)
+{
+  if (dispatch_table.count(name) == 0)
+  {
+    dispatch_table.emplace(name, KeyToEntryMap{});
+  }
+  dispatch_table[name][dispatch_key] = dispatch_entry;
+}
+
+bool has_dispatch_entry(const std::string& name,
+                        const MaxDispatchKeyT& dispatch_key)
+{
+  return (dispatch_table.count(name) > 0)
+         && (dispatch_table[name].count(dispatch_key) > 0);
+}
+
+const DispatchFunctionEntry&
+get_dispatch_entry(const std::string& name, const MaxDispatchKeyT& dispatch_key)
+{
+  if (!has_dispatch_entry(name, dispatch_key))
+  {
+    throw H2FatalException("Attempt to look up dispatch for name ",
+                           name,
+                           " and key ",
+                           dispatch_key,
+                           " which does not exist");
+  }
+  return dispatch_table[name][dispatch_key];
+}
+
+}  // namespace internal
+
+void dispatch_unregister(const std::string& name,
+                         const internal::MaxDispatchKeyT& dispatch_key)
+{
+  if (internal::has_dispatch_entry(name, dispatch_key))
+  {
+    internal::dispatch_table[name].erase(dispatch_key);
+  }
+}
+
+}  // namespace h2
 
 // *****
 // Static dispatch example (also used in unit testing).

--- a/src/tensor/CMakeLists.txt
+++ b/src/tensor/CMakeLists.txt
@@ -6,6 +6,7 @@
 ################################################################################
 
 target_sources(H2Core PRIVATE
+  base_utils.cpp
   copy.cpp)
 
 if (H2_HAS_GPU)

--- a/src/tensor/base_utils.cpp
+++ b/src/tensor/base_utils.cpp
@@ -1,0 +1,190 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#include "h2/tensor/base_utils.hpp"
+
+#include "h2/core/dispatch.hpp"
+#include "h2/utils/unique_ptr_cast.hpp"
+
+
+namespace h2
+{
+namespace base
+{
+
+namespace
+{
+
+template <typename T>
+void make_tensor_impl(std::unique_ptr<BaseTensor>& ptr,
+                      Device device,
+                      const ShapeTuple& shape,
+                      const DimensionTypeTuple& dim_types,
+                      const StrideTuple& strides,
+                      TensorAllocationStrategy alloc_type,
+                      const ComputeStream& stream)
+{
+  ptr = std::make_unique<Tensor<T>>(
+      device, shape, dim_types, strides, alloc_type, stream);
+}
+
+template <typename T>
+void view_impl(std::unique_ptr<BaseTensor>& ptr, BaseTensor& tensor)
+{
+  Tensor<T>& real_tensor = static_cast<Tensor<T>&>(tensor);
+  ptr = real_tensor.view();
+}
+
+template <typename T>
+void view_impl(std::unique_ptr<BaseTensor>& ptr,
+               BaseTensor& tensor,
+               const IndexRangeTuple& coords)
+{
+  Tensor<T>& real_tensor = static_cast<Tensor<T>&>(tensor);
+  ptr = real_tensor.view(coords);
+}
+
+template <typename T>
+void const_view_impl(std::unique_ptr<BaseTensor>& ptr,
+                     const BaseTensor& tensor)
+{
+  const Tensor<T>& real_tensor = static_cast<const Tensor<T>&>(tensor);
+  ptr = real_tensor.const_view();
+}
+
+template <typename T>
+void const_view_impl(std::unique_ptr<BaseTensor>& ptr,
+                     const BaseTensor& tensor,
+                     const IndexRangeTuple& coords)
+{
+  const Tensor<T>& real_tensor = static_cast<const Tensor<T>&>(tensor);
+  ptr = real_tensor.const_view(coords);
+}
+
+}  // anonymous namespace
+
+std::unique_ptr<BaseTensor>
+make_tensor(const TypeInfo& tinfo,
+            Device device,
+            const ShapeTuple& shape,
+            const DimensionTypeTuple& dim_types,
+            const StrideTuple& strides,
+            TensorAllocationStrategy alloc_type,
+            const std::optional<ComputeStream> stream)
+{
+  // H2_DISPATCH_NAME: make_tensor
+  // H2_DISPATCH_NUM_TYPES: 1
+  // H2_DISPATCH_INIT: make_tensor_impl<{T1}>("std::unique_ptr<BaseTensor>&", "Device", "const ShapeTuple&", "const DimensionTypeTuple&", "const StrideTuple&", "TensorAllocationStrategy", "const ComputeStream&")
+
+  StrideTuple real_strides = (strides.is_empty() && !shape.is_empty())
+                                 ? get_contiguous_strides(shape)
+                                 : strides;
+  ComputeStream real_stream = stream.value_or(ComputeStream{device});
+  std::unique_ptr<BaseTensor> ptr = nullptr;
+
+  // H2_DISPATCH_ON: "tinfo"
+  // H2_DISPATCH_ARGS: "ptr", "device", "shape", "dim_types", "real_strides", "alloc_type", "real_stream"
+  // H2_DO_DISPATCH
+
+  return ptr;
+}
+
+std::unique_ptr<BaseTensor> view(BaseTensor& tensor)
+{
+  // H2_DISPATCH_NAME: view
+  // H2_DISPATCH_NUM_TYPES: 1
+  // H2_DISPATCH_INIT: view_impl<{T1}>("std::unique_ptr<BaseTensor>&", "BaseTensor&")
+
+  std::unique_ptr<BaseTensor> ptr = nullptr;
+
+  // H2_DISPATCH_ON: "tensor"
+  // H2_DISPATCH_ARGS: "ptr", "tensor"
+  // H2_DO_DISPATCH
+
+  return ptr;
+}
+
+std::unique_ptr<BaseTensor> view(BaseTensor& tensor,
+                                 const IndexRangeTuple& coords)
+{
+  // H2_DISPATCH_NAME: view_coords
+  // H2_DISPATCH_NUM_TYPES: 1
+  // H2_DISPATCH_INIT: view_impl<{T1}>("std::unique_ptr<BaseTensor>&", "BaseTensor&", "const IndexRangeTuple&")
+
+  std::unique_ptr<BaseTensor> ptr = nullptr;
+
+  // H2_DISPATCH_ON: "tensor"
+  // H2_DISPATCH_ARGS: "ptr", "tensor", "coords"
+  // H2_DO_DISPATCH
+
+  return ptr;
+}
+
+std::unique_ptr<BaseTensor> view(const BaseTensor& tensor)
+{
+  // H2_DISPATCH_NAME: const_view
+  // H2_DISPATCH_NUM_TYPES: 1
+  // H2_DISPATCH_INIT: const_view_impl<{T1}>("std::unique_ptr<BaseTensor>&", "const BaseTensor&")
+
+  std::unique_ptr<BaseTensor> ptr = nullptr;
+
+  // H2_DISPATCH_ON: "tensor"
+  // H2_DISPATCH_ARGS: "ptr", "tensor"
+  // H2_DO_DISPATCH
+
+  return ptr;
+}
+
+std::unique_ptr<BaseTensor> view(const BaseTensor& tensor,
+                                 const IndexRangeTuple& coords)
+{
+  // H2_DISPATCH_NAME: const_view_coords
+  // H2_DISPATCH_NUM_TYPES: 1
+  // H2_DISPATCH_INIT: const_view_impl<{T1}>("std::unique_ptr<BaseTensor>&", "const BaseTensor&", "const IndexRangeTuple&")
+
+  std::unique_ptr<BaseTensor> ptr = nullptr;
+
+  // H2_DISPATCH_ON: "tensor"
+  // H2_DISPATCH_ARGS: "ptr", "tensor", "coords"
+  // H2_DO_DISPATCH
+
+  return ptr;
+}
+
+std::unique_ptr<BaseTensor> const_view(const BaseTensor& tensor)
+{
+  // H2_DISPATCH_NAME: const_view
+  // H2_DISPATCH_NUM_TYPES: 1
+  // H2_DISPATCH_INIT: const_view_impl<{T1}>("std::unique_ptr<BaseTensor>&", "const BaseTensor&")
+
+  std::unique_ptr<BaseTensor> ptr = nullptr;
+
+  // H2_DISPATCH_ON: "tensor"
+  // H2_DISPATCH_ARGS: "ptr", "tensor"
+  // H2_DO_DISPATCH
+
+  return ptr;
+}
+
+std::unique_ptr<BaseTensor> const_view(const BaseTensor& tensor,
+                                       const IndexRangeTuple& coords)
+{
+  // H2_DISPATCH_NAME: const_view_coords
+  // H2_DISPATCH_NUM_TYPES: 1
+  // H2_DISPATCH_INIT: const_view_impl<{T1}>("std::unique_ptr<BaseTensor>&", "const BaseTensor&", "const IndexRangeTuple&")
+
+  std::unique_ptr<BaseTensor> ptr = nullptr;
+
+  // H2_DISPATCH_ON: "tensor"
+  // H2_DISPATCH_ARGS: "ptr", "tensor", "coords"
+  // H2_DO_DISPATCH
+
+  return ptr;
+}
+
+}  // namespace base
+}  // namespace h2

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -9,6 +9,7 @@
 target_sources(H2Core PRIVATE
   environment_vars.cpp
   Error.cpp
+  logger_internals.hpp
   Logger.cpp
   typename.cpp
   )

--- a/test/unit_test/core/unit_test_dispatch.cpp
+++ b/test/unit_test/core/unit_test_dispatch.cpp
@@ -66,10 +66,12 @@ TEMPLATE_LIST_TEST_CASE("Static dispatch works for new types",
   constexpr Device Dev = TestType::value;
   using DispatchType = bool;
 
+  ComputeStream stream{Dev};
+
   DeviceBuf<DispatchType, Dev> buf{1};
   buf.fill(static_cast<DispatchType>(false));
   dispatch_test(Dev, buf.buf);
-  REQUIRE(read_ele<Dev>(buf.buf, 0) == true);
+  REQUIRE(read_ele<Dev>(buf.buf, stream) == true);
 }
 
 // Dynamic dispatch test:

--- a/test/unit_test/tensor/unit_test_copy.cpp
+++ b/test/unit_test/tensor/unit_test_copy.cpp
@@ -10,6 +10,7 @@
 
 #include "h2/tensor/tensor.hpp"
 #include "h2/tensor/copy.hpp"
+#include "h2/utils/unique_ptr_cast.hpp"
 #include "utils.hpp"
 #include "../wait.hpp"
 
@@ -574,5 +575,107 @@ TEMPLATE_LIST_TEST_CASE("Different-type cast works with constant tensors",
     REQUIRE(
         read_ele<Dev>(cast_tensor->const_data(), i, cast_tensor->get_stream())
         == dst_val);
+  }
+}
+
+TEMPLATE_LIST_TEST_CASE("Cast through a BaseTensor works",
+                        "[tensor][copy]",
+                        AllDevComputeTypePairsPairsList)
+{
+  constexpr Device Dev = meta::tlist::At<TestType, 0>::value;
+  using SrcType = meta::tlist::At<meta::tlist::At<TestType, 1>, 0>;
+  using DstType = meta::tlist::At<meta::tlist::At<TestType, 1>, 1>;
+  using SrcTensorType = Tensor<SrcType>;
+  using DstTensorType = Tensor<DstType>;
+  constexpr SrcType src_val = static_cast<SrcType>(42);
+  constexpr DstType dst_val = static_cast<DstType>(42);
+
+  SrcTensorType src_tensor{Dev, {4, 6}, {DT::Sample, DT::Any}};
+
+  for (DataIndexType i = 0; i < src_tensor.numel(); ++i)
+  {
+    write_ele<Dev>(src_tensor.data(), i, src_val, src_tensor.get_stream());
+  }
+
+  BaseTensor& base_tensor = src_tensor;
+  std::unique_ptr<DstTensorType> cast_tensor = cast<DstType>(base_tensor);
+
+  REQUIRE(cast_tensor->shape() == src_tensor.shape());
+  REQUIRE(cast_tensor->dim_types() == src_tensor.dim_types());
+  REQUIRE(cast_tensor->strides() == src_tensor.strides());
+  REQUIRE(cast_tensor->get_device() == src_tensor.get_device());
+  // Since it is a cross-product, SrcType may equal DstType.
+  if constexpr (std::is_same_v<SrcType, DstType>)
+  {
+    REQUIRE(cast_tensor->is_view());
+    REQUIRE(cast_tensor->data() == src_tensor.data());
+  }
+  else
+  {
+    REQUIRE_FALSE(cast_tensor->is_view());
+    REQUIRE(reinterpret_cast<void*>(cast_tensor->data())
+            != reinterpret_cast<void*>(src_tensor.data()));
+  }
+  REQUIRE(cast_tensor->get_type_info() == get_h2_type<DstType>());
+
+  for (DataIndexType i = 0; i < cast_tensor->numel(); ++i)
+  {
+    REQUIRE(read_ele<Dev>(src_tensor.data(), i, src_tensor.get_stream())
+            == src_val);
+    REQUIRE(read_ele<Dev>(cast_tensor->data(), i, cast_tensor->get_stream())
+            == dst_val);
+  }
+}
+
+TEMPLATE_LIST_TEST_CASE("Runtime cast through a BaseTensor works",
+                        "[tensor][copy]",
+                        AllDevComputeTypePairsPairsList)
+{
+  constexpr Device Dev = meta::tlist::At<TestType, 0>::value;
+  using SrcType = meta::tlist::At<meta::tlist::At<TestType, 1>, 0>;
+  using DstType = meta::tlist::At<meta::tlist::At<TestType, 1>, 1>;
+  using SrcTensorType = Tensor<SrcType>;
+  using DstTensorType = Tensor<DstType>;
+  constexpr SrcType src_val = static_cast<SrcType>(42);
+  constexpr DstType dst_val = static_cast<DstType>(42);
+  const TypeInfo DstRuntimeType = get_h2_type<DstType>();
+
+  SrcTensorType src_tensor{Dev, {4, 6}, {DT::Sample, DT::Any}};
+
+  for (DataIndexType i = 0; i < src_tensor.numel(); ++i)
+  {
+    write_ele<Dev>(src_tensor.data(), i, src_val, src_tensor.get_stream());
+  }
+
+  BaseTensor& base_tensor = src_tensor;
+  std::unique_ptr<BaseTensor> cast_base_tensor =
+      cast(DstRuntimeType, base_tensor);
+  std::unique_ptr<DstTensorType> cast_tensor =
+      downcast_uptr<DstTensorType>(cast_base_tensor);
+
+  REQUIRE(cast_tensor->shape() == src_tensor.shape());
+  REQUIRE(cast_tensor->dim_types() == src_tensor.dim_types());
+  REQUIRE(cast_tensor->strides() == src_tensor.strides());
+  REQUIRE(cast_tensor->get_device() == src_tensor.get_device());
+  // Since it is a cross-product, SrcType may equal DstType.
+  if constexpr (std::is_same_v<SrcType, DstType>)
+  {
+    REQUIRE(cast_tensor->is_view());
+    REQUIRE(cast_tensor->data() == src_tensor.data());
+  }
+  else
+  {
+    REQUIRE_FALSE(cast_tensor->is_view());
+    REQUIRE(reinterpret_cast<void*>(cast_tensor->data())
+            != reinterpret_cast<void*>(src_tensor.data()));
+  }
+  REQUIRE(cast_tensor->get_type_info() == get_h2_type<DstType>());
+
+  for (DataIndexType i = 0; i < cast_tensor->numel(); ++i)
+  {
+    REQUIRE(read_ele<Dev>(src_tensor.data(), i, src_tensor.get_stream())
+            == src_val);
+    REQUIRE(read_ele<Dev>(cast_tensor->data(), i, cast_tensor->get_stream())
+            == dst_val);
   }
 }

--- a/test/unit_test/utils/CMakeLists.txt
+++ b/test/unit_test/utils/CMakeLists.txt
@@ -15,4 +15,5 @@ target_sources(SeqCatchTests PRIVATE
   unit_test_logging.cpp
   unit_test_strings.cpp
   unit_test_typename.cpp
+  unit_test_unique_ptr_cast.cpp
   )

--- a/test/unit_test/utils/unit_test_unique_ptr_cast.cpp
+++ b/test/unit_test/utils/unit_test_unique_ptr_cast.cpp
@@ -1,0 +1,36 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2023 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+
+#include "h2/utils/unique_ptr_cast.hpp"
+#include "h2/tensor/tensor.hpp"
+#include "../tensor/utils.hpp"
+
+using namespace h2;
+
+
+TEMPLATE_LIST_TEST_CASE("unique_ptr_cast works with tensors",
+                        "[utilities][unique_ptr_cast]",
+                        AllDevComputeTypePairsList)
+{
+  constexpr Device Dev = meta::tlist::At<TestType, 0>::value;
+  using Type = meta::tlist::At<TestType, 1>;
+  using TensorType = Tensor<Type>;
+
+  std::unique_ptr<BaseTensor> base_ptr = std::make_unique<TensorType>(
+      Dev, ShapeTuple{4, 6}, DTTuple{DT::Sample, DT::Any});
+  void* orig_data = base_ptr->storage_data();
+  std::unique_ptr<TensorType> derived_ptr;
+  REQUIRE_NOTHROW([&]() {
+    derived_ptr = downcast_uptr<TensorType>(base_ptr);
+  }());
+  // Some additional sanity-checks:
+  REQUIRE(derived_ptr->shape() == ShapeTuple{4, 6});
+  REQUIRE(orig_data == static_cast<void*>(derived_ptr->data()));
+}


### PR DESCRIPTION
This adds support for dynamic dispatch (e.g., for `BaseTensor`s), including user registration of dispatch methods for custom types.

This also adds some methods that use dynamic dispatch and some other utilities.

Note dynamic dispatch code is auto-generated at build time. A Python interpreter with version >= 3.9 is now a required build-time dependency. (Just the interpreter: no linking with Python.) This should be available on all our systems.