### PR TITLE
Some cleanup in the metaprogramming bits

### DIFF
--- a/include/h2/meta/CMakeLists.txt
+++ b/include/h2/meta/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+## Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 ## DiHydrogen Project Developers. See the top-level LICENSE file for details.
 ##
 ## SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/Core.hpp
+++ b/include/h2/meta/Core.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/PartialFunctions.hpp
+++ b/include/h2/meta/PartialFunctions.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/TypeList.hpp
+++ b/include/h2/meta/TypeList.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/core/CMakeLists.txt
+++ b/include/h2/meta/core/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+## Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 ## DiHydrogen Project Developers. See the top-level LICENSE file for details.
 ##
 ## SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/core/Eq.hpp
+++ b/include/h2/meta/core/Eq.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/core/IfThenElse.hpp
+++ b/include/h2/meta/core/IfThenElse.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/core/Invocable.hpp
+++ b/include/h2/meta/core/Invocable.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/core/Lazy.hpp
+++ b/include/h2/meta/core/Lazy.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/core/SFINAE.hpp
+++ b/include/h2/meta/core/SFINAE.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/core/ValueAsType.hpp
+++ b/include/h2/meta/core/ValueAsType.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/partial_functions/Apply.hpp
+++ b/include/h2/meta/partial_functions/Apply.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/partial_functions/CMakeLists.txt
+++ b/include/h2/meta/partial_functions/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+## Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 ## DiHydrogen Project Developers. See the top-level LICENSE file for details.
 ##
 ## SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/partial_functions/MakeFunction.hpp
+++ b/include/h2/meta/partial_functions/MakeFunction.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/partial_functions/Placeholders.hpp
+++ b/include/h2/meta/partial_functions/Placeholders.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/typelist/Append.hpp
+++ b/include/h2/meta/typelist/Append.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/typelist/Append.hpp
+++ b/include/h2/meta/typelist/Append.hpp
@@ -5,8 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef H2_META_TYPELIST_APPEND_HPP_
-#define H2_META_TYPELIST_APPEND_HPP_
+#pragma once
 
 #include "TypeList.hpp"
 #include "h2/meta/core/Lazy.hpp"
@@ -51,4 +50,3 @@ struct AppendT<FirstList, OtherLists...>
 } // namespace tlist
 } // namespace meta
 } // namespace h2
-#endif // H2_META_TYPELIST_APPEND_HPP_

--- a/include/h2/meta/typelist/At.hpp
+++ b/include/h2/meta/typelist/At.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/typelist/At.hpp
+++ b/include/h2/meta/typelist/At.hpp
@@ -5,8 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef H2_META_TYPELIST_AT_HPP_
-#define H2_META_TYPELIST_AT_HPP_
+#pragma once
 
 #include "LispAccessors.hpp"
 #include "TypeList.hpp"
@@ -42,4 +41,3 @@ struct AtT : AtT<Cdr<List>, Idx - 1>
 } // namespace tlist
 } // namespace meta
 } // namespace h2
-#endif // H2_META_TYPELIST_AT_HPP_

--- a/include/h2/meta/typelist/CMakeLists.txt
+++ b/include/h2/meta/typelist/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+## Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 ## DiHydrogen Project Developers. See the top-level LICENSE file for details.
 ##
 ## SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/typelist/Expand.hpp
+++ b/include/h2/meta/typelist/Expand.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/typelist/Expand.hpp
+++ b/include/h2/meta/typelist/Expand.hpp
@@ -5,8 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef H2_META_TYPELIST_EXPAND_HPP_
-#define H2_META_TYPELIST_EXPAND_HPP_
+#pragma once
 
 #include "TypeList.hpp"
 #include "h2/meta/core/Lazy.hpp"
@@ -55,4 +54,3 @@ struct ExpandTLT<UnaryT, TL<Ts...>>
 } // namespace tlist
 } // namespace meta
 } // namespace h2
-#endif // H2_META_TYPELIST_EXPAND_HPP_

