### PR TITLE
Loops and constant initialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,8 @@ if (H2_ENABLE_CUDA)
       list(APPEND H2_CUDA_LIBS NVSHMEM::NVSHMEM)
     endif ()
   endif ()
+
+  set(CMAKE_CUDA_FLAGS "--expt-relaxed-constexpr ${CMAKE_CUDA_FLAGS}")
 endif (H2_ENABLE_CUDA)
 
 find_package(spdlog CONFIG REQUIRED)

--- a/include/h2/CMakeLists.txt
+++ b/include/h2/CMakeLists.txt
@@ -21,6 +21,8 @@ add_subdirectory(core)
 
 add_subdirectory(gpu)
 
+add_subdirectory(loops)
+
 add_subdirectory(tensor)
 
 # Setup the metaprogramming component. The metaprogramming facilities

--- a/include/h2/core/types.hpp
+++ b/include/h2/core/types.hpp
@@ -175,6 +175,14 @@ inline bool operator!=(const TypeInfo& t1, const TypeInfo& t2)
   return *t1.get_type_info() != *t2.get_type_info();
 }
 
+/** Support printing TypeInfo. */
+inline std::ostream& operator<<(std::ostream& os, const TypeInfo& tinfo)
+{
+  os << "TypeInfo(" << tinfo.get_type_info()->name()
+     << ", token=" << tinfo.get_token() << ")";
+  return os;
+}
+
 /** Get the TypeInfo for a given type. */
 template <typename T>
 inline TypeInfo get_h2_type()

--- a/include/h2/gpu/CMakeLists.txt
+++ b/include/h2/gpu/CMakeLists.txt
@@ -15,6 +15,7 @@ h2_add_sources_to_target_and_install(
   SOURCES
   error.hpp
   logger.hpp
+  macros.hpp
   memory_utils.hpp
   runtime.hpp
   )

--- a/include/h2/gpu/cuda/runtime.hpp
+++ b/include/h2/gpu/cuda/runtime.hpp
@@ -48,6 +48,11 @@ constexpr unsigned int max_block_z = 64;
 constexpr unsigned int max_threads_per_block = 1024;
 constexpr unsigned int warp_size = 32;
 
