### PR TITLE
Add a generic  definition

### DIFF
--- a/include/h2/utils/IntegerMath.hpp
+++ b/include/h2/utils/IntegerMath.hpp
@@ -46,7 +46,13 @@ namespace h2
 // FIXME (trb 03/16/2023): These should continue migrating elsewhere,
 // perhaps to the meta directory?
 template <typename T>
-struct IntegerTraits;
+struct IntegerTraits
+{
+    using type = T;
+    using signed_type = std::make_signed_t<T>;
+    using unsigned_type = std::make_unsigned_t<T>;
+    static constexpr int nbits = static_cast<int>(sizeof(T) * 8);
+};
 
 template <>
 struct IntegerTraits<int32_t>


### PR DESCRIPTION
On OSX, it seems that
```
int32_t -> int
uint32_t -> unsigned int
int64_t -> long long
uint64_t -> unsigned long long
size_t -> unsigned long
```
So we were missing `IntegerTraits<size_t>`, as it's equivalent to none of those other types. This adds a fall-back implementation.