--- a/include/h2/meta/typelist/Expand.hpp
+++ b/include/h2/meta/typelist/Expand.hpp
@@ -16,22 +16,31 @@ namespace meta
 {
 namespace tlist
 {
-/** @brief Expand a template and parameters into a typelist */
+/** @brief Expand a template and parameters into a typelist.
+ *
+ *  Users should prefer `MapT` for a more relatable name.
+ */
 template <template <typename> class UnaryT, typename... Ts>
 struct ExpandT;
 
-/** @brief Expand a template and parameters into a typelist */
+/** @brief Expand a template and parameters into a typelist.
+ *  Users should prefer `Map` for a more relatable name.
+ */
 template <template <typename> class UnaryT, typename... Ts>
 using Expand = Force<ExpandT<UnaryT, Ts...>>;
 
 /** @brief Expand a template and parameters stored in a typelist into
  *  a typelist.
+ *
+ *  Users should prefer `MapTLT` for a more relatable name.
  */
 template <template <typename> class UnaryT, typename TList>
 struct ExpandTLT;
 
 /** @brief Expand a template and parameters stored in a typelist into
  *  a typelist.
+ *
+ *  Users should prefer `MapTL` for a more relatable name.
  */
 template <template <typename> class UnaryT, typename TList>
 using ExpandTL = Force<ExpandTLT<UnaryT, TList>>;

--- a/include/h2/meta/typelist/Find.hpp
+++ b/include/h2/meta/typelist/Find.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/typelist/Find.hpp
+++ b/include/h2/meta/typelist/Find.hpp
@@ -5,8 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef H2_META_TYPELIST_FIND_HPP_
-#define H2_META_TYPELIST_FIND_HPP_
+#pragma once
 
 #include "LispAccessors.hpp"
 #include "TypeList.hpp"
@@ -61,4 +60,3 @@ public:
 } // namespace tlist
 } // namespace meta
 } // namespace h2
-#endif // H2_META_TYPELIST_FIND_HPP_

--- a/include/h2/meta/typelist/Flatten.hpp
+++ b/include/h2/meta/typelist/Flatten.hpp
@@ -5,8 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef H2_META_TYPELIST_FLATTEN_HPP_
-#define H2_META_TYPELIST_FLATTEN_HPP_
+#pragma once
 
 #include "Append.hpp"
 #include "Map.hpp"
@@ -65,4 +64,3 @@ struct FlattenT
 } // namespace tlist
 } // namespace meta
 } // namespace h2
-#endif // H2_META_TYPELIST_FLATTEN_HPP_

--- a/include/h2/meta/typelist/HaskellAccessors.hpp
+++ b/include/h2/meta/typelist/HaskellAccessors.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/typelist/HaskellAccessors.hpp
+++ b/include/h2/meta/typelist/HaskellAccessors.hpp
@@ -5,8 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef H2_META_TYPELIST_HASKELLACCESSORS_HPP_
-#define H2_META_TYPELIST_HASKELLACCESSORS_HPP_
+#pragma once
 
 #include "TypeList.hpp"
 #include "h2/meta/core/Lazy.hpp"
@@ -134,4 +133,3 @@ struct InitT<Empty>
 } // namespace tlist
 } // namespace meta
 } // namespace h2
-#endif // H2_META_TYPELIST_HASKELLACCESSORS_HPP_

--- a/include/h2/meta/typelist/Length.hpp
+++ b/include/h2/meta/typelist/Length.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/typelist/Length.hpp
+++ b/include/h2/meta/typelist/Length.hpp
@@ -18,11 +18,11 @@ namespace meta
 {
 namespace tlist
 {
-/** @brief Get the index of a given type in the list. */
+/** @brief Get the length of the given typelist. */
 template <typename List>
 struct LengthVT;
 
-/** @brief Get the index of a given type in the list. */
+/** @brief Get the length of the given typelist. */
 template <typename List>
 constexpr unsigned long LengthV()
 {

--- a/include/h2/meta/typelist/Length.hpp
+++ b/include/h2/meta/typelist/Length.hpp
@@ -5,8 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef H2_META_TYPELIST_LENGTH_HPP_
-#define H2_META_TYPELIST_LENGTH_HPP_
+#pragma once
 
 #include "LispAccessors.hpp"
 #include "TypeList.hpp"
@@ -35,19 +34,12 @@ inline constexpr unsigned long Length = LengthV<List>();
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
-// Base case
-template <>
-struct LengthVT<Empty> : ValueAsType<unsigned long, 0>
-{};
-
-// Recursive case
-template <typename T, typename... Ts>
-struct LengthVT<TL<T, Ts...>>
-    : ValueAsType<unsigned long, 1 + LengthV<TL<Ts...>>()>
+template <typename... Ts>
+struct LengthVT<TL<Ts...>>
+    : ValueAsType<unsigned long, sizeof...(Ts)>
 {};
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 } // namespace tlist
 } // namespace meta
 } // namespace h2
