### PR TITLE
Adjust corona CI to target CPU builds

### DIFF
--- a/.gitlab/build-and-test-corona.yml
+++ b/.gitlab/build-and-test-corona.yml
@@ -22,28 +22,29 @@ include:
 # Note: There are issues with /usr/tce/bin/python3 (the default) and
 # build systems (in particular, it's not clear that all the
 # includes/libs are setup properly under the "/usr/tce" prefix). So I
-# load a module to get a real prefix. This only matters when
-# "+ci+coverage".
-
+# load a module to get a real prefix.
 rocm-6-0-2-corona:
   variables:
     COMPILER_FAMILY: amdclang
-    MODULES: "gcc/10.3.1-magic openmpi/4.1.2 rocm/6.0.2 python"
+    MODULES: "gcc/10.3.1-magic mvapich2/2.3.7 rocm/6.0.2 python"
   extends: [.build-and-test-on-corona, .build-and-test]
 
-rocm-6-0-2-distconv-corona:
+gcc-12-1-1-cpu-corona:
   variables:
-    COMPILER_FAMILY: amdclang
-    MODULES: "gcc/10.3.1-magic openmpi/4.1.2 rocm/6.0.2 python"
-    WITH_DISTCONV: "1"
+    COMPILER_FAMILY: gnu
+    MODULES: "gcc/12.1.1-magic mvapich2/2.3.7 python"
   extends: [.build-and-test-on-corona, .build-and-test]
-  rules:
-    - if: $TEST_DISTCONV_BUILD == "1"
 
-rocm-6-0-2-coverage-corona:
+clang-14-0-6-cpu-corona:
   variables:
-    COMPILER_FAMILY: amdclang
-    MODULES: "gcc/10.3.1-magic mvapich2 rocm/6.0.2 python"
+    COMPILER_FAMILY: clang
+    MODULES: "clang/14.0.6-magic mvapich2/2.3.7 python"
+  extends: [.build-and-test-on-corona, .build-and-test]
+
+gcc-11-2-1-coverage-cpu-corona:
+  variables:
+    COMPILER_FAMILY: gnu
+    MODULES: "gcc/11.2.1-magic mvapich2/2.3.7 python"
     WITH_COVERAGE: "1"
   extends: [.build-and-test-on-corona, .build-and-test-coverage]
 

--- a/.gitlab/configure_deps.sh
+++ b/.gitlab/configure_deps.sh
@@ -5,6 +5,13 @@ else
     lapack_opt=""
 fi
 
+if [[ -n "${gpu_arch}" ]]
+then
+    with_nccl=ON
+else
+    with_nccl=OFF
+fi
+
 cmake \
     -G Ninja \
     -S ${lbann_sb_dir} \
@@ -47,7 +54,7 @@ cmake \
     -D LBANN_SB_BUILD_spdlog=ON  \
     \
     -D LBANN_SB_BUILD_Aluminum=ON \
-    -D LBANN_SB_FWD_Aluminum_ALUMINUM_ENABLE_NCCL=ON \
+    -D LBANN_SB_FWD_Aluminum_ALUMINUM_ENABLE_NCCL=${with_nccl} \
     -D LBANN_SB_FWD_Aluminum_ALUMINUM_ENABLE_HWLOC=OFF \
     -D LBANN_SB_FWD_Aluminum_ALUMINUM_ENABLE_TESTS=OFF \
     -D LBANN_SB_FWD_Aluminum_ALUMINUM_ENABLE_BENCHMARKS=OFF \

--- a/.gitlab/setup_env.sh
+++ b/.gitlab/setup_env.sh
@@ -72,9 +72,13 @@ case "${cluster}" in
         launcher=flux
         ;;
     corona)
-        extra_rpaths="${ROCM_PATH}/lib:${extra_rpaths}"
-        rocm_platform=ON
-	gpu_arch=gfx906
+        # Only turn on GPU stuff if ROCm module has been loaded, which
+        # is checked by testing for ROCM_PATH.
+        extra_rpaths=${ROCM_PATH:+${ROCM_PATH}/lib:${extra_rpaths}}
+	gpu_arch=${ROCM_PATH:+gfx906}
+        if [[ -n "${gpu_arch}" ]]; then
+            rocm_platform=ON
+        fi
         launcher=flux
         ;;
     *)

--- a/cmake/modules/H2CXXCodeCoverage.cmake
+++ b/cmake/modules/H2CXXCodeCoverage.cmake
@@ -289,6 +289,11 @@ GCOV_PREFIX=\$\{_prefix\} GCOV_PREFIX_STRIP=${_build_dir_len} $@
         endif ()
       endif ()
 
+      set(_seq_progs "$<TARGET_FILE:SeqCatchTests>")
+      if (TARGET GPUCatchTests)
+        list(APPEND _seq_progs "$<TARGET_FILE:GPUCatchTests>")
+      endif ()
+
       add_custom_target(
         ${_tltgt}-gen-lcov
         COMMAND
@@ -300,7 +305,7 @@ GCOV_PREFIX=\$\{_prefix\} GCOV_PREFIX_STRIP=${_build_dir_len} $@
         -D MPI_LAUNCH_PATTERN="${_mpi_pattern}"
         -D LCOV_PROGRAM=${LCOV_PROGRAM}
         -D GCOV_PROGRAM=${GCOV_PROGRAM}
-        -D SEQ_COVERAGE_PROGRAMS=$<TARGET_FILE:SeqCatchTests>;$<TARGET_FILE:GPUCatchTests>
+        -D SEQ_COVERAGE_PROGRAMS=${_seq_progs}
         -D MPI_COVERAGE_PROGRAMS="${CMAKE_BINARY_DIR}/bin/MPICatchTests -r mpicumulative"
         -P "${CMAKE_SOURCE_DIR}/cmake/modules/H2RunCoverage.cmake"
         COMMENT "Generating coverage data for coverage target \"${_tltgt}\""


### PR DESCRIPTION
Removes DistConv build on Corona as the GPUs are not supported in all necessary ROCm packages (for now, the vanilla H2 build seems ok). Adds GCC and Clang CPU builds. Also changes the coverage target to use a CPU build.