+// Useful defaults for decomposing work:
+constexpr unsigned int num_threads_per_block = 128;
+constexpr unsigned int work_per_thread = 4;
+constexpr unsigned int work_per_block = work_per_thread * num_threads_per_block;
+
 inline bool ok(DeviceError status) noexcept
 {
     return (status == cudaSuccess);

--- a/include/h2/gpu/macros.hpp
+++ b/include/h2/gpu/macros.hpp
@@ -1,0 +1,50 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+/** @file
+ *
+ * Macro helpers for GPU code.
+ */
+
+#include <h2_config.hpp>
+
+
+#if defined H2_HAS_GPU
+
+#if (defined __CUDA_ARCH__ && __CUDA_ARCH__)                                   \
+    || (defined __HIP_DEVICE_COMPILE__ && __HIP_DEVICE_COMPILE__)
+#define H2_GPU_DEVICE_COMPILING 1
+#else
+#define H2_GPU_DEVICE_COMPILING 0
+#endif
+
+#endif  // H2_HAS_GPU
+
+
+#if defined(__CUDACC__) || defined(__HIPCC__)
+
+#define H2_GPU_HOST __host__
+#define H2_GPU_DEVICE __device__
+#define H2_GPU_HOST_DEVICE __host__ __device__
+#define H2_GPU_GLOBAL __global__
+#define H2_GPU_LAMBDA __host__ __device__
+#define H2_GPU_FORCE_INLINE __forceinline__
+
+#else
+
+// These are defined to produce nothing when not building with a
+// CUDA/HIP compiler, mostly to make clangd happy.
+#define H2_GPU_HOST
+#define H2_GPU_DEVICE
+#define H2_GPU_HOST_DEVICE
+#define H2_GPU_GLOBAL
+#define H2_GPU_LAMBDA
+#define H2_GPU_FORCE_INLINE inline
+
+#endif  // defined(__CUDACC__) || defined(__HIPCC__)

--- a/include/h2/gpu/macros.hpp
+++ b/include/h2/gpu/macros.hpp
@@ -14,6 +14,8 @@
 
 #include <h2_config.hpp>
 
+// Note: This file should be safe to include when not building with GPU
+// support.
 
 #if defined H2_HAS_GPU
 

--- a/include/h2/gpu/rocm/runtime.hpp
+++ b/include/h2/gpu/rocm/runtime.hpp
@@ -43,7 +43,12 @@ constexpr unsigned int max_block_x = 1024;
 constexpr unsigned int max_block_y = 1024;
 constexpr unsigned int max_block_z = 1024;
 constexpr unsigned int max_threads_per_block = 1024;
-constexpr unsigned int warp_size = 32;
+constexpr unsigned int warp_size = 64;
+
+// Useful defaults for decomposing work:
+constexpr unsigned int num_threads_per_block = 256;
+constexpr unsigned int work_per_thread = 4;
+constexpr unsigned int work_per_block = work_per_thread * num_threads_per_block;
 
 inline bool ok(DeviceError status) noexcept
 {

--- a/include/h2/gpu/runtime.hpp
+++ b/include/h2/gpu/runtime.hpp
@@ -151,6 +151,51 @@ inline void launch_kernel(void (*kernel)(KernelArgs...),
                                                 meta::TL<Args...>>>>::value,
       "Provided kernel arguments are not convertible to formal arguments");
 
+  // Check grid and block dimensions.
+  H2_ASSERT_DEBUG(grid_dim.x <= max_grid_x,
+                  "Grid dimension x (",
+                  grid_dim.x,
+                  ") exceeds maximum (",
+                  max_grid_x,
+                  ")");
+  H2_ASSERT_DEBUG(grid_dim.y <= max_grid_y,
+                  "Grid dimension y (",
+                  grid_dim.y,
+                  ") exceeds maximum (",
+                  max_grid_y,
+                  ")");
+  H2_ASSERT_DEBUG(grid_dim.z <= max_grid_z,
+                  "Grid dimension z (",
+                  grid_dim.z,
+                  ") exceeds maximum (",
+                  max_grid_z,
+                  ")");
+  H2_ASSERT_DEBUG(block_dim.x <= max_block_x,
+                  "Block dimension x (",
+                  block_dim.x,
+                  ") exceeds maximum (",
+                  max_block_x,
+                  ")");
+  H2_ASSERT_DEBUG(block_dim.y <= max_block_y,
+                  "Block dimension y (",
+                  block_dim.y,
+                  ") exceeds maximum (",
+                  max_block_y,
+                  ")");
+  H2_ASSERT_DEBUG(block_dim.z <= max_block_z,
+                  "Block dimension z (",
+                  block_dim.z,
+                  ") exceeds maximum (",
+                  max_block_z,
+                  ")");
+  H2_ASSERT_DEBUG(block_dim.x * block_dim.y * block_dim.z
+                      <= max_threads_per_block,
+                  "Total threads in a block (",
+                  block_dim.x * block_dim.y * block_dim.z,
+                  ") exceeds maximum (",
+                  max_threads_per_block,
+                  ")");
+
   H2_GPU_TRACE("launch_kernel(kernel={} ("
                    + meta::tlist::print(meta::TL<KernelArgs...>{})
                    + "), grid_dim=({}, {}, {}), block_dim=({}, "

--- a/include/h2/gpu/runtime.hpp
+++ b/include/h2/gpu/runtime.hpp
@@ -209,8 +209,8 @@ inline void launch_kernel(void (*kernel)(KernelArgs...),
                block_dim.y,
                block_dim.z,
                shared_mem,
-               (void*) stream,
-               internal::convert_for_fmt(std::forward<Args>(args))...);
+               (void*) stream);
+               //internal::convert_for_fmt(std::forward<Args>(args))...);
   launch_kernel_internal(kernel,
                          grid_dim,
                          block_dim,

--- a/include/h2/gpu/runtime.hpp
+++ b/include/h2/gpu/runtime.hpp
@@ -158,36 +158,60 @@ inline void launch_kernel(void (*kernel)(KernelArgs...),
                   ") exceeds maximum (",
                   max_grid_x,
                   ")");
+  H2_ASSERT_DEBUG(grid_dim.x > 0,
+                  "Grid dimension x (",
+                  grid_dim.x,
+                  ") must be > 0");
   H2_ASSERT_DEBUG(grid_dim.y <= max_grid_y,
                   "Grid dimension y (",
                   grid_dim.y,
                   ") exceeds maximum (",
                   max_grid_y,
                   ")");
+  H2_ASSERT_DEBUG(grid_dim.y > 0,
+                  "Grid dimension y (",
+                  grid_dim.y,
+                  ") must be > 0");
   H2_ASSERT_DEBUG(grid_dim.z <= max_grid_z,
                   "Grid dimension z (",
                   grid_dim.z,
                   ") exceeds maximum (",
                   max_grid_z,
                   ")");
+  H2_ASSERT_DEBUG(grid_dim.z > 0,
+                  "Grid dimension z (",
+                  grid_dim.z,
+                  ") must be > 0");
   H2_ASSERT_DEBUG(block_dim.x <= max_block_x,
                   "Block dimension x (",
                   block_dim.x,
                   ") exceeds maximum (",
                   max_block_x,
                   ")");
+  H2_ASSERT_DEBUG(block_dim.x > 0,
+                  "Block dimension x (",
+                  block_dim.x,
+                  ") must be > 0");
   H2_ASSERT_DEBUG(block_dim.y <= max_block_y,
                   "Block dimension y (",
                   block_dim.y,
                   ") exceeds maximum (",
                   max_block_y,
                   ")");
+  H2_ASSERT_DEBUG(block_dim.y > 0,
+                  "Block dimension y (",
+                  block_dim.y,
+                  ") must be > 0");
   H2_ASSERT_DEBUG(block_dim.z <= max_block_z,
                   "Block dimension z (",
                   block_dim.z,
                   ") exceeds maximum (",
                   max_block_z,
                   ")");
+  H2_ASSERT_DEBUG(block_dim.z > 0,
+                  "Block dimension z (",
+                  block_dim.z,
+                  ") must be > 0");
   H2_ASSERT_DEBUG(block_dim.x * block_dim.y * block_dim.z
                       <= max_threads_per_block,
                   "Total threads in a block (",

--- a/include/h2/loops/CMakeLists.txt
+++ b/include/h2/loops/CMakeLists.txt
@@ -1,0 +1,17 @@
+################################################################################
+## Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+## DiHydrogen Project Developers. See the top-level LICENSE file for details.
+##
+## SPDX-License-Identifier: Apache-2.0
+################################################################################
+
+# Append this directory to the current install prefix
+set(H2_CURRENT_INSTALL_PREFIX "${H2_CURRENT_INSTALL_PREFIX}/loops")
+
+# Setup this directory's files
+h2_add_sources_to_target_and_install(
+  TARGET H2Core COMPONENT CORE SCOPE INTERFACE
+  INSTALL_PREFIX "${H2_CURRENT_INSTALL_PREFIX}"
+  SOURCES
+  cpu_loops.hpp
+)

--- a/include/h2/loops/cpu_loops.hpp
+++ b/include/h2/loops/cpu_loops.hpp
@@ -28,6 +28,13 @@ namespace h2
 namespace cpu
 {
 
+/**
+ * Naive n-ary element-wise loop.
+ *
+ * If func returns a value, the first pointer in args is required to be
+ * an output buffer of a type which func's return type is convertible
+ * to. (The return value may not be discarded.)
+ */
 template <typename FuncT, typename... Args>
 void elementwise_loop(FuncT&& func,
                       std::size_t size,

--- a/include/h2/loops/cpu_loops.hpp
+++ b/include/h2/loops/cpu_loops.hpp
@@ -1,0 +1,79 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+// This file is meant to be included only in source files.
+
+#pragma once
+
+/** @file
+ *
+ * Loop routines for CPUs.
+ */
+
+#include <h2_config.hpp>
+
+#include <cstddef>
+#include <type_traits>
+
+#include "h2/utils/const_for.hpp"
+#include "h2/utils/function_traits.hpp"
+
+
+namespace h2
+{
+namespace cpu
+{
+
+template <typename FuncT, typename... Args>
+void inplace_elementwise_loop(FuncT&& func,
+                              std::size_t size,
+                              Args* __restrict__... args)
+{
+  using traits = FunctionTraits<FuncT>;
+  static_assert(traits::arity == sizeof...(args), "Argument number mismatch");
+  static_assert(std::is_same_v<typename traits::RetT, void>,
+                "Would discard return");
+  // TODO: Check args is convertible to function args.
+
+  std::tuple<Args* __restrict__...> args_ptrs{args...};
+  typename traits::ArgsTuple loaded_args;
+
+  for (std::size_t i = 0; i < size; ++i)
+  {
+    const_for<std::size_t{0}, sizeof...(Args), std::size_t{1}>([&](auto arg_i) {
+      std::get<arg_i.value>(loaded_args) = std::get<arg_i.value>(args_ptrs)[i];
+    });
+    std::apply(func, loaded_args);
+  }
+}
+
+template <typename FuncT, typename OutT, typename... Args>
+void elementwise_loop(FuncT&& func,
+                      std::size_t size,
+                      OutT* __restrict__ out,
+                      Args* __restrict__... args)
+{
+  using traits = FunctionTraits<FuncT>;
+  static_assert(traits::arity == sizeof...(args), "Argument number mismatch");
+  static_assert(std::is_convertible_v<typename traits::RetT, OutT>,
+                "Cannot convert return value to output type");
+  // TODO: Check args is convertible to function args.
+
+  std::tuple<Args* __restrict__...> args_ptrs{args...};
+  typename traits::ArgsTuple loaded_args;
+
+  for (std::size_t i = 0; i < size; ++i)
+  {
+    const_for<std::size_t{0}, sizeof...(Args), std::size_t{1}>([&](auto arg_i) {
+      std::get<arg_i.value>(loaded_args) = std::get<arg_i.value>(args_ptrs)[i];
+    });
+    out[i] = std::apply(func, loaded_args);
+  }
+}
+
+}  // namespace cpu
+}  // namespace h2

--- a/include/h2/loops/gpu_loops.cuh
+++ b/include/h2/loops/gpu_loops.cuh
@@ -1,0 +1,200 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+// This file is meant to be included only in source files.
+
+#if !defined(__CUDACC__) && !defined(__HIPCC__)
+#error "This file is to only be included in GPU code"
+#endif
+
+#pragma once
+
+/** @file
+ *
+ * Loop routines for GPUs.
+ */
+
+#include <h2_config.hpp>
+
+#include <type_traits>
+
+#include <cstddef>
+
+#include "h2/core/sync.hpp"
+#include "h2/gpu/runtime.hpp"
+#include "h2/gpu/macros.hpp"
+//#include "h2/loops/gpu_vec_helpers.cuh"
+#include "h2/utils/const_for.hpp"
+#include "h2/utils/function_traits.hpp"
+
+
+namespace h2
+{
+namespace gpu
+{
+
+namespace kernels
+{
+
+/**
+ * Naive n-ary element-wise loop.
+ *
+ * If f returns a value, the first pointer in args is required to be
+ * an output buffer of a type which f's return type is convertible to.
+ * (The return value may not be discarded.)
+ *
+ * f is called once for each element in the input buffers, with all
+ * args (except the output, if present) provided.
+ */
+template <typename FuncT, typename... Args>
+H2_GPU_GLOBAL void elementwise_loop(const FuncT& f,
+                                    std::size_t size,
+                                    Args... args)
+{
+  using traits = FunctionTraits<FuncT>;
+  constexpr bool has_return = !std::is_same_v<typename traits::RetT, void>;
+  constexpr std::size_t arg_offset = has_return ? 1 : 0;
+  static_assert(traits::arity + arg_offset == sizeof...(args),
+                "Argument number mismatch");
+  // TODO: Check args is convertible to function args.
+
+  const unsigned int tid = blockIdx.x * blockDim.x + threadIdx.x;
+  const unsigned int stride = blockDim.x * gridDim.x;
+
+  std::tuple<Args...> args_ptrs{args...};
+  typename traits::ArgsTuple loaded_args;
+
+  static_assert(!has_return
+                    || std::is_convertible_v<
+                        typename traits::RetT,
+                        std::remove_pointer_t<
+                            std::tuple_element_t<0, decltype(args_ptrs)>>>,
+                "Cannot convert return value to output");
+
+  for (std::size_t i = tid; i < size; i += stride)
+  {
+    // Load arguments.
+    const_for<arg_offset, sizeof...(Args), std::size_t{1}>([&](auto arg_i) {
+      std::get<arg_i.value - arg_offset>(loaded_args) =
+          std::get<arg_i.value>(args_ptrs)[i];
+        });
+    if constexpr (has_return)
+    {
+      std::get<0>(args_ptrs)[i] = std::apply(f, loaded_args);
+    }
+    else
+    {
+      std::apply(f, loaded_args);
+    }
+  }
+}
+
+/**
+ * Like `elementwise_loop`, but taking an immediate parameter as an
+ * argument.
+ *
+ * This allows the parameter to be passed as a kernel argument, and so
+ * does not need to be in GPU memory. (Obviously, this should be kept
+ * to small arguments, e.g., scalars.)
+ */
+template <typename FuncT, typename ImmediateT, typename... Args>
+H2_GPU_GLOBAL void elementwise_loop_with_immediate(FuncT f,
+                                                   std::size_t size,
+                                                   ImmediateT imm,
+                                                   Args... args)
+{
+  using traits = FunctionTraits<FuncT>;
+  constexpr bool has_return = !std::is_same_v<typename traits::RetT, void>;
+  constexpr std::size_t arg_offset = has_return ? 1 : 0;
+  static_assert(traits::arity + arg_offset == sizeof...(args) + 1,
+                "Argument number mismatch");
+  static_assert(
+      std::is_convertible_v<ImmediateT, typename traits::template arg<0>>,
+      "Cannot pass immediate to first argument");
+  // TODO: Check args is convertible to function args.
+
+  const unsigned int tid = blockIdx.x * blockDim.x + threadIdx.x;
+  const unsigned int stride = blockDim.x * gridDim.x;
+
+  std::tuple<Args...> args_ptrs{args...};
+  typename traits::ArgsTuple loaded_args;
+  std::get<0>(loaded_args) = imm;  // Store immediate in first arg.
+
+  static_assert(!has_return
+                    || std::is_convertible_v<
+                        typename traits::RetT,
+                        std::remove_pointer_t<
+                            std::tuple_element_t<0, std::tuple<Args...>>>>,
+                "Cannot convert return value to output");
+
+  for (std::size_t i = tid; i < size; i += stride)
+  {
+    // Load arguments.
+    // This skips the output argument in args if we have a return value
+    // and the immediate argument in the function's argument list.
+    const_for<arg_offset, sizeof...(Args), std::size_t{1}>([&](auto arg_i) {
+      std::get<arg_i.value + 1 - arg_offset>(loaded_args) =
+          std::get<arg_i.value>(args_ptrs)[i];
+    });
+    if constexpr (has_return)
+    {
+      std::get<0>(args_ptrs)[i] = std::apply(f, loaded_args);
+    }
+    else
+    {
+      std::apply(f, loaded_args);
+    }
+  }
+}
+
+}  // namespace kernels
+
+template <typename FuncT, typename... Args>
+void launch_elementwise_loop(const FuncT& func,
+                             const ComputeStream& stream,
+                             std::size_t size,
+                             Args... args)
+{
+  const unsigned int block_size = gpu::num_threads_per_block;
+  const unsigned int num_blocks = (size + block_size - 1) / block_size;
+
+  gpu::launch_kernel(kernels::elementwise_loop<FuncT, Args...>,
+                     num_blocks,
+                     block_size,
+                     0,
+                     stream.template get_stream<Device::GPU>(),
+                     func,
+                     size,
+                     args...);
+}
+
+template <typename FuncT, typename ImmediateT, typename... Args>
+void launch_elementwise_loop_with_immediate(const FuncT& func,
+                                            const ComputeStream& stream,
+                                            std::size_t size,
+                                            ImmediateT imm,
+                                            Args... args)
+{
+  const unsigned int block_size = gpu::num_threads_per_block;
+  const unsigned int num_blocks = (size + block_size - 1) / block_size;
+
+  gpu::launch_kernel(
+      kernels::elementwise_loop_with_immediate<FuncT,
+                                               ImmediateT,
+                                               Args...>,
+      num_blocks,
+      block_size,
+      0,
+      stream.template get_stream<Device::GPU>(),
+      func,
+      size,
+      imm,
+      args...);
+}
+
+}  // namespace gpu
+}  // namespace h2

--- a/include/h2/loops/gpu_loops.cuh
+++ b/include/h2/loops/gpu_loops.cuh
@@ -51,7 +51,7 @@ namespace kernels
  * args (except the output, if present) provided.
  */
 template <typename FuncT, typename... Args>
-H2_GPU_GLOBAL void elementwise_loop(const FuncT& f,
+H2_GPU_GLOBAL void elementwise_loop(const FuncT& func,
                                     std::size_t size,
                                     Args... args)
 {
@@ -84,11 +84,11 @@ H2_GPU_GLOBAL void elementwise_loop(const FuncT& f,
         });
     if constexpr (has_return)
     {
-      std::get<0>(args_ptrs)[i] = std::apply(f, loaded_args);
+      std::get<0>(args_ptrs)[i] = std::apply(func, loaded_args);
     }
     else
     {
-      std::apply(f, loaded_args);
+      std::apply(func, loaded_args);
     }
   }
 }

--- a/include/h2/loops/gpu_loops.cuh
+++ b/include/h2/loops/gpu_loops.cuh
@@ -27,7 +27,7 @@
 #include "h2/core/sync.hpp"
 #include "h2/gpu/runtime.hpp"
 #include "h2/gpu/macros.hpp"
-//#include "h2/loops/gpu_vec_helpers.cuh"
+#include "h2/loops/gpu_vec_helpers.cuh"
 #include "h2/utils/const_for.hpp"
 #include "h2/utils/function_traits.hpp"
 
@@ -40,14 +40,105 @@ namespace gpu
 namespace kernels
 {
 
+template <typename SizeT,
+          std::size_t vec_width,
+          std::size_t unroll_factor,
+          typename FuncT,
+          typename... Args>
+H2_GPU_GLOBAL void
+vectorized_elementwise_loop(const FuncT& func, SizeT size, Args... args)
+{
+  using traits = FunctionTraits<FuncT>;
+  constexpr bool has_return = !std::is_same_v<typename traits::RetT, void>;
+  constexpr std::size_t arg_offset = has_return ? 1 : 0;
+  static_assert(traits::arity + arg_offset == sizeof...(args),
+                "Argument number mismatch");
+
+  constexpr SizeT ele_per_iter = vec_width * unroll_factor;
+  const unsigned int tid = blockIdx.x * blockDim.x + threadIdx.x;
+  const unsigned int grid_stride = blockDim.x * gridDim.x;
+  const SizeT stride = grid_stride * ele_per_iter;
+  const SizeT num_iter = (size / ele_per_iter) * ele_per_iter;
+
+  // Main vectorized/unrolled loop. Only run if this thread has a
+  // complete iteration.
+  if ((tid + 1) * ele_per_iter <= num_iter) {
+    std::tuple<VectorType_t<Args, vec_width>*...> args_ptrs{
+      reinterpret_cast<VectorType_t<Args, vec_width>*>(args)...};
+    VectorTupleType_t<vec_width, typename traits::ArgsTuple>
+        loaded_args[unroll_factor];
+
+    for (SizeT i = tid * ele_per_iter; i < num_iter; i += stride)
+    {
+      #pragma unroll
+      for (int u = 0; u < unroll_factor; ++u)
+      {
+        const SizeT idx = (i + u * vec_width) / vec_width;
+        // Vector load.
+        const_for<arg_offset, sizeof...(args), std::size_t{1}>([&](auto arg_i) {
+            std::get<arg_i.value - arg_offset>(loaded_args[u]) =
+                std::get<arg_i.value>(args_ptrs)[idx];
+          });
+        // Apply function to each vector element.
+        if constexpr (has_return)
+        {
+          VectorType_t<typename traits::RetT, vec_width> result;
+          const_for<std::size_t{0}, vec_width, std::size_t{1}>([&](auto arg_i) {
+            index_vector<arg_i, vec_width, typename traits::RetT>(result) =
+              std::apply(
+                  func,
+                  LoadVectorTuple<
+                      arg_i,
+                      vec_width,
+                  typename traits::ArgsTuple>::load(loaded_args[u]));
+          });
+          // Vector store.
+          std::get<0>(args_ptrs)[idx] = result;
+        }
+        else
+        {
+          const_for<std::size_t{0}, vec_width, std::size_t{1}>([&](auto arg_i) {
+            std::apply(
+                func,
+                LoadVectorTuple<arg_i, vec_width, typename traits::ArgsTuple>::
+                    load(loaded_args[u]));
+            });
+        }
+      }
+    }
+  }
+
+  // Handle remainder.
+  {
+    std::tuple<Args...> args_ptrs{args...};
+    typename traits::ArgsTuple loaded_args;
+
+    for (SizeT i = num_iter + tid; i < size; i += grid_stride)
+    {
+      const_for<arg_offset, sizeof...(Args), std::size_t{1}>([&](auto arg_i) {
+        std::get<arg_i.value - arg_offset>(loaded_args) =
+            std::get<arg_i.value>(args_ptrs)[i];
+      });
+      if constexpr (has_return)
+      {
+        std::get<0>(args_ptrs)[i] = std::apply(func, loaded_args);
+      }
+      else
+      {
+        std::apply(func, loaded_args);
+      }
+    }
+  }
+}
+
 /**
  * Naive n-ary element-wise loop.
  *
- * If f returns a value, the first pointer in args is required to be
- * an output buffer of a type which f's return type is convertible to.
- * (The return value may not be discarded.)
+ * If func returns a value, the first pointer in args is required to be
+ * an output buffer of a type which func's return type is convertible
+ * to. (The return value may not be discarded.)
  *
- * f is called once for each element in the input buffers, with all
+ * func is called once for each element in the input buffers, with all
  * args (except the output, if present) provided.
  */
 template <typename FuncT, typename... Args>
@@ -162,14 +253,65 @@ void launch_elementwise_loop(const FuncT& func,
   const unsigned int block_size = gpu::num_threads_per_block;
   const unsigned int num_blocks = (size + block_size - 1) / block_size;
 
-  gpu::launch_kernel(kernels::elementwise_loop<FuncT, Args...>,
+  /*gpu::launch_kernel(kernels::elementwise_loop<FuncT, Args...>,
                      num_blocks,
                      block_size,
                      0,
                      stream.template get_stream<Device::GPU>(),
                      func,
                      size,
-                     args...);
+                     args...);*/
+  std::size_t vec_width = std::min({max_vectorization_amount(args)...});
+  switch (vec_width)
+  {
+  case 4:
+    gpu::launch_kernel(
+        kernels::vectorized_elementwise_loop<std::size_t,
+                                             4,
+                                             gpu::work_per_thread,
+                                             FuncT,
+                                             Args...>,
+        num_blocks,
+        block_size,
+        0,
+        stream.template get_stream<Device::GPU>(),
+        func,
+        size,
+        args...);
+    break;
+  case 2:
+    gpu::launch_kernel(
+        kernels::vectorized_elementwise_loop<std::size_t,
+                                             2,
+                                             gpu::work_per_thread,
+                                             FuncT,
+                                             Args...>,
+        num_blocks,
+        block_size,
+        0,
+        stream.template get_stream<Device::GPU>(),
+        func,
+        size,
+        args...);
+    break;
+  case 1:
+    gpu::launch_kernel(
+        kernels::vectorized_elementwise_loop<std::size_t,
+                                             1,
+                                             gpu::work_per_thread,
+                                             FuncT,
+                                             Args...>,
+        num_blocks,
+        block_size,
+        0,
+        stream.template get_stream<Device::GPU>(),
+        func,
+        size,
+        args...);
+    break;
+  default:
+    throw H2FatalException("Unexpected vectorization size, ", vec_width);
+  }
 }
 
 template <typename FuncT, typename ImmediateT, typename... Args>

--- a/include/h2/loops/gpu_vec_helpers.cuh
+++ b/include/h2/loops/gpu_vec_helpers.cuh
@@ -23,8 +23,7 @@
 #include <cstddef>
 #include <cstdint>
 
-#include <cuda_runtime.h>
-
+#include "h2/gpu/runtime.hpp"
 #include "h2/gpu/macros.hpp"
 #include "h2/utils/const_for.hpp"
 

--- a/include/h2/loops/gpu_vec_helpers.cuh
+++ b/include/h2/loops/gpu_vec_helpers.cuh
@@ -1,0 +1,208 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+// This file is meant to be included only in source files.
+#if !defined(__CUDACC__) && !defined(__HIPCC__)
+#error "This file is to only be included in GPU code"
+#endif
+
+#pragma once
+
+/** @file
+ *
+ * Helper utilities for GPU vectorization.
+ */
+
+#include <h2_config.hpp>
+
+#include <type_traits>
+#include <cstddef>
+#include <cstdint>
+
+#include <cuda_runtime.h>
+
+#include "h2/gpu/macros.hpp"
+
+
+namespace h2
+{
+
+/**
+ * Identify a vector type for T with the given vector width.
+ *
+ * Falls back to T if none is available.
+ */
+template <typename T, std::size_t vec_width>
+struct VectorTypeForT;
+template <typename T>
+struct VectorTypeForT<T, 1>
+{
+  using type = T;
+};
+template <>
+struct VectorTypeForT<char, 2>
+{
+  using type = char2;
+};
+template <>
+struct VectorTypeForT<char, 4>
+{
+  using type = char4;
+};
+template <>
+struct VectorTypeForT<unsigned char, 2>
+{
+  using type = uchar2;
+};
+template <>
+struct VectorTypeForT<unsigned char, 4>
+{
+  using type = uchar4;
+};
+template <>
+struct VectorTypeForT<short, 2>
+{
+  using type = short2;
+};
+template <>
+struct VectorTypeForT<short, 4>
+{
+  using type = short4;
+};
+template <>
+struct VectorTypeForT<unsigned short, 2>
+{
+  using type = ushort2;
+};
+template <>
+struct VectorTypeForT<unsigned short, 4>
+{
+  using type = ushort4;
+};
+template <>
+struct VectorTypeForT<int, 2>
+{
+  using type = int2;
+};
+template <>
+struct VectorTypeForT<int, 4>
+{
+  using type = int4;
+};
+template <>
+struct VectorTypeForT<unsigned int, 2>
+{
+  using type = uint2;
+};
+template <>
+struct VectorTypeForT<unsigned int, 4>
+{
+  using type = uint4;
+};
+template <>
+struct VectorTypeForT<long, 2>
+{
+  using type = long2;
+};
+template <>
+struct VectorTypeForT<long, 4>
+{
+  using type = long4;
+};
+template <>
+struct VectorTypeForT<unsigned long, 2>
+{
+  using type = ulong2;
+};
+template <>
+struct VectorTypeForT<unsigned long, 4>
+{
+  using type = ulong4;
+};
+template <>
+struct VectorTypeForT<long long, 2>
+{
+  using type = longlong2;
+};
+template <>
+struct VectorTypeForT<long long, 4>
+{
+  using type = longlong4;
+};
+template <>
+struct VectorTypeForT<unsigned long long, 2>
+{
+  using type = ulonglong2;
+};
+template <>
+struct VectorTypeForT<unsigned long long, 4>
+{
+  using type = ulonglong4;
+};
+template <>
+struct VectorTypeForT<float, 2>
+{
+  using type = float2;
+};
+template <>
+struct VectorTypeForT<float, 4>
+{
+  using type = float4;
+};
+template <>
+struct VectorTypeForT<double, 2>
+{
+  using type = double2;
+};
+template <>
+struct VectorTypeForT<double, 4>
+{
+  using type = double4;
+};
+
+template <typename T, std::size_t vec_width>
+using VectorType_t = typename VectorTypeForT<T, vec_width>::type;
+
+/**
+ * Aligned data suitable for vectorization over vec_width elements.
+ */
+template <typename T, std::size_t vec_width>
+struct alignas(sizeof(T) * vec_width) aligned_data
+{
+  T data[vec_width];
+};
+
+/** Load a vector of data from the given offset. */
+template <std::size_t vec_width, typename T>
+H2_GPU_DEVICE VectorType_t<T, vec_width> load_vector(const T* data,
+                                                     std::size_t offset)
+{
+  auto vec_data = reinterpret_cast<const VectorType_t<T, vec_width>*>(data);
+  return vec_data[offset];
+}
+
+/**
+ * Return the maximum vector width for ptr, based on its alignment.
+ *
+ * @note Currently this only considers vector widths of 1, 2, or 4.
+ */
+template <typename T>
+H2_GPU_HOST_DEVICE std::size_t max_vectorization_amount(const T* ptr)
+{
+  const std::uintptr_t addr = reinterpret_cast<std::uintptr_t>(ptr);
+  if ((addr % std::alignment_of_v<VectorType_t<T, 4>>) == 0)
+  {
+    return 4;
+  }
+  else if ((addr % std::alignment_of_v<VectorType_t<T, 2>>) == 0)
+  {
+    return 2;
+  }
+  return 1;
+}
+
+}  // namespace h2

--- a/include/h2/loops/gpu_vec_helpers.cuh
+++ b/include/h2/loops/gpu_vec_helpers.cuh
@@ -240,6 +240,20 @@ struct LoadVectorTuple<i, vec_width, std::tuple<Ts...>>
     });
     return ret;
   }
+
+  template <typename ImmediateT>
+  static H2_GPU_HOST_DEVICE std::tuple<ImmediateT, Ts...> load_with_immediate(
+      ImmediateT& imm, VectorTupleType_t<vec_width, std::tuple<Ts...>>& vec_tuple)
+  {
+    std::tuple<ImmediateT, Ts...> ret;
+    std::get<0>(ret) = imm;
+    const_for<std::size_t{0}, sizeof...(Ts), std::size_t{1}>([&](auto arg_i) {
+      using T = std::tuple_element_t<arg_i, std::tuple<Ts...>>;
+      std::get<arg_i + 1>(ret) =
+          index_vector<i, vec_width, T>(std::get<arg_i>(vec_tuple));
+    });
+    return ret;
+  }
 };
 
 /**

--- a/include/h2/tensor/init/CMakeLists.txt
+++ b/include/h2/tensor/init/CMakeLists.txt
@@ -14,5 +14,5 @@ h2_add_sources_to_target_and_install(
   TARGET H2Core COMPONENT CORE SCOPE INTERFACE
   INSTALL_PREFIX "${H2_CURRENT_INSTALL_PREFIX}"
   SOURCES
-
+  fill.hpp
 )

--- a/include/h2/tensor/init/CMakeLists.txt
+++ b/include/h2/tensor/init/CMakeLists.txt
@@ -5,13 +5,14 @@
 ## SPDX-License-Identifier: Apache-2.0
 ################################################################################
 
-target_sources(H2Core PRIVATE
-  base_utils.cpp
-  copy.cpp)
+# Append this directory to the current install prefix
+set(H2_CURRENT_INSTALL_PREFIX
+  "${H2_CURRENT_INSTALL_PREFIX}/init")
 
-if (H2_HAS_GPU)
-  target_sources(H2Core PRIVATE
-    copy.cu)
-endif ()
+# Setup this directory's files
+h2_add_sources_to_target_and_install(
+  TARGET H2Core COMPONENT CORE SCOPE INTERFACE
+  INSTALL_PREFIX "${H2_CURRENT_INSTALL_PREFIX}"
+  SOURCES
 
-add_subdirectory(init)
+)

--- a/include/h2/tensor/init/fill.hpp
+++ b/include/h2/tensor/init/fill.hpp
@@ -89,6 +89,14 @@ void fill_impl(GPUDev_t, Tensor<T>& tensor, const T& val);
 
 }  // namespace impl
 
+/**
+ * Fill tensor with a given value.
+ *
+ * This is usable only for compute types.
+ *
+ * If the tensor is on a GPU, this will be asynchronous. `val` does not
+ * need to be on the GPU.
+ */
 template <typename T>
 void fill(Tensor<T>& tensor, const T& val)
 {
@@ -96,6 +104,14 @@ void fill(Tensor<T>& tensor, const T& val)
                           impl::fill_impl(DeviceT_v<Dev>, tensor, val));
 }
 
+/**
+ * Fill tensor with a given value.
+ *
+ * This is usable only for compute types.
+ *
+ * If the tensor is on a GPU, this will be asynchronous. `val` does not
+ * need to be on the GPU.
+ */
 template <typename T>
 void fill(BaseTensor& tensor, const T& val);
 

--- a/include/h2/tensor/init/fill.hpp
+++ b/include/h2/tensor/init/fill.hpp
@@ -1,0 +1,102 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+/** @file
+ *
+ * Routines for filling buffers or tensors with values.
+ */
+
+#include <h2_config.hpp>
+
+#include <cstring>
+
+#include "h2/core/sync.hpp"
+#include "h2/core/types.hpp"
+#include "h2/tensor/tensor.hpp"
+
+#ifdef H2_HAS_GPU
+#include "h2/gpu/memory_utils.hpp"
+#endif
+
+namespace h2
+{
+
+/**
+ * Fill data with zeros.
+ *
+ * This is usable on any storage type: It just writes 0 bytes.
+ *
+ * If stream is a GPU stream, this will be asynchronous.
+ */
+template <typename T>
+void zero(T* data, const ComputeStream& stream, std::size_t count)
+{
+  H2_ASSERT_DEBUG(count == 0 || data != nullptr, "Null buffers");
+  static_assert(IsH2StorageType_v<T> || std::is_same_v<T*, void*>,
+                "Attempt to zero a buffer with a non-storage type");
+
+  H2_DEVICE_DISPATCH(
+      stream.get_device(),
+      std::memset(
+          data, 0, std::is_same_v<T*, void*> ? count : count * sizeof(T)),
+      gpu::mem_zero(data, count, stream.get_stream<Dev>()));
+}
+
+/**
+ * Fill tensor with zeros.
+ *
+ * This is usable on any storage type: It just writes 0 bytes.
+ *
+ * If the tensor is on a GPU, this will be asynchronous.
+ */
+template <typename T>
+void zero(Tensor<T>& tensor)
+{
+  if (tensor.is_contiguous())
+  {
+    zero(tensor.data(), tensor.get_stream(), tensor.numel());
+  }
+  else
+  {
+    throw H2FatalException("Zero not implemented for non-contiguous tensors");
+  }
+}
+
+/**
+ * Fill tensor with zeros.
+ *
+ * Unlike other `zero` versions, this is only usable for compute types.
+ *
+ * If the tensor is on a GPU, this will be asynchronous.
+ */
+void zero(BaseTensor& tensor);
+
+namespace impl
+{
+
+template <typename T>
+void fill_impl(CPUDev_t, Tensor<T>& tensor, const T& val);
+#ifdef H2_HAS_GPU
+template <typename T>
+void fill_impl(GPUDev_t, Tensor<T>& tensor, const T& val);
+#endif
+
+}  // namespace impl
+
+template <typename T>
+void fill(Tensor<T>& tensor, const T& val)
+{
+  H2_DEVICE_DISPATCH_SAME(tensor.get_device(),
+                          impl::fill_impl(DeviceT_v<Dev>, tensor, val));
+}
+
+template <typename T>
+void fill(BaseTensor& tensor, const T& val);
+
+}  // namespace h2

--- a/include/h2/utils/CMakeLists.txt
+++ b/include/h2/utils/CMakeLists.txt
@@ -17,6 +17,7 @@ h2_add_sources_to_target_and_install(
   Describable.hpp
   environment_vars.hpp
   Error.hpp
+  function_traits.hpp
   IntegerMath.hpp
   Logger.hpp
   passkey.hpp

--- a/include/h2/utils/CMakeLists.txt
+++ b/include/h2/utils/CMakeLists.txt
@@ -14,6 +14,7 @@ h2_add_sources_to_target_and_install(
   SOURCES
   As.hpp
   Cloneable.hpp
+  const_for.hpp
   Describable.hpp
   environment_vars.hpp
   Error.hpp

--- a/include/h2/utils/CMakeLists.txt
+++ b/include/h2/utils/CMakeLists.txt
@@ -23,6 +23,7 @@ h2_add_sources_to_target_and_install(
   Logger.hpp
   passkey.hpp
   strings.hpp
+  tuple_utils.hpp
   typename.hpp
   unique_ptr_cast.hpp
   )

--- a/include/h2/utils/IntegerMath.hpp
+++ b/include/h2/utils/IntegerMath.hpp
@@ -14,8 +14,8 @@
 #include <cstdint>
 #include <stdexcept>
 
-#ifdef H2_HAS_GPU
 #include "h2/gpu/macros.hpp"
+#ifdef H2_HAS_GPU
 #include "h2/gpu/runtime.hpp"
 #endif
 

--- a/include/h2/utils/IntegerMath.hpp
+++ b/include/h2/utils/IntegerMath.hpp
@@ -14,31 +14,11 @@
 #include <cstdint>
 #include <stdexcept>
 
-// TODO: Move this elsewhere.
-#if defined H2_HAS_GPU
-
-#if (defined __CUDA_ARCH__ && __CUDA_ARCH__)                                   \
-    || (defined __HIP_DEVICE_COMPILE__ && __HIP_DEVICE_COMPILE__)
-#define H2_GPU_DEVICE_COMPILING 1
-#else
-#define H2_GPU_DEVICE_COMPILING 0
-#endif
-
-#endif // H2_HAS_GPU
-
-// TODO: Move these defines elsewhere
-#if H2_GPU_DEVICE_COMPILING
+#ifdef H2_HAS_GPU
+#include "h2/gpu/macros.hpp"
 #include "h2/gpu/runtime.hpp"
-#define H2_GPU_DEVICE __device__
-#define H2_GPU_FORCE_INLINE __forceinline__
-#define H2_GPU_HOST __host__
-#define H2_GPU_HOST_DEVICE __host__ __device__
-#else
-#define H2_GPU_DEVICE
-#define H2_GPU_FORCE_INLINE inline
-#define H2_GPU_HOST
-#define H2_GPU_HOST_DEVICE
 #endif
+
 
 namespace h2
 {

--- a/include/h2/utils/const_for.hpp
+++ b/include/h2/utils/const_for.hpp
@@ -1,0 +1,63 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+/** @file
+ *
+ * For loops with compile-time constant indices and such.
+ */
+
+#include <tuple>
+#include <type_traits>
+
+#include <cstddef>
+
+
+namespace h2
+{
+
+/**
+ * An integral for loop which provides a compile-time constant to func.
+ *
+ * Example:
+ *     const_for<0, N, 1>([](auto i) { i is a compile-time constant })
+ */
+template <auto Start, auto End, auto Incr, typename FuncT>
+constexpr void const_for(FuncT&& func)
+{
+  if constexpr (Start < End)
+  {
+    func(std::integral_constant<decltype(Start), Start>{});
+    const_for<Start + Incr, End, Incr, FuncT>(std::forward<FuncT>(func));
+  }
+}
+
+/**
+ * Helper to apply a function to each element of a tuple.
+ */
+template <typename FuncT, typename Tuple>
+constexpr void const_for_tuple(FuncT&& func, Tuple&& tuple)
+{
+  constexpr std::size_t size = std::tuple_size_v<std::decay_t<Tuple>>;
+  const_for<std::size_t{0}, size, std::size_t{1}>(
+      [&](auto i) { func(std::get<i.value>(tuple)); });
+}
+
+/**
+ * Apply a function to each argument of a parameter pack.
+ *
+ * Example:
+ *    const_for_pack([](auto const& v) { ... }, args...)
+ */
+template <typename FuncT, typename... Args>
+constexpr void const_for_pack(FuncT&& func, Args&&... args)
+{
+  (func(std::forward<Args>(args)), ...);
+}
+
+}  // namespace h2

--- a/include/h2/utils/function_traits.hpp
+++ b/include/h2/utils/function_traits.hpp
@@ -1,0 +1,80 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+/** @file
+ *
+ * Traits describing functions.
+ */
+
+// This partially adapted from
+// https://stackoverflow.com/questions/7943525/is-it-possible-to-figure-out-the-parameter-type-and-return-type-of-a-lambda
+
+#include <functional>
+#include <tuple>
+
+#include <cstddef>
+
+
+namespace h2
+{
+
+/**
+ * Collect information on a function (anything with operator()).
+ */
+template <typename T>
+struct FunctionTraits
+    : public FunctionTraits<decltype(&std::remove_reference_t<T>::operator())>
+{};
+
+template <typename Ret, typename... Args>
+struct FunctionTraits<Ret(Args...)>
+{
+  using ArgsTuple = std::tuple<Args...>;
+  using RetT = Ret;
+  using FuncT = Ret(Args...);
+
+  /** Number of arguments the function takes. */
+  static constexpr std::size_t arity = sizeof...(Args);
+
+  /** Access the ith argument type. */
+  template <std::size_t i>
+  using arg = std::tuple_element_t<i, ArgsTuple>;
+};
+
+template <typename Ret, typename... Args>
+struct FunctionTraits<Ret(*)(Args...)> : public FunctionTraits<Ret(Args...)> {};
+template <typename FuncT>
+struct FunctionTraits<std::function<FuncT>> : public FunctionTraits<FuncT> {};
+template <typename T>
+struct FunctionTraits<T&> : public FunctionTraits<T> {};
+template <typename T>
+struct FunctionTraits<const T&> : public FunctionTraits<T> {};
+template <typename T>
+struct FunctionTraits<T&&> : public FunctionTraits<T> {};
+template <typename T>
+struct FunctionTraits<const T&&> : public FunctionTraits<T> {};
+template <typename T>
+struct FunctionTraits<T*> : public FunctionTraits<T> {};
+template <typename T>
+struct FunctionTraits<const T*> : public FunctionTraits<T> {};
+
+template <typename Class, typename Ret, typename... Args>
+struct FunctionTraits<Ret (Class::*)(Args...)>
+    : public FunctionTraits<Ret(Args...)>
+{
+  using ClassT = Class;
+};
+template <typename Class, typename Ret, typename... Args>
+struct FunctionTraits<Ret (Class::*)(Args...) const>
+    : public FunctionTraits<Ret(Args...)>
+{
+  using ClassT = Class;
+};
+
+}  // namespace h2

--- a/include/h2/utils/tuple_utils.hpp
+++ b/include/h2/utils/tuple_utils.hpp
@@ -1,0 +1,68 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+/** @file
+ *
+ * Utilities for working with `std::tuple`s.
+ */
+
+#include <tuple>
+
+
+namespace h2
+{
+
+/**
+ * Defines a type that is a tuple of all types except the first type in
+ * the tuple.
+ *
+ * I.e., this is cdr.
+ */
+template <typename Tuple>
+struct TupleRemoveFirstT;
+
+template <typename First, typename... Rest>
+struct TupleRemoveFirstT<std::tuple<First, Rest...>>
+{
+  using type = std::tuple<Rest...>;
+};
+
+template <typename Tuple>
+using TupleRemoveFirst_t = typename TupleRemoveFirstT<Tuple>::type;
+
+/**
+ * Defines a type that is a tuple containing the concatenation of the
+ * types in the given tuples.
+ *
+ * Essentially, this is a shorthand for `decltype(std::tuple_cat(...))`.
+ */
+template <typename... Tuples>
+struct TupleCatT;
+
+template <typename... Ts>
+struct TupleCatT<std::tuple<Ts...>>
+{
+  using type = std::tuple<Ts...>;
+};
+
+template <typename... T1s, typename... T2s>
+struct TupleCatT<std::tuple<T1s...>, std::tuple<T2s...>>
+{
+  using type = std::tuple<T1s..., T2s...>;
+};
+
+template <typename Tuple, typename... OtherTuples>
+struct TupleCatT<Tuple, OtherTuples...>
+    : TupleCatT<Tuple, TupleCatT<OtherTuples...>>
+{};
+
+template <typename... Tuples>
+using TupleCat_t = typename TupleCatT<Tuples...>::type;
+
+}

--- a/src/tensor/init/CMakeLists.txt
+++ b/src/tensor/init/CMakeLists.txt
@@ -6,12 +6,9 @@
 ################################################################################
 
 target_sources(H2Core PRIVATE
-  base_utils.cpp
-  copy.cpp)
+  fill.cpp)
 
 if (H2_HAS_GPU)
   target_sources(H2Core PRIVATE
-    copy.cu)
+    fill.cu)
 endif ()
-
-add_subdirectory(init)

--- a/src/tensor/init/fill.cpp
+++ b/src/tensor/init/fill.cpp
@@ -1,0 +1,95 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#include "h2/tensor/init/fill.hpp"
+
+#include "h2/core/dispatch.hpp"
+#include "h2/utils/typename.hpp"
+#include "h2/loops/cpu_loops.hpp"
+
+
+namespace h2
+{
+
+void zero(BaseTensor& tensor)
+{
+  // H2_DISPATCH_NAME: zero
+  // H2_DISPATCH_NUM_TYPES: 1
+  // H2_DISPATCH_INIT: zero<{T1}>("Tensor<{T1}>&")
+
+  if (tensor.is_contiguous())
+  {
+    // H2_DISPATCH_ON: "tensor"
+    // H2_DISPATCH_ARGS: "tensor"
+    // H2_DO_DISPATCH
+  }
+  else
+  {
+    throw H2FatalException("Zero not implemented for non-contiguous tensors");
+  }
+}
+
+namespace impl
+{
+
+template <typename T>
+void fill_impl(CPUDev_t, Tensor<T>& tensor, const T& val)
+{
+  if (tensor.is_empty())
+  {
+    return;
+  }
+  if (tensor.is_contiguous())
+  {
+    cpu::elementwise_loop(
+        [&val]() -> T { return val; }, tensor.numel(), tensor.data());
+  }
+  else
+  {
+    throw H2FatalException("Not supporting non-contiguous tensors");
+  }
+}
+
+#define PROTO(device, t1)                                       \
+  template void fill_impl<t1>(device, Tensor<t1>&, const t1&)
+H2_INSTANTIATE_CPU_1
+#undef PROTO
+
+}  // namespace impl
+
+template <typename T>
+void fill(BaseTensor& tensor, const T& val)
+{
+  // H2_DISPATCH_NAME: fill
+  // H2_DISPATCH_NUM_TYPES: 1
+  // H2_DISPATCH_INIT_CPU: impl::fill_impl("CPUDev_t", "Tensor<{T1}>&", "const {T1}&")
+  //  H2_DISPATCH_INIT_GPU: impl::fill_impl("GPUDev_t", "Tensor<{T1}>&", "const {T1}&")
+
+  // Ensure val matches the tensor's type.
+  // TODO: Relax this to allow conversion.
+  if (get_h2_type<T>() != tensor.get_type_info())
+  {
+    throw H2FatalException("Cannot fill a tensor of ",
+                           tensor.get_type_info(),
+                           " with ",
+                           val,
+                           " of type ",
+                           TypeName<T>());
+  }
+
+  // H2_DISPATCH_GET_DEVICE: "tensor.get_device()"
+  // H2_DISPATCH_ON: "tensor"
+  // H2_DISPATCH_ARGS_CPU: "CPUDev_t{}", "tensor", "val"
+  //  H2_DISPATCH_ARGS_GPU: "GPUDev_t{}", "tensor", "val"
+  // H2_DO_DISPATCH
+}
+
+#define PROTO(device, t1) template void fill<t1>(BaseTensor&, const t1&)
+H2_INSTANTIATE_DEV_1(none)
+#undef PROTO
+
+}  // namespace h2

--- a/src/tensor/init/fill.cu
+++ b/src/tensor/init/fill.cu
@@ -1,0 +1,51 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#include "h2/tensor/init/fill.hpp"
+#include "h2/core/dispatch.hpp"
+#include "h2/gpu/runtime.hpp"
+
+#include "h2/loops/gpu_loops.cuh"
+
+
+namespace h2
+{
+
+namespace impl
+{
+
+template <typename T>
+void fill_impl(GPUDev_t, Tensor<T>& tensor, const T& val)
+{
+  if (tensor.is_empty())
+  {
+    return;
+  }
+  if (tensor.is_contiguous())
+  {
+    T* __restrict__ out = tensor.data();
+    h2::gpu::launch_elementwise_loop_with_immediate(
+        [] H2_GPU_LAMBDA(const T val_) -> T { return val_; },
+        tensor.get_stream(),
+        tensor.numel(),
+        val,
+        out);
+  }
+  else
+  {
+    throw H2FatalException("Not supporting non-contiguous tensors");
+  }
+}
+
+#define PROTO(device, t1)                                                      \
+  template void fill_impl<t1>(device, Tensor<t1>&, const t1&);
+H2_INSTANTIATE_GPU_1
+#undef PROTO
+
+}  // namespace impl
+
+}  // namespace h2

--- a/src/utils/typename.cpp
+++ b/src/utils/typename.cpp
@@ -40,12 +40,12 @@ std::string safe_demangle(const char* mangled)
     auto error_str = demangle_errors.find(status);
     if (error_str != demangle_errors.end())
     {
-      throw H2Exception(std::string("Demangling failed: ")
-                        + error_str->second);
+      throw H2NonfatalException(std::string("Demangling failed: ")
+                                + error_str->second);
     }
     else
     {
-      throw H2Exception("Demangling failed: Unknown error");
+      throw H2NonfatalException("Demangling failed: Unknown error");
     }
   }
 
@@ -62,7 +62,14 @@ namespace internal
 std::string get_type_name(const std::type_info& tinfo)
 {
 #ifdef H2_HAS_CXXABI_H
-  return safe_demangle(tinfo.name());
+  try
+  {
+    return safe_demangle(tinfo.name());
+  }
+  catch (const H2NonfatalException&)
+  {
+    return tinfo.name();  // Getting a type name should not kill us.
+  }
 #else
   return tinfo.name();
 #endif

--- a/test/static_test/utils/CMakeLists.txt
+++ b/test/static_test/utils/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright 2019-2023 Lawrence Livermore National Security, LLC and other
+## Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 ## DiHydrogen Project Developers. See the top-level LICENSE file for details.
 ##
 ## SPDX-License-Identifier: Apache-2.0
@@ -8,4 +8,5 @@
 target_sources(StaticTest
   PRIVATE
   static_test_cloneable.cpp
+  static_test_function_traits.cpp
   )

--- a/test/static_test/utils/CMakeLists.txt
+++ b/test/static_test/utils/CMakeLists.txt
@@ -9,4 +9,5 @@ target_sources(StaticTest
   PRIVATE
   static_test_cloneable.cpp
   static_test_function_traits.cpp
+  static_test_tuple_utils.cpp
   )

--- a/test/static_test/utils/static_test_function_traits.cpp
+++ b/test/static_test/utils/static_test_function_traits.cpp
@@ -1,0 +1,87 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#include "h2/utils/function_traits.hpp"
+
+#include <type_traits>
+
+
+using namespace h2;
+
+
+int nullary() { return 42; }
+int unary(float) { return 42; }
+void unary_v(float) {}
+int binary(float, double) { return 42; }
+[[maybe_unused]] auto unary_lambda = [](float) -> int { return 42; };
+
+struct Test
+{
+  int nullary() { return 42; }
+  int unary(float) { return 42; }
+};
+
+struct NullaryFunctor
+{
+  int operator()() { return 42; }
+};
+struct UnaryFunctor
+{
+  int operator()(float) { return 42; }
+};
+
+static_assert(std::is_same_v<FunctionTraits<decltype(nullary)>::RetT, int>);
+static_assert(std::is_same_v<FunctionTraits<decltype(nullary)>::FuncT,
+                             decltype(nullary)>);
+static_assert(FunctionTraits<decltype(nullary)>::arity == 0);
+
+static_assert(std::is_same_v<FunctionTraits<decltype(unary)>::RetT, int>);
+static_assert(FunctionTraits<decltype(unary)>::arity == 1);
+static_assert(
+    std::is_same_v<FunctionTraits<decltype(unary)>::arg<0>, float>);
+
+static_assert(std::is_same_v<FunctionTraits<decltype(unary_v)>::RetT, void>);
+
+static_assert(FunctionTraits<decltype(binary)>::arity == 2);
+static_assert(
+    std::is_same_v<FunctionTraits<decltype(binary)>::arg<0>, float>);
+static_assert(
+    std::is_same_v<FunctionTraits<decltype(binary)>::arg<1>, double>);
+
+static_assert(FunctionTraits<decltype(&unary)>::arity == 1);
+
+static_assert(FunctionTraits<decltype(unary_lambda)>::arity == 1);
+static_assert(
+    std::is_same_v<FunctionTraits<decltype(unary_lambda)>::RetT, int>);
+static_assert(
+    std::is_same_v<FunctionTraits<decltype(unary_lambda)>::arg<0>,
+                   float>);
+
+static_assert(FunctionTraits<decltype(&Test::nullary)>::arity == 0);
+static_assert(
+    std::is_same_v<FunctionTraits<decltype(&Test::nullary)>::RetT, int>);
+static_assert(
+    std::is_same_v<FunctionTraits<decltype(&Test::nullary)>::ClassT, Test>);
+static_assert(FunctionTraits<decltype(&Test::unary)>::arity == 1);
+static_assert(
+    std::is_same_v<FunctionTraits<decltype(&Test::unary)>::arg<0>, float>);
+static_assert(
+    std::is_same_v<FunctionTraits<decltype(&Test::unary)>::ClassT, Test>);
+
+static_assert(FunctionTraits<NullaryFunctor>::arity == 0);
+static_assert(std::is_same_v<FunctionTraits<NullaryFunctor>::RetT, int>);
+
+static_assert(FunctionTraits<UnaryFunctor>::arity == 1);
+static_assert(
+    std::is_same_v<FunctionTraits<UnaryFunctor>::arg<0>, float>);
+
+static_assert(FunctionTraits<std::function<int(float)>>::arity == 1);
+static_assert(
+    std::is_same_v<FunctionTraits<std::function<int(float)>>::RetT, int>);
+static_assert(
+    std::is_same_v<FunctionTraits<std::function<int(float)>>::arg<0>,
+                   float>);

--- a/test/static_test/utils/static_test_tuple_utils.cpp
+++ b/test/static_test/utils/static_test_tuple_utils.cpp
@@ -1,0 +1,34 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#include "h2/utils/tuple_utils.hpp"
+
+#include <type_traits>
+
+
+using namespace h2;
+
+
+using EmptyTuple = std::tuple<>;
+using Tuple1 = std::tuple<int>;
+using Tuple2 = std::tuple<int, float>;
+using Tuple3 = std::tuple<int, float, char>;
+
+static_assert(std::is_same_v<TupleRemoveFirst_t<Tuple1>, std::tuple<>>);
+static_assert(std::is_same_v<TupleRemoveFirst_t<Tuple2>, std::tuple<float>>);
+static_assert(std::is_same_v<TupleRemoveFirst_t<Tuple3>, std::tuple<float, char>>);
+
+static_assert(std::is_same_v<TupleCat_t<EmptyTuple>, std::tuple<>>);
+static_assert(std::is_same_v<TupleCat_t<EmptyTuple, EmptyTuple>, std::tuple<>>);
+static_assert(std::is_same_v<TupleCat_t<Tuple1>, std::tuple<int>>);
+static_assert(std::is_same_v<TupleCat_t<Tuple1, EmptyTuple>, std::tuple<int>>);
+static_assert(std::is_same_v<TupleCat_t<EmptyTuple, Tuple1>, std::tuple<int>>);
+static_assert(std::is_same_v<TupleCat_t<Tuple1, Tuple1>, std::tuple<int, int>>);
+static_assert(
+    std::is_same_v<TupleCat_t<Tuple1, Tuple2>, std::tuple<int, int, float>>);
+static_assert(
+    std::is_same_v<TupleCat_t<Tuple2, Tuple1>, std::tuple<int, float, int>>);

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -72,6 +72,7 @@ endif ()
 # Add Catch2 unit tests
 add_subdirectory(core)
 add_subdirectory(gpu)
+add_subdirectory(loops)
 add_subdirectory(patterns/factory)
 add_subdirectory(patterns/multimethods)
 add_subdirectory(meta)

--- a/test/unit_test/core/unit_test_dispatch.cpp
+++ b/test/unit_test/core/unit_test_dispatch.cpp
@@ -127,9 +127,10 @@ void dyndist_test(GPUDev_t, Tensor<T1>& dst, const Tensor<T2>& src)
   }
 }
 
-void dyndist_cust_test(GPUDev_t,
-                       Tensor<dyndist_cust_type_t>& dst,
-                       const Tensor<dyndist_cust_type_t>& src)
+// This exists but is not used if we do not test with GPU support.
+[[maybe_unused]] void dyndist_cust_test(GPUDev_t,
+                                        Tensor<dyndist_cust_type_t>& dst,
+                                        const Tensor<dyndist_cust_type_t>& src)
 {
   for (DataIndexType i = 0; i < src.numel(); ++i)
   {

--- a/test/unit_test/loops/CMakeLists.txt
+++ b/test/unit_test/loops/CMakeLists.txt
@@ -1,0 +1,16 @@
+################################################################################
+## Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+## DiHydrogen Project Developers. See the top-level LICENSE file for details.
+##
+## SPDX-License-Identifier: Apache-2.0
+################################################################################
+
+target_sources(SeqCatchTests PRIVATE
+  unit_test_cpu_loops.cpp
+)
+
+if (H2_HAS_GPU)
+  target_sources(GPUCatchTests PRIVATE
+
+  )
+endif ()

--- a/test/unit_test/loops/CMakeLists.txt
+++ b/test/unit_test/loops/CMakeLists.txt
@@ -11,6 +11,6 @@ target_sources(SeqCatchTests PRIVATE
 
 if (H2_HAS_GPU)
   target_sources(GPUCatchTests PRIVATE
-
+    unit_test_gpu_loops.cu
   )
 endif ()

--- a/test/unit_test/loops/unit_test_cpu_loops.cpp
+++ b/test/unit_test/loops/unit_test_cpu_loops.cpp
@@ -1,0 +1,113 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+
+#include "h2/loops/cpu_loops.hpp"
+#include "../tensor/utils.hpp"
+
+
+using namespace h2;
+
+
+TEMPLATE_LIST_TEST_CASE("CPU elementwise loop works",
+                        "[loops]",
+                        h2::ComputeTypes)
+{
+  using Type = TestType;
+
+  SECTION("Empty buffer")
+  {
+    // No assertions, if this compiles and doesn't segfault, we should
+    // be okay.
+    Type* empty_buf = nullptr;
+    cpu::elementwise_loop([](Type) {}, 0, empty_buf);
+    cpu::elementwise_loop(
+        []() -> Type { return static_cast<Type>(42); }, 0, empty_buf);
+    cpu::elementwise_loop([](Type) -> Type { return static_cast<Type>(42); },
+                          0,
+                          empty_buf,
+                          empty_buf);
+  }
+
+  SECTION("Zero buffers and return")
+  {
+    DeviceBuf<Type, Device::CPU> buf{32};
+    buf.fill(static_cast<Type>(0));
+    const Type val = static_cast<Type>(42);
+    cpu::elementwise_loop([&val]() { return val; }, buf.size, buf.buf);
+    for (std::size_t i = 0; i < buf.size; ++i)
+    {
+      REQUIRE(buf.buf[i] == static_cast<Type>(42));
+    }
+  }
+
+  SECTION("One buffer")
+  {
+    DeviceBuf<Type, Device::CPU> buf{32};
+    buf.fill(static_cast<Type>(42));
+    // Has no effect.
+    cpu::elementwise_loop([](Type v) {}, buf.size, buf.buf);
+    for (std::size_t i = 0; i < buf.size; ++i)
+    {
+      REQUIRE(buf.buf[i] == static_cast<Type>(42));
+    }
+  }
+
+  SECTION("One buffer and return")
+  {
+    DeviceBuf<Type, Device::CPU> in_buf{32}, out_buf{32};
+    in_buf.fill(static_cast<Type>(42));
+    out_buf.fill(static_cast<Type>(0));
+    cpu::elementwise_loop([](Type v) -> Type { return v + 1; },
+                          out_buf.size,
+                          out_buf.buf,
+                          static_cast<const Type*>(in_buf.buf));
+    for (std::size_t i = 0; i < in_buf.size; ++i)
+    {
+      REQUIRE(in_buf.buf[i] == static_cast<Type>(42));
+      REQUIRE(out_buf.buf[i] == static_cast<Type>(43));
+    }
+  }
+
+  SECTION("Two buffers, no return")
+  {
+    DeviceBuf<Type, Device::CPU> buf1{32}, buf2{32};
+    buf1.fill(static_cast<Type>(21));
+    buf2.fill(static_cast<Type>(21));
+    // Has no effect.
+    cpu::elementwise_loop([](Type v1, Type v2) { v1 += v2; },
+                          buf1.size,
+                          buf1.buf,
+                          static_cast<const Type*>(buf2.buf));
+    for (std::size_t i = 0; i < buf1.size; ++i)
+    {
+      REQUIRE(buf1.buf[i] == static_cast<Type>(21));
+      REQUIRE(buf2.buf[i] == static_cast<Type>(21));
+    }
+  }
+
+  SECTION("Two buffers, and return")
+  {
+    DeviceBuf<Type, Device::CPU> buf1{32}, buf2{32}, out_buf{32};
+    buf1.fill(static_cast<Type>(21));
+    buf2.fill(static_cast<Type>(21));
+    out_buf.fill(static_cast<Type>(0));
+    cpu::elementwise_loop([](Type v1, Type v2) -> Type { return v1 + v2; },
+                          buf1.size,
+                          out_buf.buf,
+                          static_cast<const Type*>(buf1.buf),
+                          static_cast<const Type*>(buf2.buf));
+    for (std::size_t i = 0; i < buf1.size; ++i)
+    {
+      REQUIRE(buf1.buf[i] == static_cast<Type>(21));
+      REQUIRE(buf2.buf[i] == static_cast<Type>(21));
+      REQUIRE(out_buf.buf[i] == static_cast<Type>(42));
+    }
+  }
+}

--- a/test/unit_test/loops/unit_test_cpu_loops.cpp
+++ b/test/unit_test/loops/unit_test_cpu_loops.cpp
@@ -40,7 +40,7 @@ TEMPLATE_LIST_TEST_CASE("CPU elementwise loop works",
     DeviceBuf<Type, Device::CPU> buf{32};
     buf.fill(static_cast<Type>(0));
     const Type val = static_cast<Type>(42);
-    cpu::elementwise_loop([&val]() { return val; }, buf.size, buf.buf);
+    cpu::elementwise_loop([&]() { return val; }, buf.size, buf.buf);
     for (std::size_t i = 0; i < buf.size; ++i)
     {
       REQUIRE(buf.buf[i] == static_cast<Type>(42));

--- a/test/unit_test/loops/unit_test_gpu_loops.cu
+++ b/test/unit_test/loops/unit_test_gpu_loops.cu
@@ -1,0 +1,634 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+
+#include "h2/loops/gpu_loops.cuh"
+#include "../tensor/utils.hpp"
+
+
+using namespace h2;
+
+
+// Test helpers, use `gpu::launch_elementwise_loop`, etc. in real code.
+
+template <typename FuncT, typename... Args>
+void test_launch_naive_elementwise_loop(const FuncT func,
+                                        const ComputeStream& stream,
+                                        std::size_t size,
+                                        Args... args)
+{
+  const unsigned int block_size = gpu::num_threads_per_block;
+  const unsigned int num_blocks = (size + block_size - 1) / block_size;
+
+  if (size == 0)
+  {
+    return;
+  }
+
+  gpu::launch_kernel(gpu::kernels::elementwise_loop<FuncT, Args...>,
+                     num_blocks,
+                     block_size,
+                     0,
+                     stream.template get_stream<Device::GPU>(),
+                     func,
+                     size,
+                     args...);
+}
+
+template <typename FuncT, typename ImmediateT, typename... Args>
+void test_launch_naive_elementwise_loop_with_immediate(
+    const FuncT func,
+    const ComputeStream& stream,
+    std::size_t size,
+    ImmediateT imm,
+    Args... args)
+{
+  const unsigned int block_size = gpu::num_threads_per_block;
+  const unsigned int num_blocks = (size + block_size - 1) / block_size;
+
+  if (size == 0)
+  {
+    return;
+  }
+
+  gpu::launch_kernel(
+      gpu::kernels::elementwise_loop_with_immediate<FuncT, ImmediateT, Args...>,
+      num_blocks,
+      block_size,
+      0,
+      stream.template get_stream<Device::GPU>(),
+      func,
+      size,
+      imm,
+      args...);
+}
+
+template <std::size_t vec_width,
+          std::size_t unroll_factor,
+          typename FuncT,
+          typename... Args>
+void test_launch_vectorized_elementwise_loop(const FuncT func,
+                                             const ComputeStream& stream,
+                                             std::size_t size,
+                                             Args... args)
+{
+  const unsigned int block_size = gpu::num_threads_per_block;
+  const unsigned int num_blocks = (size + block_size - 1) / block_size;
+
+  if (size == 0)
+  {
+    return;
+  }
+
+  std::size_t reqd_vec_width =
+      std::min({gpu::max_vectorization_amount(args)...});
+  if (vec_width > reqd_vec_width)
+  {
+    throw H2FatalException(
+        "Invalid test vector width: ", vec_width, " > ", reqd_vec_width);
+  }
+
+  gpu::launch_kernel(gpu::kernels::vectorized_elementwise_loop<std::size_t,
+                                                               vec_width,
+                                                               unroll_factor,
+                                                               FuncT,
+                                                               Args...>,
+                     num_blocks,
+                     block_size,
+                     0,
+                     stream.template get_stream<Device::GPU>(),
+                     func,
+                     size,
+                     args...);
+}
+
+
+TEMPLATE_LIST_TEST_CASE("Naive GPU element-wise loop works",
+                        "[loops]",
+                        h2::ComputeTypes)
+{
+  using Type = TestType;
+
+  ComputeStream stream{Device::GPU};
+
+  SECTION("Empty buffer")
+  {
+    // No assertions, if this compiles and doesn't segfault, we should
+    // be okay.
+    Type* empty_buf = nullptr;
+    test_launch_naive_elementwise_loop(
+        [] H2_GPU_LAMBDA(Type) {}, stream, 0, empty_buf);
+    test_launch_naive_elementwise_loop(
+        [] H2_GPU_LAMBDA() -> Type { return static_cast<Type>(42); },
+        stream,
+        0,
+        empty_buf);
+    test_launch_naive_elementwise_loop(
+        [] H2_GPU_LAMBDA(Type) -> Type { return static_cast<Type>(42); },
+        stream,
+        0,
+        empty_buf,
+        empty_buf);
+  }
+
+  SECTION("Zero buffers and return")
+  {
+    DeviceBuf<Type, Device::GPU> buf{32};
+    buf.fill(static_cast<Type>(0));
+    test_launch_naive_elementwise_loop(
+      [] H2_GPU_LAMBDA() { return 42; }, stream, buf.size, buf.buf);
+    for (std::size_t i = 0; i < buf.size; ++i)
+    {
+      REQUIRE(read_ele<Device::GPU>(buf.buf, i, stream)
+              == static_cast<Type>(42));
+    }
+  }
+
+  SECTION("Zero buffers, capture-by-value, and return")
+  {
+    DeviceBuf<Type, Device::GPU> buf{32};
+    buf.fill(static_cast<Type>(0));
+    const Type val = static_cast<Type>(42);
+    test_launch_naive_elementwise_loop(
+      [val] H2_GPU_LAMBDA() { return val; }, stream, buf.size, buf.buf);
+    for (std::size_t i = 0; i < buf.size; ++i)
+    {
+      REQUIRE(read_ele<Device::GPU>(buf.buf, i, stream)
+              == static_cast<Type>(42));
+    }
+  }
+
+  SECTION("One buffer")
+  {
+    DeviceBuf<Type, Device::GPU> buf{32};
+    buf.fill(static_cast<Type>(42));
+    // Has no effect.
+    test_launch_naive_elementwise_loop(
+        [] H2_GPU_LAMBDA(Type v) {}, stream, buf.size, buf.buf);
+    for (std::size_t i = 0; i < buf.size; ++i)
+    {
+      REQUIRE(read_ele<Device::GPU>(buf.buf, i, stream)
+              == static_cast<Type>(42));
+    }
+  }
+
+  SECTION("One buffer and return")
+  {
+    DeviceBuf<Type, Device::GPU> in_buf{32}, out_buf{32};
+    in_buf.fill(static_cast<Type>(42));
+    out_buf.fill(static_cast<Type>(0));
+    test_launch_naive_elementwise_loop(
+        [] H2_GPU_LAMBDA(Type v) -> Type { return v + 1; },
+        stream,
+        out_buf.size,
+        out_buf.buf,
+        static_cast<const Type*>(in_buf.buf));
+    for (std::size_t i = 0; i < in_buf.size; ++i)
+    {
+      REQUIRE(read_ele<Device::GPU>(in_buf.buf, i, stream)
+              == static_cast<Type>(42));
+      REQUIRE(read_ele<Device::GPU>(out_buf.buf, i, stream)
+              == static_cast<Type>(43));
+    }
+  }
+
+  SECTION("Two buffers, no return")
+  {
+    DeviceBuf<Type, Device::GPU> buf1{32}, buf2{32};
+    buf1.fill(static_cast<Type>(21));
+    buf2.fill(static_cast<Type>(21));
+    // Has no effect.
+    test_launch_naive_elementwise_loop(
+        [] H2_GPU_LAMBDA(Type v1, Type v2) { v1 += v2; },
+        stream,
+        buf1.size,
+        buf1.buf,
+        static_cast<const Type*>(buf2.buf));
+    for (std::size_t i = 0; i < buf1.size; ++i)
+    {
+      REQUIRE(read_ele<Device::GPU>(buf1.buf, i, stream)
+              == static_cast<Type>(21));
+      REQUIRE(read_ele<Device::GPU>(buf2.buf, i, stream)
+              == static_cast<Type>(21));
+    }
+  }
+
+  SECTION("Two buffers, and return")
+  {
+    DeviceBuf<Type, Device::GPU> buf1{32}, buf2{32}, out_buf{32};
+    buf1.fill(static_cast<Type>(21));
+    buf2.fill(static_cast<Type>(21));
+    out_buf.fill(static_cast<Type>(0));
+    test_launch_naive_elementwise_loop(
+        [] H2_GPU_LAMBDA(Type v1, Type v2) -> Type { return v1 + v2; },
+        stream,
+        buf1.size,
+        out_buf.buf,
+        static_cast<const Type*>(buf1.buf),
+        static_cast<const Type*>(buf2.buf));
+    for (std::size_t i = 0; i < buf1.size; ++i)
+    {
+      REQUIRE(read_ele<Device::GPU>(buf1.buf, i, stream)
+              == static_cast<Type>(21));
+      REQUIRE(read_ele<Device::GPU>(buf2.buf, i, stream)
+              == static_cast<Type>(21));
+      REQUIRE(read_ele<Device::GPU>(out_buf.buf, i, stream)
+              == static_cast<Type>(42));
+    }
+  }
+
+  SECTION("Two buffers, funky size, and return")
+  {
+    DeviceBuf<Type, Device::GPU> buf1{31}, buf2{31}, out_buf{31};
+    buf1.fill(static_cast<Type>(21));
+    buf2.fill(static_cast<Type>(21));
+    out_buf.fill(static_cast<Type>(0));
+    test_launch_naive_elementwise_loop(
+        [] H2_GPU_LAMBDA(Type v1, Type v2) -> Type { return v1 + v2; },
+        stream,
+        buf1.size,
+        out_buf.buf,
+        static_cast<const Type*>(buf1.buf),
+        static_cast<const Type*>(buf2.buf));
+    for (std::size_t i = 0; i < buf1.size; ++i)
+    {
+      REQUIRE(read_ele<Device::GPU>(buf1.buf, i, stream)
+              == static_cast<Type>(21));
+      REQUIRE(read_ele<Device::GPU>(buf2.buf, i, stream)
+              == static_cast<Type>(21));
+      REQUIRE(read_ele<Device::GPU>(out_buf.buf, i, stream)
+              == static_cast<Type>(42));
+    }
+  }
+}
+
+TEMPLATE_LIST_TEST_CASE("Naive GPU element-wise loop with immediate works",
+                        "[loops]",
+                        h2::ComputeTypes)
+{
+  using Type = TestType;
+
+  ComputeStream stream{Device::GPU};
+
+  SECTION("Zero buffers and return")
+  {
+    DeviceBuf<Type, Device::GPU> buf{32};
+    buf.fill(static_cast<Type>(0));
+    test_launch_naive_elementwise_loop_with_immediate(
+        [] H2_GPU_LAMBDA(Type val) { return val; },
+        stream,
+        buf.size,
+        static_cast<Type>(42),
+        buf.buf);
+    for (std::size_t i = 0; i < buf.size; ++i)
+    {
+      REQUIRE(read_ele<Device::GPU>(buf.buf, i, stream)
+              == static_cast<Type>(42));
+    }
+  }
+
+  SECTION("One buffer and return")
+  {
+    DeviceBuf<Type, Device::GPU> in_buf{32}, out_buf{32};
+    in_buf.fill(static_cast<Type>(42));
+    out_buf.fill(static_cast<Type>(0));
+    test_launch_naive_elementwise_loop_with_immediate(
+        [] H2_GPU_LAMBDA(Type v1, Type v2) -> Type { return v1 + v2; },
+        stream,
+        out_buf.size,
+        static_cast<Type>(1),
+        out_buf.buf,
+        static_cast<const Type*>(in_buf.buf));
+    for (std::size_t i = 0; i < in_buf.size; ++i)
+    {
+      REQUIRE(read_ele<Device::GPU>(in_buf.buf, i, stream)
+              == static_cast<Type>(42));
+      REQUIRE(read_ele<Device::GPU>(out_buf.buf, i, stream)
+              == static_cast<Type>(43));
+    }
+  }
+
+  SECTION("Two buffers, no return")
+  {
+    DeviceBuf<Type, Device::GPU> buf1{32}, buf2{32};
+    buf1.fill(static_cast<Type>(21));
+    buf2.fill(static_cast<Type>(21));
+    // Has no effect.
+    test_launch_naive_elementwise_loop_with_immediate(
+      [] H2_GPU_LAMBDA(bool b, Type v1, Type v2) { v1 += b ? 42 : v2; },
+        stream,
+        buf1.size,
+        false,
+        buf1.buf,
+        static_cast<const Type*>(buf2.buf));
+    for (std::size_t i = 0; i < buf1.size; ++i)
+    {
+      REQUIRE(read_ele<Device::GPU>(buf1.buf, i, stream)
+              == static_cast<Type>(21));
+      REQUIRE(read_ele<Device::GPU>(buf2.buf, i, stream)
+              == static_cast<Type>(21));
+    }
+  }
+
+  SECTION("Two buffers, and return")
+  {
+    DeviceBuf<Type, Device::GPU> buf1{32}, buf2{32}, out_buf{32};
+    buf1.fill(static_cast<Type>(21));
+    buf2.fill(static_cast<Type>(21));
+    out_buf.fill(static_cast<Type>(0));
+    test_launch_naive_elementwise_loop_with_immediate(
+        [] H2_GPU_LAMBDA(Type a, Type v1, Type v2) -> Type {
+          return a + v1 + v2;
+        },
+        stream,
+        buf1.size,
+        static_cast<Type>(1),
+        out_buf.buf,
+        static_cast<const Type*>(buf1.buf),
+        static_cast<const Type*>(buf2.buf));
+    for (std::size_t i = 0; i < buf1.size; ++i)
+    {
+      REQUIRE(read_ele<Device::GPU>(buf1.buf, i, stream)
+              == static_cast<Type>(21));
+      REQUIRE(read_ele<Device::GPU>(buf2.buf, i, stream)
+              == static_cast<Type>(21));
+      REQUIRE(read_ele<Device::GPU>(out_buf.buf, i, stream)
+              == static_cast<Type>(43));
+    }
+  }
+
+  SECTION("Two buffers, funky size, and return")
+  {
+    DeviceBuf<Type, Device::GPU> buf1{31}, buf2{31}, out_buf{31};
+    buf1.fill(static_cast<Type>(21));
+    buf2.fill(static_cast<Type>(21));
+    out_buf.fill(static_cast<Type>(0));
+    test_launch_naive_elementwise_loop_with_immediate(
+        [] H2_GPU_LAMBDA(Type a, Type v1, Type v2) -> Type {
+          return a + v1 + v2;
+        },
+        stream,
+        buf1.size,
+        static_cast<Type>(1),
+        out_buf.buf,
+        static_cast<const Type*>(buf1.buf),
+        static_cast<const Type*>(buf2.buf));
+    for (std::size_t i = 0; i < buf1.size; ++i)
+    {
+      REQUIRE(read_ele<Device::GPU>(buf1.buf, i, stream)
+              == static_cast<Type>(21));
+      REQUIRE(read_ele<Device::GPU>(buf2.buf, i, stream)
+              == static_cast<Type>(21));
+      REQUIRE(read_ele<Device::GPU>(out_buf.buf, i, stream)
+              == static_cast<Type>(43));
+    }
+  }
+}
+
+TEMPLATE_LIST_TEST_CASE("Vectorized GPU element-wise loop works",
+                        "[loops]",
+                        h2::ComputeTypes)
+{
+  using Type = TestType;
+
+  ComputeStream stream{Device::GPU};
+
+  SECTION("Empty buffer")
+  {
+    // No assertions, if this compiles and doesn't segfault, we should
+    // be okay.
+    Type* empty_buf = nullptr;
+    test_launch_vectorized_elementwise_loop<4, 4>(
+        [] H2_GPU_LAMBDA(Type) {}, stream, 0, empty_buf);
+    test_launch_vectorized_elementwise_loop<4, 4>(
+        [] H2_GPU_LAMBDA() -> Type { return static_cast<Type>(42); },
+        stream,
+        0,
+        empty_buf);
+    test_launch_vectorized_elementwise_loop<4, 4>(
+        [] H2_GPU_LAMBDA(Type) -> Type { return static_cast<Type>(42); },
+        stream,
+        0,
+        empty_buf,
+        empty_buf);
+  }
+
+  SECTION("Zero buffers and return")
+  {
+    DeviceBuf<Type, Device::GPU> buf{32};
+    buf.fill(static_cast<Type>(0));
+    test_launch_vectorized_elementwise_loop<4, 4>(
+        [] H2_GPU_LAMBDA() -> Type { return static_cast<Type>(42); },
+        stream,
+        buf.size,
+        buf.buf);
+    for (std::size_t i = 0; i < buf.size; ++i)
+    {
+      REQUIRE(read_ele<Device::GPU>(buf.buf, i, stream)
+              == static_cast<Type>(42));
+    }
+  }
+
+  SECTION("Zero buffers, capture-by-value, and return")
+  {
+    DeviceBuf<Type, Device::GPU> buf{32};
+    buf.fill(static_cast<Type>(0));
+    const Type val = static_cast<Type>(42);
+    test_launch_vectorized_elementwise_loop<4, 4>(
+      [val] H2_GPU_LAMBDA() { return val; }, stream, buf.size, buf.buf);
+    for (std::size_t i = 0; i < buf.size; ++i)
+    {
+      REQUIRE(read_ele<Device::GPU>(buf.buf, i, stream)
+              == static_cast<Type>(42));
+    }
+  }
+
+  SECTION("One buffer")
+  {
+    DeviceBuf<Type, Device::GPU> buf{32};
+    buf.fill(static_cast<Type>(42));
+    // Has no effect.
+    test_launch_vectorized_elementwise_loop<4, 4>(
+        [] H2_GPU_LAMBDA(Type v) {}, stream, buf.size, buf.buf);
+    for (std::size_t i = 0; i < buf.size; ++i)
+    {
+      REQUIRE(read_ele<Device::GPU>(buf.buf, i, stream)
+              == static_cast<Type>(42));
+    }
+  }
+
+  SECTION("One buffer and return")
+  {
+    DeviceBuf<Type, Device::GPU> in_buf{32}, out_buf{32};
+    in_buf.fill(static_cast<Type>(42));
+    out_buf.fill(static_cast<Type>(0));
+    test_launch_vectorized_elementwise_loop<4, 4>(
+        [] H2_GPU_LAMBDA(Type v) -> Type { return v + 1; },
+        stream,
+        out_buf.size,
+        out_buf.buf,
+        static_cast<const Type*>(in_buf.buf));
+    for (std::size_t i = 0; i < in_buf.size; ++i)
+    {
+      REQUIRE(read_ele<Device::GPU>(in_buf.buf, i, stream)
+              == static_cast<Type>(42));
+      REQUIRE(read_ele<Device::GPU>(out_buf.buf, i, stream)
+              == static_cast<Type>(43));
+    }
+  }
+
+  SECTION("Two buffers, no return")
+  {
+    DeviceBuf<Type, Device::GPU> buf1{32}, buf2{32};
+    buf1.fill(static_cast<Type>(21));
+    buf2.fill(static_cast<Type>(21));
+    // Has no effect.
+    test_launch_vectorized_elementwise_loop<4, 4>(
+        [] H2_GPU_LAMBDA(Type v1, Type v2) { v1 += v2; },
+        stream,
+        buf1.size,
+        buf1.buf,
+        static_cast<const Type*>(buf2.buf));
+    for (std::size_t i = 0; i < buf1.size; ++i)
+    {
+      REQUIRE(read_ele<Device::GPU>(buf1.buf, i, stream)
+              == static_cast<Type>(21));
+      REQUIRE(read_ele<Device::GPU>(buf2.buf, i, stream)
+              == static_cast<Type>(21));
+    }
+  }
+
+  SECTION("Two buffers, and return")
+  {
+    DeviceBuf<Type, Device::GPU> buf1{32}, buf2{32}, out_buf{32};
+    buf1.fill(static_cast<Type>(21));
+    buf2.fill(static_cast<Type>(21));
+    out_buf.fill(static_cast<Type>(0));
+    test_launch_vectorized_elementwise_loop<4, 4>(
+        [] H2_GPU_LAMBDA(Type v1, Type v2) -> Type { return v1 + v2; },
+        stream,
+        buf1.size,
+        out_buf.buf,
+        static_cast<const Type*>(buf1.buf),
+        static_cast<const Type*>(buf2.buf));
+    for (std::size_t i = 0; i < buf1.size; ++i)
+    {
+      REQUIRE(read_ele<Device::GPU>(buf1.buf, i, stream)
+              == static_cast<Type>(21));
+      REQUIRE(read_ele<Device::GPU>(buf2.buf, i, stream)
+              == static_cast<Type>(21));
+      REQUIRE(read_ele<Device::GPU>(out_buf.buf, i, stream)
+              == static_cast<Type>(42));
+    }
+  }
+
+  SECTION("Two buffers, funky size, and return")
+  {
+    DeviceBuf<Type, Device::GPU> buf1{31}, buf2{31}, out_buf{31};
+    buf1.fill(static_cast<Type>(21));
+    buf2.fill(static_cast<Type>(21));
+    out_buf.fill(static_cast<Type>(0));
+    test_launch_vectorized_elementwise_loop<4, 4>(
+        [] H2_GPU_LAMBDA(Type v1, Type v2) -> Type { return v1 + v2; },
+        stream,
+        buf1.size,
+        out_buf.buf,
+        static_cast<const Type*>(buf1.buf),
+        static_cast<const Type*>(buf2.buf));
+    for (std::size_t i = 0; i < buf1.size; ++i)
+    {
+      REQUIRE(read_ele<Device::GPU>(buf1.buf, i, stream)
+              == static_cast<Type>(21));
+      REQUIRE(read_ele<Device::GPU>(buf2.buf, i, stream)
+              == static_cast<Type>(21));
+      REQUIRE(read_ele<Device::GPU>(out_buf.buf, i, stream)
+              == static_cast<Type>(42));
+    }
+  }
+
+  SECTION("One buffer and return, 2 unrolls")
+  {
+    DeviceBuf<Type, Device::GPU> in_buf{32}, out_buf{32};
+    in_buf.fill(static_cast<Type>(42));
+    out_buf.fill(static_cast<Type>(0));
+    test_launch_vectorized_elementwise_loop<4, 2>(
+        [] H2_GPU_LAMBDA(Type v) -> Type { return v + 1; },
+        stream,
+        out_buf.size,
+        out_buf.buf,
+        static_cast<const Type*>(in_buf.buf));
+    for (std::size_t i = 0; i < in_buf.size; ++i)
+    {
+      REQUIRE(read_ele<Device::GPU>(in_buf.buf, i, stream)
+              == static_cast<Type>(42));
+      REQUIRE(read_ele<Device::GPU>(out_buf.buf, i, stream)
+              == static_cast<Type>(43));
+    }
+  }
+
+  SECTION("One buffer and return, veclen 2")
+  {
+    DeviceBuf<Type, Device::GPU> in_buf{32}, out_buf{32};
+    in_buf.fill(static_cast<Type>(42));
+    out_buf.fill(static_cast<Type>(0));
+    test_launch_vectorized_elementwise_loop<2, 4>(
+        [] H2_GPU_LAMBDA(Type v) -> Type { return v + 1; },
+        stream,
+        out_buf.size,
+        out_buf.buf,
+        static_cast<const Type*>(in_buf.buf));
+    for (std::size_t i = 0; i < in_buf.size; ++i)
+    {
+      REQUIRE(read_ele<Device::GPU>(in_buf.buf, i, stream)
+              == static_cast<Type>(42));
+      REQUIRE(read_ele<Device::GPU>(out_buf.buf, i, stream)
+              == static_cast<Type>(43));
+    }
+  }
+
+  SECTION("One buffer and return, tiny buffer")
+  {
+    DeviceBuf<Type, Device::GPU> in_buf{1}, out_buf{1};
+    in_buf.fill(static_cast<Type>(42));
+    out_buf.fill(static_cast<Type>(0));
+    test_launch_vectorized_elementwise_loop<4, 4>(
+        [] H2_GPU_LAMBDA(Type v) -> Type { return v + 1; },
+        stream,
+        out_buf.size,
+        out_buf.buf,
+        static_cast<const Type*>(in_buf.buf));
+    for (std::size_t i = 0; i < in_buf.size; ++i)
+    {
+      REQUIRE(read_ele<Device::GPU>(in_buf.buf, i, stream)
+              == static_cast<Type>(42));
+      REQUIRE(read_ele<Device::GPU>(out_buf.buf, i, stream)
+              == static_cast<Type>(43));
+    }
+  }
+
+  SECTION("One buffer and return, smaller than unroll*veclen")
+  {
+    DeviceBuf<Type, Device::GPU> in_buf{6}, out_buf{6};
+    in_buf.fill(static_cast<Type>(42));
+    out_buf.fill(static_cast<Type>(0));
+    test_launch_vectorized_elementwise_loop<2, 4>(
+        [] H2_GPU_LAMBDA(Type v) -> Type { return v + 1; },
+        stream,
+        out_buf.size,
+        out_buf.buf,
+        static_cast<const Type*>(in_buf.buf));
+    for (std::size_t i = 0; i < in_buf.size; ++i)
+    {
+      REQUIRE(read_ele<Device::GPU>(in_buf.buf, i, stream)
+              == static_cast<Type>(42));
+      REQUIRE(read_ele<Device::GPU>(out_buf.buf, i, stream)
+              == static_cast<Type>(43));
+    }
+  }
+}

--- a/test/unit_test/loops/unit_test_gpu_loops.cu
+++ b/test/unit_test/loops/unit_test_gpu_loops.cu
@@ -108,6 +108,51 @@ void test_launch_vectorized_elementwise_loop(const FuncT func,
                      args...);
 }
 
+template <std::size_t vec_width,
+          std::size_t unroll_factor,
+          typename FuncT,
+          typename ImmediateT,
+          typename... Args>
+void test_launch_vectorized_elementwise_loop_with_immediate(
+    const FuncT func,
+    const ComputeStream& stream,
+    std::size_t size,
+    ImmediateT imm,
+    Args... args)
+{
+  const unsigned int block_size = gpu::num_threads_per_block;
+  const unsigned int num_blocks = (size + block_size - 1) / block_size;
+
+  if (size == 0)
+  {
+    return;
+  }
+
+  std::size_t reqd_vec_width =
+      std::min({gpu::max_vectorization_amount(args)...});
+  if (vec_width > reqd_vec_width)
+  {
+    throw H2FatalException(
+        "Invalid test vector width: ", vec_width, " > ", reqd_vec_width);
+  }
+
+  gpu::launch_kernel(
+      gpu::kernels::vectorized_elementwise_loop_with_immediate<std::size_t,
+                                                               vec_width,
+                                                               unroll_factor,
+                                                               FuncT,
+                                                               ImmediateT,
+                                                               Args...>,
+      num_blocks,
+      block_size,
+      0,
+      stream.template get_stream<Device::GPU>(),
+      func,
+      size,
+      imm,
+      args...);
+}
+
 
 TEMPLATE_LIST_TEST_CASE("Naive GPU element-wise loop works",
                         "[loops]",
@@ -627,6 +672,149 @@ TEMPLATE_LIST_TEST_CASE("Vectorized GPU element-wise loop works",
     {
       REQUIRE(read_ele<Device::GPU>(in_buf.buf, i, stream)
               == static_cast<Type>(42));
+      REQUIRE(read_ele<Device::GPU>(out_buf.buf, i, stream)
+              == static_cast<Type>(43));
+    }
+  }
+
+  SECTION("One buffer and return, big buffer")
+  {
+    DeviceBuf<Type, Device::GPU> in_buf{32768}, out_buf{32768};
+    in_buf.fill(static_cast<Type>(42));
+    out_buf.fill(static_cast<Type>(0));
+    test_launch_vectorized_elementwise_loop<4, 4>(
+        [] H2_GPU_LAMBDA(Type v) -> Type { return v + 1; },
+        stream,
+        out_buf.size,
+        out_buf.buf,
+        static_cast<const Type*>(in_buf.buf));
+    for (std::size_t i = 0; i < in_buf.size; ++i)
+    {
+      REQUIRE(read_ele<Device::GPU>(in_buf.buf, i, stream)
+              == static_cast<Type>(42));
+      REQUIRE(read_ele<Device::GPU>(out_buf.buf, i, stream)
+              == static_cast<Type>(43));
+    }
+  }
+}
+
+TEMPLATE_LIST_TEST_CASE("Vectorized GPU element-wise loop with immediate works",
+                        "[loops]",
+                        h2::ComputeTypes)
+{
+  using Type = TestType;
+
+  ComputeStream stream{Device::GPU};
+
+  SECTION("Zero buffers and return")
+  {
+    DeviceBuf<Type, Device::GPU> buf{32};
+    buf.fill(static_cast<Type>(0));
+    test_launch_vectorized_elementwise_loop_with_immediate<4, 4>(
+        [] H2_GPU_LAMBDA(Type val) -> Type { return val; },
+        stream,
+        buf.size,
+        static_cast<Type>(42),
+        buf.buf);
+    for (std::size_t i = 0; i < buf.size; ++i)
+    {
+      REQUIRE(read_ele<Device::GPU>(buf.buf, i, stream)
+              == static_cast<Type>(42));
+    }
+  }
+
+  SECTION("One buffer and return")
+  {
+    DeviceBuf<Type, Device::GPU> in_buf{32}, out_buf{32};
+    in_buf.fill(static_cast<Type>(42));
+    out_buf.fill(static_cast<Type>(0));
+    test_launch_vectorized_elementwise_loop_with_immediate<4, 4>(
+        [] H2_GPU_LAMBDA(Type v1, Type v2) -> Type { return v1 + v2; },
+        stream,
+        out_buf.size,
+        static_cast<Type>(1),
+        out_buf.buf,
+        static_cast<const Type*>(in_buf.buf));
+    for (std::size_t i = 0; i < in_buf.size; ++i)
+    {
+      REQUIRE(read_ele<Device::GPU>(in_buf.buf, i, stream)
+              == static_cast<Type>(42));
+      REQUIRE(read_ele<Device::GPU>(out_buf.buf, i, stream)
+              == static_cast<Type>(43));
+    }
+  }
+
+  SECTION("Two buffers, no return")
+  {
+    DeviceBuf<Type, Device::GPU> buf1{32}, buf2{32};
+    buf1.fill(static_cast<Type>(21));
+    buf2.fill(static_cast<Type>(21));
+    // Has no effect.
+    test_launch_vectorized_elementwise_loop_with_immediate<4, 4>(
+        [] H2_GPU_LAMBDA(bool b, Type v1, Type v2) { v1 += b ? 42 : v2; },
+        stream,
+        buf1.size,
+        false,
+        buf1.buf,
+        static_cast<const Type*>(buf2.buf));
+    for (std::size_t i = 0; i < buf1.size; ++i)
+    {
+      REQUIRE(read_ele<Device::GPU>(buf1.buf, i, stream)
+              == static_cast<Type>(21));
+      REQUIRE(read_ele<Device::GPU>(buf2.buf, i, stream)
+              == static_cast<Type>(21));
+    }
+  }
+
+  SECTION("Two buffers, and return")
+  {
+    DeviceBuf<Type, Device::GPU> buf1{32}, buf2{32}, out_buf{32};
+    buf1.fill(static_cast<Type>(21));
+    buf2.fill(static_cast<Type>(21));
+    out_buf.fill(static_cast<Type>(0));
+    test_launch_vectorized_elementwise_loop_with_immediate<4, 4>(
+        [] H2_GPU_LAMBDA(Type a, Type v1, Type v2) -> Type {
+          return a + v1 + v2;
+        },
+        stream,
+        buf1.size,
+        static_cast<Type>(1),
+        out_buf.buf,
+        static_cast<const Type*>(buf1.buf),
+        static_cast<const Type*>(buf2.buf));
+    for (std::size_t i = 0; i < buf1.size; ++i)
+    {
+      REQUIRE(read_ele<Device::GPU>(buf1.buf, i, stream)
+              == static_cast<Type>(21));
+      REQUIRE(read_ele<Device::GPU>(buf2.buf, i, stream)
+              == static_cast<Type>(21));
+      REQUIRE(read_ele<Device::GPU>(out_buf.buf, i, stream)
+              == static_cast<Type>(43));
+    }
+  }
+
+  SECTION("Two buffers, funky size, and return")
+  {
+    DeviceBuf<Type, Device::GPU> buf1{31}, buf2{31}, out_buf{31};
+    buf1.fill(static_cast<Type>(21));
+    buf2.fill(static_cast<Type>(21));
+    out_buf.fill(static_cast<Type>(0));
+    test_launch_vectorized_elementwise_loop_with_immediate<4, 4>(
+        [] H2_GPU_LAMBDA(Type a, Type v1, Type v2) -> Type {
+          return a + v1 + v2;
+        },
+        stream,
+        buf1.size,
+        static_cast<Type>(1),
+        out_buf.buf,
+        static_cast<const Type*>(buf1.buf),
+        static_cast<const Type*>(buf2.buf));
+    for (std::size_t i = 0; i < buf1.size; ++i)
+    {
+      REQUIRE(read_ele<Device::GPU>(buf1.buf, i, stream)
+              == static_cast<Type>(21));
+      REQUIRE(read_ele<Device::GPU>(buf2.buf, i, stream)
+              == static_cast<Type>(21));
       REQUIRE(read_ele<Device::GPU>(out_buf.buf, i, stream)
               == static_cast<Type>(43));
     }

--- a/test/unit_test/tensor/CMakeLists.txt
+++ b/test/unit_test/tensor/CMakeLists.txt
@@ -8,6 +8,7 @@
 target_sources(SeqCatchTests PRIVATE
   unit_test_copy.cpp
   unit_test_dist_utils_nompi.cpp
+  unit_test_fill.cpp
   unit_test_io.cpp
   unit_test_raw_buffer.cpp
   unit_test_strided_memory.cpp
@@ -18,6 +19,7 @@ target_sources(SeqCatchTests PRIVATE
 if (H2_HAS_GPU)
   target_sources(GPUCatchTests PRIVATE
     unit_test_copy.cpp
+    unit_test_fill.cpp
     unit_test_io.cpp
     unit_test_raw_buffer.cpp
     unit_test_strided_memory.cpp

--- a/test/unit_test/tensor/unit_test_fill.cpp
+++ b/test/unit_test/tensor/unit_test_fill.cpp
@@ -1,0 +1,116 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+
+#include "h2/tensor/init/fill.hpp"
+#include "utils.hpp"
+
+
+using namespace h2;
+
+
+TEMPLATE_LIST_TEST_CASE("Zeroing buffers works",
+                        "[tensor][fill]",
+                        AllDevComputeTypePairsList)
+{
+  constexpr Device Dev = meta::tlist::At<TestType, 0>::value;
+  using Type = meta::tlist::At<TestType, 1>;
+  constexpr std::size_t buf_size = 32;
+
+  auto stream = ComputeStream{Dev};
+  DeviceBuf<Type, Dev> buf(buf_size);
+
+  for (std::size_t i = 0; i < buf_size; ++i)
+  {
+    write_ele<Dev>(buf.buf, i, static_cast<Type>(42), stream);
+  }
+
+  REQUIRE_NOTHROW(zero(buf.buf, stream, buf_size));
+
+  for (std::size_t i = 0; i < buf_size; ++i)
+  {
+    REQUIRE(read_ele<Dev>(buf.buf, i, stream) == static_cast<Type>(0));
+  }
+}
+
+TEMPLATE_LIST_TEST_CASE("Zeroing contiguous tensors",
+                        "[tensor][fill]",
+                        AllDevComputeTypePairsList)
+{
+  constexpr Device Dev = meta::tlist::At<TestType, 0>::value;
+  using Type = meta::tlist::At<TestType, 1>;
+  using TensorType = Tensor<Type>;
+
+  TensorType tensor{Dev, {4, 6}, {DT::Sample, DT::Any}};
+
+  for (DataIndexType i = 0; i < tensor.numel(); ++i)
+  {
+    write_ele<Dev>(
+        tensor.data(), i, static_cast<Type>(42), tensor.get_stream());
+  }
+
+  REQUIRE_NOTHROW(zero(tensor));
+
+  for (DataIndexType i = 0; i < tensor.numel(); ++i)
+  {
+    REQUIRE(read_ele<Dev>(tensor.data(), i, tensor.get_stream())
+            == static_cast<Type>(0));
+  }
+}
+
+TEMPLATE_LIST_TEST_CASE("Zeroing contiguous tensors through BaseTensor",
+                        "[tensor][fill]",
+                        AllDevComputeTypePairsList)
+{
+  constexpr Device Dev = meta::tlist::At<TestType, 0>::value;
+  using Type = meta::tlist::At<TestType, 1>;
+  using TensorType = Tensor<Type>;
+
+  TensorType tensor{Dev, {4, 6}, {DT::Sample, DT::Any}};
+  BaseTensor& base_tensor = tensor;
+
+  for (DataIndexType i = 0; i < tensor.numel(); ++i)
+  {
+    write_ele<Dev>(
+        tensor.data(), i, static_cast<Type>(42), tensor.get_stream());
+  }
+
+  REQUIRE_NOTHROW(zero(base_tensor));
+
+  for (DataIndexType i = 0; i < tensor.numel(); ++i)
+  {
+    REQUIRE(read_ele<Dev>(tensor.data(), i, tensor.get_stream())
+            == static_cast<Type>(0));
+  }
+}
+
+TEMPLATE_LIST_TEST_CASE("Filling contiguous tensors",
+                        "[tensor][fill]",
+                        AllDevComputeTypePairsList)
+{
+  constexpr Device Dev = meta::tlist::At<TestType, 0>::value;
+  using Type = meta::tlist::At<TestType, 1>;
+  using TensorType = Tensor<Type>;
+  constexpr Type fill_val = static_cast<Type>(42);
+
+  TensorType tensor{Dev, {4, 6}, {DT::Sample, DT::Any}};
+
+  for (DataIndexType i = 0; i < tensor.numel(); ++i)
+  {
+    write_ele<Dev>(
+        tensor.data(), i, static_cast<Type>(0), tensor.get_stream());
+  }
+
+  REQUIRE_NOTHROW(fill(tensor, fill_val));
+
+  for (DataIndexType i = 0; i < tensor.numel(); ++i)
+  {
+    REQUIRE(read_ele<Dev>(tensor.data(), i, tensor.get_stream()) == fill_val);
+  }
+}


### PR DESCRIPTION
Adds basic infrastructure for n-ary elementwise loops on CPU and GPU (with vectorization and unrolling on the GPU).

The `cast` API is now reimplemented using this.

Adds support for two basic `Tensor` initialization methods: `zero` (which works for any storage type) and `fill` (to fill a compute type with a constant value).

Closes #167.

Note: This still needs some cleanup before merging.