-#endif // H2_META_TYPELIST_LENGTH_HPP_

--- a/include/h2/meta/typelist/LispAccessors.hpp
+++ b/include/h2/meta/typelist/LispAccessors.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/typelist/LispAccessors.hpp
+++ b/include/h2/meta/typelist/LispAccessors.hpp
@@ -4,8 +4,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 ////////////////////////////////////////////////////////////////////////////////
-#ifndef H2_META_TYPELIST_LISPACCESSORS_HPP_
-#define H2_META_TYPELIST_LISPACCESSORS_HPP_
+
+#pragma once
 
 #include "TypeList.hpp"
 #include "h2/meta/core/Lazy.hpp"
@@ -180,4 +180,3 @@ struct CdrT<Empty>
 } // namespace tlist
 } // namespace meta
 } // namespace h2
-#endif // H2_META_TYPELIST_LISPACCESSORS_HPP_

--- a/include/h2/meta/typelist/Map.hpp
+++ b/include/h2/meta/typelist/Map.hpp
@@ -15,11 +15,34 @@ namespace meta
 {
 namespace tlist
 {
-/** @brief Alias for Expand. */
+
+/** @brief Return a typelist from applying metafunction to each type.
+ *
+ *  Alias for ExpandT.
+ */
+template <template <typename> class F, typename... Ts>
+using MapT = ExpandT<F, Ts...>;
+
+/** @brief Return a typelist from applying metafunction to each type.
+ *
+ *  Alias for Expand.
+ */
 template <template <typename> class F, typename... Ts>
 using Map = Expand<F, Ts...>;
 
-/** @brief Alias for ExpandTL. */
+/** @brief Return a typelist from applying metafunction to each type
+ *         in the typelist.
+ *
+ *  Alias for ExpandTL.
+ */
+template <template <typename> class F, typename List>
+using MapTLT = ExpandTLT<F, List>;
+
+/** @brief Return a typelist from applying metafunction to each type
+ *         in the typelist.
+ *
+ *  Alias for ExpandTLT.
+ */
 template <template <typename> class F, typename List>
 using MapTL = ExpandTL<F, List>;
 

--- a/include/h2/meta/typelist/Map.hpp
+++ b/include/h2/meta/typelist/Map.hpp
@@ -5,8 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef H2_META_TYPELIST_MAP_HPP_
-#define H2_META_TYPELIST_MAP_HPP_
+#pragma once
 
 #include "Expand.hpp"
 
@@ -27,4 +26,3 @@ using MapTL = ExpandTL<F, List>;
 } // namespace tlist
 } // namespace meta
 } // namespace h2
-#endif // H2_META_TYPELIST_MAP_HPP_

--- a/include/h2/meta/typelist/Member.hpp
+++ b/include/h2/meta/typelist/Member.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/typelist/Member.hpp
+++ b/include/h2/meta/typelist/Member.hpp
@@ -5,8 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef H2_META_TYPELIST_MEMBER_HPP_
-#define H2_META_TYPELIST_MEMBER_HPP_
+#pragma once
 
 #include "TypeList.hpp"
 #include "h2/meta/core/ValueAsType.hpp"
@@ -52,4 +51,3 @@ struct MemberVT<T, TL<Head, Tail...>> : MemberVT<T, TL<Tail...>>
 } // namespace tlist
 } // namespace meta
 } // namespace h2
-#endif // H2_META_TYPELIST_MEMBER_HPP_

--- a/include/h2/meta/typelist/Remove.hpp
+++ b/include/h2/meta/typelist/Remove.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/typelist/Remove.hpp
+++ b/include/h2/meta/typelist/Remove.hpp
@@ -5,8 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef H2_META_TYPELIST_REMOVE_HPP_
-#define H2_META_TYPELIST_REMOVE_HPP_
+#pragma once
 
 #include "LispAccessors.hpp"
 #include "TypeList.hpp"
@@ -50,4 +49,3 @@ struct RemoveT<TypeList<S, Ts...>, T> : ConsT<S, Remove<TypeList<Ts...>, T>>
 } // namespace tlist
 } // namespace meta
 } // namespace h2
-#endif // H2_META_TYPELIST_REMOVE_HPP_

--- a/include/h2/meta/typelist/RemoveAll.hpp
+++ b/include/h2/meta/typelist/RemoveAll.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/typelist/RemoveAll.hpp
+++ b/include/h2/meta/typelist/RemoveAll.hpp
@@ -5,8 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef H2_META_TYPELIST_REMOVEALL_HPP_
-#define H2_META_TYPELIST_REMOVEALL_HPP_
+#pragma once
 
 #include "LispAccessors.hpp"
 #include "TypeList.hpp"
@@ -50,4 +49,3 @@ struct RemoveAllT<TypeList<S, Ts...>, T>
 } // namespace tlist
 } // namespace meta
 } // namespace h2
-#endif // H2_META_TYPELIST_REMOVEALL_HPP_

--- a/include/h2/meta/typelist/Repeat.hpp
+++ b/include/h2/meta/typelist/Repeat.hpp
@@ -1,0 +1,45 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "LispAccessors.hpp"
+#include "TypeList.hpp"
+#include "h2/meta/core/Lazy.hpp"
+
+namespace h2
+{
+namespace meta
+{
+namespace tlist
+{
+
+/** @brief Create a type list with N copies of T */
+template <typename T, unsigned long N>
+struct RepeatT;
+
+/** @brief Create a type list with N copies of T */
+template <typename T, unsigned long N>
+using Repeat = Force<RepeatT<T, N>>;
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+template <typename T>
+struct RepeatT<T, 0UL>
+{
+    using type = Empty;
+};
+
+template <typename T, unsigned long N>
+struct RepeatT
+{
+    using type = Cons<T, Repeat<T, N - 1UL>>;
+};
+
+#endif // DOXYGEN_SHOULD_SKIP_THIS
+} // namespace tlist
+} // namespace meta
+} // namespace h2

--- a/include/h2/meta/typelist/Replace.hpp
+++ b/include/h2/meta/typelist/Replace.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/typelist/Replace.hpp
+++ b/include/h2/meta/typelist/Replace.hpp
@@ -5,8 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef H2_META_TYPELIST_REPLACE_HPP_
-#define H2_META_TYPELIST_REPLACE_HPP_
+#pragma once
 
 #include "LispAccessors.hpp"
 #include "TypeList.hpp"
@@ -55,4 +54,3 @@ struct ReplaceT : ConsT<Car<List>, Replace<Cdr<List>, Old, New>>
 } // namespace tlist
 } // namespace meta
 } // namespace h2
-#endif // H2_META_TYPELIST_REPLACE_HPP_

--- a/include/h2/meta/typelist/ReplaceAll.hpp
+++ b/include/h2/meta/typelist/ReplaceAll.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/typelist/ReplaceAll.hpp
+++ b/include/h2/meta/typelist/ReplaceAll.hpp
@@ -5,8 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef H2_META_TYPELIST_REPLACEALL_HPP_
-#define H2_META_TYPELIST_REPLACEALL_HPP_
+#pragma once
 
 #include "LispAccessors.hpp"
 #include "TypeList.hpp"
@@ -54,4 +53,3 @@ struct ReplaceAllT : ConsT<Car<List>, ReplaceAll<Cdr<List>, Old, New>>
 } // namespace tlist
 } // namespace meta
 } // namespace h2
-#endif // H2_META_TYPELIST_REPLACEALL_HPP_

--- a/include/h2/meta/typelist/Reverse.hpp
+++ b/include/h2/meta/typelist/Reverse.hpp
@@ -1,0 +1,58 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "LispAccessors.hpp"
+#include "TypeList.hpp"
+#include "h2/meta/core/Lazy.hpp"
+
+namespace h2
+{
+namespace meta
+{
+namespace tlist
+{
+/** @brief Reverse a typelist. */
+template <typename List>
+struct ReverseT;
+
+/** @brief Reverse a typelist. */
+template <typename List>
+using Reverse = Force<ReverseT<List>>;
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+namespace internal
+{
+template <typename L, typename RL>
+struct ReverseImpl;
+
+template <typename RL>
+struct ReverseImpl<Empty, RL>
+{
+    using type = RL;
+};
+
+template <typename T, typename... Ts, typename RL>
+struct ReverseImpl<TL<T, Ts...>, RL>
+{
+    using type = Force<ReverseImpl<TL<Ts...>, Cons<T, RL>>>;
+};
+
+} // namespace internal
+
+template <typename List>
+struct ReverseT
+{
+    using type = Force<internal::ReverseImpl<List, Empty>>;
+};
+
+#endif // DOXYGEN_SHOULD_SKIP_THIS
+} // namespace tlist
+} // namespace meta
+} // namespace h2

--- a/include/h2/meta/typelist/Select.hpp
+++ b/include/h2/meta/typelist/Select.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/typelist/Select.hpp
+++ b/include/h2/meta/typelist/Select.hpp
@@ -5,8 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef H2_META_TYPELIST_SELECT_HPP_
-#define H2_META_TYPELIST_SELECT_HPP_
+#pragma once
 
 #include "TypeList.hpp"
 #include "h2/meta/core/IfThenElse.hpp"
@@ -46,4 +45,3 @@ struct SelectT<TL<T, Ts...>, Predicate>
 } // namespace tlist
 } // namespace meta
 } // namespace h2
-#endif // H2_META_TYPELIST_SELECT_HPP_

--- a/include/h2/meta/typelist/SelectAll.hpp
+++ b/include/h2/meta/typelist/SelectAll.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/typelist/SelectAll.hpp
+++ b/include/h2/meta/typelist/SelectAll.hpp
@@ -5,8 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef H2_META_TYPELIST_SELECT_HPP_
-#define H2_META_TYPELIST_SELECT_HPP_
+#pragma once
 
 #include "LispAccessors.hpp"
 #include "TypeList.hpp"
@@ -52,4 +51,3 @@ public:
 } // namespace tlist
 } // namespace meta
 } // namespace h2
-#endif // H2_META_TYPELIST_SELECT_HPP_

--- a/include/h2/meta/typelist/Size.hpp
+++ b/include/h2/meta/typelist/Size.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/typelist/Size.hpp
+++ b/include/h2/meta/typelist/Size.hpp
@@ -5,8 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef H2_META_TYPELIST_SIZE_HPP_
-#define H2_META_TYPELIST_SIZE_HPP_
+#pragma once
 
 #include "Length.hpp"
 
@@ -33,4 +32,3 @@ inline constexpr unsigned long Size = SizeV<List>();
 } // namespace tlist
 } // namespace meta
 } // namespace h2
-#endif // H2_META_TYPELIST_SIZE_HPP_

--- a/include/h2/meta/typelist/Size.hpp
+++ b/include/h2/meta/typelist/Size.hpp
@@ -19,7 +19,7 @@ namespace tlist
 template <typename List>
 using SizeVT = LengthVT<List>;
 
-/** @brief Get the index of a given type in the list. */
+/** @brief Get the length of the given typelist. */
 template <typename List>
 constexpr unsigned long SizeV()
 {

--- a/include/h2/meta/typelist/Sort.hpp
+++ b/include/h2/meta/typelist/Sort.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/typelist/Sort.hpp
+++ b/include/h2/meta/typelist/Sort.hpp
@@ -5,8 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef H2_META_TYPELIST_SORT_HPP_
-#define H2_META_TYPELIST_SORT_HPP_
+#pragma once
 
 #include "LispAccessors.hpp"
 #include "TypeList.hpp"
@@ -88,4 +87,3 @@ struct SortT<TL<Head, Tail...>, Compare>
 } // namespace tlist
 } // namespace meta
 } // namespace h2
-#endif // H2_META_TYPELIST_SORT_HPP_

--- a/include/h2/meta/typelist/ToFromTuple.hpp
+++ b/include/h2/meta/typelist/ToFromTuple.hpp
@@ -1,0 +1,53 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "TypeList.hpp"
+#include "h2/meta/core/Lazy.hpp"
+
+namespace h2
+{
+namespace meta
+{
+namespace tlist
+{
+
+/** @brief Produce a tuple from a TypeList */
+template <typename List>
+struct ToTupleT;
+
+/** @brief Produce a tuple from a TypeList */
+template <typename List>
+using ToTuple = Force<ToTupleT<List>>;
+
+/** @brief Produce a TypeList from a tuple */
+template <typename Tup>
+struct FromTupleT;
+
+/** @brief Produce a TypeList from a tuple */
+template <typename Tup>
+using FromTuple = Force<FromTupleT<Tup>>;
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+template <typename... Ts>
+struct ToTupleT<TL<Ts...>>
+{
+    using type = std::tuple<Ts...>;
+};
+
+template <typename... Ts>
+struct FromTupleT<std::tuple<Ts...>>
+{
+    using type = TL<Ts...>;
+};
+
+#endif // DOXYGEN_SHOULD_SKIP_THIS
+} // namespace tlist
+} // namespace meta
+} // namespace h2

--- a/include/h2/meta/typelist/TypeList.hpp
+++ b/include/h2/meta/typelist/TypeList.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/typelist/TypeList.hpp
+++ b/include/h2/meta/typelist/TypeList.hpp
@@ -5,8 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef H2_META_TYPELIST_TYPELIST_HPP_
-#define H2_META_TYPELIST_TYPELIST_HPP_
+#pragma once
 
 #include "h2/meta/core/ValueAsType.hpp"
 
@@ -65,4 +64,3 @@ struct TypeList<> : FalseType
 
 } // namespace meta
 } // namespace h2
-#endif // H2_META_TYPELIST_TYPELIST_HPP_

--- a/include/h2/meta/typelist/Unique.hpp
+++ b/include/h2/meta/typelist/Unique.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/include/h2/meta/typelist/Unique.hpp
+++ b/include/h2/meta/typelist/Unique.hpp
@@ -5,8 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef H2_META_TYPELIST_UNIQUE_HPP_
-#define H2_META_TYPELIST_UNIQUE_HPP_
+#pragma once
 
 #include "LispAccessors.hpp"
 #include "Remove.hpp"
@@ -53,4 +52,3 @@ public:
 } // namespace tlist
 } // namespace meta
 } // namespace h2
-#endif // H2_META_TYPELIST_UNIQUE_HPP_

--- a/include/h2/meta/typelist/print.hpp
+++ b/include/h2/meta/typelist/print.hpp
@@ -10,7 +10,6 @@
 #include "TypeList.hpp"
 #include "h2/utils/typename.hpp"
 
-
 namespace h2
 {
 namespace meta

--- a/test/static_test/CMakeLists.txt
+++ b/test/static_test/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+## Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 ## DiHydrogen Project Developers. See the top-level LICENSE file for details.
 ##
 ## SPDX-License-Identifier: Apache-2.0

--- a/test/static_test/core/CMakeLists.txt
+++ b/test/static_test/core/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+## Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 ## DiHydrogen Project Developers. See the top-level LICENSE file for details.
 ##
 ## SPDX-License-Identifier: Apache-2.0

--- a/test/static_test/meta/CMakeLists.txt
+++ b/test/static_test/meta/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+## Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 ## DiHydrogen Project Developers. See the top-level LICENSE file for details.
 ##
 ## SPDX-License-Identifier: Apache-2.0

--- a/test/static_test/meta/core/CMakeLists.txt
+++ b/test/static_test/meta/core/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+## Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 ## DiHydrogen Project Developers. See the top-level LICENSE file for details.
 ##
 ## SPDX-License-Identifier: Apache-2.0

--- a/test/static_test/meta/core/static_test_eq.cpp
+++ b/test/static_test/meta/core/static_test_eq.cpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/test/static_test/meta/core/static_test_ifthenelse.cpp
+++ b/test/static_test/meta/core/static_test_ifthenelse.cpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/test/static_test/meta/core/static_test_invocable.cpp
+++ b/test/static_test/meta/core/static_test_invocable.cpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/test/static_test/meta/core/static_test_lazy.cpp
+++ b/test/static_test/meta/core/static_test_lazy.cpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/test/static_test/meta/core/static_test_sfinae.cpp
+++ b/test/static_test/meta/core/static_test_sfinae.cpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/test/static_test/meta/core/static_test_value_as_type.cpp
+++ b/test/static_test/meta/core/static_test_value_as_type.cpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/test/static_test/meta/partial_functions/CMakeLists.txt
+++ b/test/static_test/meta/partial_functions/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+## Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 ## DiHydrogen Project Developers. See the top-level LICENSE file for details.
 ##
 ## SPDX-License-Identifier: Apache-2.0

--- a/test/static_test/meta/partial_functions/static_test_apply.cpp
+++ b/test/static_test/meta/partial_functions/static_test_apply.cpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/test/static_test/meta/partial_functions/static_test_make_function.cpp
+++ b/test/static_test/meta/partial_functions/static_test_make_function.cpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/test/static_test/meta/partial_functions/static_test_placeholders.cpp
+++ b/test/static_test/meta/partial_functions/static_test_placeholders.cpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/test/static_test/meta/static_test_core.cpp
+++ b/test/static_test/meta/static_test_core.cpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/test/static_test/meta/typelist/CMakeLists.txt
+++ b/test/static_test/meta/typelist/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+## Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 ## DiHydrogen Project Developers. See the top-level LICENSE file for details.
 ##
 ## SPDX-License-Identifier: Apache-2.0

--- a/test/static_test/meta/typelist/CMakeLists.txt
+++ b/test/static_test/meta/typelist/CMakeLists.txt
@@ -26,6 +26,7 @@ target_sources(StaticTest
   static_test_select.cpp
   static_test_selectall.cpp
   static_test_sort.cpp
+  static_test_tofromtuple.cpp
   static_test_unique.cpp
   static_test_zip.cpp
   )

--- a/test/static_test/meta/typelist/CMakeLists.txt
+++ b/test/static_test/meta/typelist/CMakeLists.txt
@@ -19,8 +19,10 @@ target_sources(StaticTest
   static_test_reduce.cpp
   static_test_remove.cpp
   static_test_removeall.cpp
+  static_test_repeat.cpp
   static_test_replace.cpp
   static_test_replaceall.cpp
+  static_test_reverse.cpp
   static_test_select.cpp
   static_test_selectall.cpp
   static_test_sort.cpp

--- a/test/static_test/meta/typelist/static_test_accessors.cpp
+++ b/test/static_test/meta/typelist/static_test_accessors.cpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/test/static_test/meta/typelist/static_test_append.cpp
+++ b/test/static_test/meta/typelist/static_test_append.cpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/test/static_test/meta/typelist/static_test_at.cpp
+++ b/test/static_test/meta/typelist/static_test_at.cpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/test/static_test/meta/typelist/static_test_find.cpp
+++ b/test/static_test/meta/typelist/static_test_find.cpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/test/static_test/meta/typelist/static_test_length.cpp
+++ b/test/static_test/meta/typelist/static_test_length.cpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/test/static_test/meta/typelist/static_test_member.cpp
+++ b/test/static_test/meta/typelist/static_test_member.cpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/test/static_test/meta/typelist/static_test_remove.cpp
+++ b/test/static_test/meta/typelist/static_test_remove.cpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/test/static_test/meta/typelist/static_test_removeall.cpp
+++ b/test/static_test/meta/typelist/static_test_removeall.cpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/test/static_test/meta/typelist/static_test_repeat.cpp
+++ b/test/static_test/meta/typelist/static_test_repeat.cpp
@@ -1,0 +1,19 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#include "h2/meta/Core.hpp"
+#include "h2/meta/typelist/Repeat.hpp"
+
+using namespace h2::meta;
+
+static_assert(
+    Eq<tlist::Repeat<int, 0>, tlist::Empty>,
+    "Repeating zero times gives an empty list.");
+
+static_assert(
+    Eq<tlist::Repeat<int, 3>, TL<int, int, int>>,
+    "Repeating a nonzero times gives the correct type list.");

--- a/test/static_test/meta/typelist/static_test_replace.cpp
+++ b/test/static_test/meta/typelist/static_test_replace.cpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/test/static_test/meta/typelist/static_test_replaceall.cpp
+++ b/test/static_test/meta/typelist/static_test_replaceall.cpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/test/static_test/meta/typelist/static_test_reverse.cpp
+++ b/test/static_test/meta/typelist/static_test_reverse.cpp
@@ -1,0 +1,23 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#include "h2/meta/Core.hpp"
+#include "h2/meta/typelist/Reverse.hpp"
+
+using namespace h2::meta;
+
+static_assert(
+    Eq<tlist::Reverse<tlist::Empty>, tlist::Empty>,
+    "Reversing an empty tlist is valid and returns an empty tlist.");
+
+static_assert(
+    Eq<tlist::Reverse<TL<int>>, TL<int>>,
+    "Reversing a single-element list returns a single-element list.");
+
+static_assert(
+    Eq<tlist::Reverse<TL<char, short, int, long>>, TL<long, int, short, char>>,
+    "Reversing a nontrivial list returns the reversed list.");

--- a/test/static_test/meta/typelist/static_test_select.cpp
+++ b/test/static_test/meta/typelist/static_test_select.cpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/test/static_test/meta/typelist/static_test_selectall.cpp
+++ b/test/static_test/meta/typelist/static_test_selectall.cpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/test/static_test/meta/typelist/static_test_sort.cpp
+++ b/test/static_test/meta/typelist/static_test_sort.cpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/test/static_test/meta/typelist/static_test_tofromtuple.cpp
+++ b/test/static_test/meta/typelist/static_test_tofromtuple.cpp
@@ -1,0 +1,27 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
+// DiHydrogen Project Developers. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+////////////////////////////////////////////////////////////////////////////////
+
+#include "h2/meta/Core.hpp"
+#include "h2/meta/typelist/ToFromTuple.hpp"
+
+using namespace h2::meta;
+
+static_assert(
+    Eq<tlist::ToTuple<tlist::Empty>, std::tuple<>>,
+    "Empty typelist gives empty tuple.");
+
+static_assert(
+    Eq<tlist::FromTuple<std::tuple<>>, tlist::Empty>,
+    "Empty tuple gives empty typelist.");
+
+static_assert(
+    Eq<tlist::ToTuple<TL<char, short, int>>, std::tuple<char, short, int>>,
+    "Nontrivial typelist gives nontrivial tuple.");
+
+static_assert(
+    Eq<tlist::FromTuple<std::tuple<int, float, double>>, TL<int, float, double>>,
+    "Nontrivial tuple gives nontrivial typelist.");

--- a/test/static_test/meta/typelist/static_test_unique.cpp
+++ b/test/static_test/meta/typelist/static_test_unique.cpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+// Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 // DiHydrogen Project Developers. See the top-level LICENSE file for details.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/test/static_test/tensor/CMakeLists.txt
+++ b/test/static_test/tensor/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+## Copyright 2019-2024 Lawrence Livermore National Security, LLC and other
 ## DiHydrogen Project Developers. See the top-level LICENSE file for details.
 ##
 ## SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
This tidies up the copyrights, include guards, and documentation in the metaprogramming library (and associated static_tests).

This also adds `Repeat`, `Reverse`, `ToTuple`, and `FromTuple` metafunctions.