### PR TITLE
Support for building dependencies internally

### DIFF
--- a/.gitlab/build-and-test-corona.yml
+++ b/.gitlab/build-and-test-corona.yml
@@ -26,25 +26,25 @@ include:
 rocm-6-0-2-corona:
   variables:
     COMPILER_FAMILY: amdclang
-    MODULES: "gcc/10.3.1-magic mvapich2/2.3.7 rocm/6.0.2 python"
+    MODULES: "gcc/10.3.1-magic mvapich2/2.3.7 rocm/6.0.2 cmake/3.26.3 python"
   extends: [.build-and-test-on-corona, .build-and-test]
 
 gcc-12-1-1-cpu-corona:
   variables:
     COMPILER_FAMILY: gnu
-    MODULES: "gcc/12.1.1-magic mvapich2/2.3.7 python"
+    MODULES: "gcc/12.1.1-magic mvapich2/2.3.7 cmake/3.26.3 python"
   extends: [.build-and-test-on-corona, .build-and-test]
 
 clang-14-0-6-cpu-corona:
   variables:
     COMPILER_FAMILY: clang
-    MODULES: "clang/14.0.6-magic mvapich2/2.3.7 python"
+    MODULES: "clang/14.0.6-magic mvapich2/2.3.7 cmake/3.26.3 python"
   extends: [.build-and-test-on-corona, .build-and-test]
 
 gcc-11-2-1-coverage-cpu-corona:
   variables:
     COMPILER_FAMILY: gnu
-    MODULES: "gcc/11.2.1-magic mvapich2/2.3.7 python"
+    MODULES: "gcc/11.2.1-magic mvapich2/2.3.7 cmake/3.26.3 python"
     WITH_COVERAGE: "1"
   extends: [.build-and-test-on-corona, .build-and-test-coverage]
 

--- a/.gitlab/build-and-test-tioga.yml
+++ b/.gitlab/build-and-test-tioga.yml
@@ -19,13 +19,13 @@ include:
 rocm-6-2-1-tioga:
   variables:
     COMPILER_FAMILY: amdclang
-    MODULES: "PrgEnv-cray rocm/6.2.1 cray-mpich cray-libsci"
+    MODULES: "PrgEnv-cray rocm/6.2.1 cmake/3.29.2 cray-mpich cray-libsci"
   extends: .build-and-test-on-tioga
 
 rocm-6-2-1-distconv-tioga:
   variables:
     COMPILER_FAMILY: amdclang
-    MODULES: "PrgEnv-cray rocm/6.2.1 cray-mpich cray-libsci"
+    MODULES: "PrgEnv-cray rocm/6.2.1 cmake/3.29.2 cray-mpich cray-libsci"
     WITH_DISTCONV: "1"
   extends: .build-and-test-on-tioga
   rules:

--- a/.gitlab/build-and-test.sh
+++ b/.gitlab/build-and-test.sh
@@ -71,7 +71,7 @@ echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 prefix="${project_dir}/install-deps-${CI_JOB_NAME_SLUG:-${job_unique_id}}"
 
 # Just for good measure...
-export CMAKE_PREFIX_PATH=${prefix}/aluminum:${prefix}/catch2:${prefix}/hwloc:${prefix}/hydrogen:${prefix}/nccl:${prefix}/spdlog:${CMAKE_PREFIX_PATH}
+export CMAKE_PREFIX_PATH=${prefix}/hwloc:${prefix}/nccl:${CMAKE_PREFIX_PATH}
 
 # Allow a user to force this
 rebuild_deps=${REBUILD_DEPS:-""}
@@ -82,29 +82,9 @@ then
     rebuild_deps=1
 fi
 
-# Rebuild if latest hashes don't match
-if [[ -z "${rebuild_deps}" ]]
+if [[ -z "${gpu_arch}" ]]
 then
-    function fetch-sha {
-        # $1 is the LLNL package name (e.g., 'aluminum')
-        # $2 is the branch name (e.g., 'master')
-        curl -s -H "Accept: application/vnd.github.VERSION.sha" \
-             "https://api.github.com/repos/llnl/$1/commits/$2"
-    }
-
-    al_head=$(fetch-sha aluminum master)
-    al_prebuilt="<not found>"
-    if [[ -f "${prefix}/al-prebuilt-hash.txt" ]]
-    then
-        al_prebuilt=$(cat ${prefix}/al-prebuilt-hash.txt)
-    fi
-
-    if [[ "${al_head}" != "${al_prebuilt}" ]]
-    then
-        echo "Prebuilt Aluminum hash does not match latest head; rebuilding."
-        echo "  (prebuilt: ${al_prebuilt}; head: ${al_head})"
-        rebuild_deps=1
-    fi
+    rebuild_deps=""
 fi
 
 if [[ -n "${rebuild_deps}" ]]

--- a/.gitlab/configure_deps.sh
+++ b/.gitlab/configure_deps.sh
@@ -1,15 +1,7 @@
-if [[ "$cluster" == "lassen" ]]
-then
-    lapack_opt="-D LBANN_SB_FWD_Hydrogen_BLA_VENDOR=Generic"
-else
-    lapack_opt=""
-fi
-
+with_nccl=OFF
 if [[ -n "${gpu_arch}" ]]
 then
     with_nccl=ON
-else
-    with_nccl=OFF
 fi
 
 cmake \
@@ -46,16 +38,5 @@ cmake \
     -D LBANN_SB_DEFAULT_CUDA_OPTS=${cuda_platform} \
     -D LBANN_SB_DEFAULT_ROCM_OPTS=${rocm_platform} \
     \
-    -D LBANN_SB_BUILD_Catch2=ON \
-    -D LBANN_SB_Catch2_TAG="devel" \
-    \
     -D LBANN_SB_BUILD_hwloc=${rocm_platform} \
-    -D LBANN_SB_BUILD_NCCL=${cuda_platform} \
-    -D LBANN_SB_BUILD_spdlog=ON  \
-    \
-    -D LBANN_SB_BUILD_Aluminum=ON \
-    -D LBANN_SB_FWD_Aluminum_ALUMINUM_ENABLE_NCCL=${with_nccl} \
-    -D LBANN_SB_FWD_Aluminum_ALUMINUM_ENABLE_HWLOC=OFF \
-    -D LBANN_SB_FWD_Aluminum_ALUMINUM_ENABLE_TESTS=OFF \
-    -D LBANN_SB_FWD_Aluminum_ALUMINUM_ENABLE_BENCHMARKS=OFF \
-    -D LBANN_SB_FWD_Aluminum_ALUMINUM_ENABLE_THREAD_MULTIPLE=OFF
+    -D LBANN_SB_BUILD_NCCL=${cuda_platform}

--- a/.gitlab/configure_h2.sh
+++ b/.gitlab/configure_h2.sh
@@ -1,8 +1,7 @@
-if [[ "$cluster" == "lassen" ]]
+with_nccl=OFF
+if [[ -n "${gpu_arch}" ]]
 then
-    lapack_opt="-D BLA_VENDOR=Generic"
-else
-    lapack_opt=""
+    with_nccl=ON
 fi
 
 cmake -G Ninja \
@@ -23,8 +22,13 @@ cmake -G Ninja \
       -D AMDGPU_TARGETS=${gpu_arch} \
       -D GPU_TARGETS=${gpu_arch} \
       \
-      ${lapack_opt} \
       -D H2_CI_BUILD=${run_coverage:-OFF} \
       -D H2_DEVELOPER_BUILD=ON \
       -D H2_ENABLE_CODE_COVERAGE=${run_coverage:-OFF} \
-      -D H2_ENABLE_DISTCONV_LEGACY=${build_distconv:-OFF}
+      -D H2_ENABLE_DISTCONV_LEGACY=${build_distconv:-OFF} \
+      \
+      -D ALUMINUM_ENABLE_NCCL=${with_nccl} \
+      -D ALUMINUM_ENABLE_HWLOC=OFF \
+      -D ALUMINUM_ENABLE_TESTS=OFF \
+      -D ALUMINUM_ENABLE_BENCHMARKS=OFF \
+      -D ALUMINUM_ENABLE_THREAD_MULTIPLE=OFF

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,7 @@ FetchContent_Declare(
   Aluminum
   GIT_REPOSITORY https://github.com/LLNL/Aluminum.git
   GIT_TAG 672bbb782dccf41e3db99d58ddbd2ad0de7e266a # 'master' at 23 Oct 2024
+  GIT_SHALLOW 1
   FIND_PACKAGE_ARGS 1.0.0 CONFIG
 )
 
@@ -209,6 +210,7 @@ FetchContent_Declare(
   spdlog
   GIT_REPOSITORY https://github.com/gabime/spdlog.git
   GIT_TAG 27cb4c76708608465c413f6d0e6b8d99a4d84302 # v1.14.1
+  GIT_SHALLOW 1
   FIND_PACKAGE_ARGS CONFIG
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,8 @@
 ## SPDX-License-Identifier: Apache-2.0
 ################################################################################
 
-cmake_minimum_required(VERSION 3.21.0)
-cmake_policy(VERSION 3.21.0)
+cmake_minimum_required(VERSION 3.25.0)
+cmake_policy(VERSION 3.25.0)
 
 project(DiHydrogen
   VERSION 0.4.0
@@ -187,13 +187,42 @@ if (H2_ENABLE_CODE_COVERAGE)
 endif ()
 
 # Required dependencies
+include(FetchContent)
 
-# Do we strictly need 1.0.0 for anything? No. Is it worthwhile to
-# backport to 0.7? Stronger no.
-find_package(Aluminum 1.0.0 CONFIG REQUIRED)
+macro(report_dep PKG)
+  if (${PKG}_FOUND)
+    message(STATUS "Found ${PKG}: ${${PKG}_DIR}")
+    message(STATUS "${PKG} version: ${${PKG}_VERSION}")
+  else ()
+    message(STATUS "Building ${PKG} with FetchContent")
+  endif ()
+endmacro()
+
+FetchContent_Declare(
+  Aluminum
+  GIT_REPOSITORY https://github.com/LLNL/Aluminum.git
+  GIT_TAG 672bbb782dccf41e3db99d58ddbd2ad0de7e266a # 'master' at 23 Oct 2024
+  FIND_PACKAGE_ARGS 1.0.0 CONFIG
+)
+FetchContent_Declare(
+  spdlog
+  GIT_REPOSITORY https://github.com/gabime/spdlog.git
+  GIT_TAG 27cb4c76708608465c413f6d0e6b8d99a4d84302 # v1.14.1
+  FIND_PACKAGE_ARGS CONFIG
+)
+
+set(SPDLOG_INSTALL ON CACHE BOOL "Install spdlog" FORCE)
+
+# Make sure the fetchable dependencies are available.
+FetchContent_MakeAvailable(Aluminum spdlog)
+report_dep(Aluminum)
+report_dep(spdlog)
+
+# FIXME: spdlog is now required and thus this is always true. We
+#        should remove the clutter.
+set(H2_HAS_SPDLOG TRUE)
 
 if (H2_ENABLE_CUDA)
-
   enable_language(CUDA)
   include(SetupCUDAToolkit)
   if (CMAKE_CUDA_COMPILER)
@@ -211,9 +240,6 @@ if (H2_ENABLE_CUDA)
 
   set(CMAKE_CUDA_FLAGS "--expt-relaxed-constexpr ${CMAKE_CUDA_FLAGS}")
 endif (H2_ENABLE_CUDA)
-
-find_package(spdlog CONFIG REQUIRED)
-set(H2_HAS_SPDLOG TRUE)
 
 # This is a placeholder.
 if (H2_ENABLE_ROCM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,7 @@ FetchContent_Declare(
   GIT_TAG 672bbb782dccf41e3db99d58ddbd2ad0de7e266a # 'master' at 23 Oct 2024
   FIND_PACKAGE_ARGS 1.0.0 CONFIG
 )
+
 FetchContent_Declare(
   spdlog
   GIT_REPOSITORY https://github.com/gabime/spdlog.git
@@ -211,16 +212,21 @@ FetchContent_Declare(
   FIND_PACKAGE_ARGS CONFIG
 )
 
-set(SPDLOG_INSTALL ON CACHE BOOL "Install spdlog" FORCE)
+# Forward CUDA/ROCm-ness upstream. Users are still responsible for
+# explicitly enabling backends/other configuration options. Note that
+# the relevant CMAKE_* variables should all be inherited "for free".
+set(ALUMINUM_ENABLE_CUDA "${H2_ENABLE_CUDA}"
+  CACHE INTERNAL "Enable CUDA support in Aluminum")
+set(ALUMINUM_ENABLE_ROCM "${H2_ENABLE_ROCM}"
+  CACHE INTERNAL "Enable ROCm support in Aluminum")
+
+# Ensure the "spdlog" target gets exported.
+set(SPDLOG_INSTALL ON CACHE INTERNAL "Install spdlog")
 
 # Make sure the fetchable dependencies are available.
 FetchContent_MakeAvailable(Aluminum spdlog)
 report_dep(Aluminum)
 report_dep(spdlog)
-
-# FIXME: spdlog is now required and thus this is always true. We
-#        should remove the clutter.
-set(H2_HAS_SPDLOG TRUE)
 
 if (H2_ENABLE_CUDA)
   enable_language(CUDA)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,12 +69,6 @@ if (H2_ENABLE_DISTCONV_LEGACY)
     message(FATAL_ERROR "Must enable one of CUDA and ROCm with DistConv.")
   endif ()
 
-  # These might become full-fledged options later, but I hope
-  # not. Aluminum should just be the communication interface that H2
-  # uses across the board.
-  set(H2_ENABLE_ALUMINUM ${H2_ENABLE_DISTCONV_LEGACY}
-    CACHE BOOL "Use the Aluminum library for communications.")
-
   set(H2_ENABLE_OPENMP ${H2_ENABLE_DISTCONV_LEGACY}
     CACHE BOOL "Enable CPU acceleration with OpenMP threads.")
 endif ()
@@ -302,33 +296,6 @@ if (H2_ENABLE_DISTCONV_LEGACY)
       INTERFACE_COMPILE_OPTIONS
       $<$<COMPILE_LANGUAGE:CXX>:${__mpi_compile_options}>)
     unset(__mpi_compile_options)
-  endif ()
-endif ()
-
-if (H2_ENABLE_ALUMINUM)
-  find_package(Aluminum 1.0.0 CONFIG QUIET)
-  if (NOT Aluminum_FOUND AND Aluminum_NOT_FOUND_MESSAGE)
-    message(STATUS
-      "A candidate Aluminum > v1.0.0 was found, but was not selected:")
-    message(STATUS
-      "  ${Aluminum_NOT_FOUND_MESSAGE}")
-  endif ()
-  # Try again, since we're technically ok with >v0.7.0
-  if (NOT Aluminum_FOUND)
-    find_package(Aluminum 0.7.0 CONFIG QUIET)
-    if (NOT Aluminum_FOUND AND Aluminum_NOT_FOUND_MESSAGE)
-      message(STATUS
-        "A candidate Aluminum > v0.7.0 was found, but was not selected:")
-      message(STATUS
-        "  ${Aluminum_NOT_FOUND_MESSAGE}")
-    endif ()
-  endif ()
-  if (NOT Aluminum_FOUND)
-    message(FATAL_ERROR "Aluminum support required but not found.")
-  endif ()
-  if (H2_ENABLE_DISTCONV_LEGACY AND NOT AL_HAS_NCCL)
-    message(FATAL_ERROR
-      "DistConv requires Aluminum with at least the NCCLBackend enabled.")
   endif ()
 endif ()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,7 @@ if (H2_ENABLE_TESTS)
     Catch2
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
     GIT_TAG fa43b77429ba76c462b1898d6cd2f2d7a9416b14 # v3.7.1
+    GIT_SHALLOW 1
     FIND_PACKAGE_ARGS 3.0.0 CONFIG
   )
   FetchContent_MakeAvailable(Catch2)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,11 +7,14 @@
 
 if (H2_ENABLE_TESTS)
   # Setup the Catch2 stuff.
-  find_package(Catch2 3.0.0 CONFIG REQUIRED)
-
-  message(STATUS "Found Catch2: ${Catch2_DIR}")
-  message(STATUS "Catch2 Version: ${Catch2_VERSION}")
-  include(Catch)
+  FetchContent_Declare(
+    Catch2
+    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+    GIT_TAG fa43b77429ba76c462b1898d6cd2f2d7a9416b14 # v3.7.1
+    FIND_PACKAGE_ARGS 3.0.0 CONFIG
+  )
+  FetchContent_MakeAvailable(Catch2)
+  report_dep(Catch2)
 
   # Add the actual drivers
   add_subdirectory(unit_test)


### PR DESCRIPTION
This is essentially the same idea as #195, but it uses CMake's `FetchContent` instead.

In my opinion, neither of these PRs (this or #195) is necessary because neither git nor CMake nor any combination thereof is a substitute for a good package manager (though also in my opinion there doesn't exist a good package manager for C++ code on arbitrary platforms). However, there is certainly a quality-of-life argument to be made for developers on the bleeding edge -- get your `git` commits right and you're good to go! Moreover, this workflow makes it trivial to work with locally modified source checkouts, be they from git, a tarball, or any other source (possibly without even needing online access to the upstream).

Anyway, the way this is currently configured is that CMake will first `find_package(<pkg>)` for each `<pkg>` of `Aluminum`, `Catch2`, or `spdlog`. If a sufficient version is found, it will happily accept it and move on. Otherwise it will clone the appropriate git repo and check out a specific commit.

[CI is happy.](https://lc.llnl.gov/gitlab/benson31/h2/-/pipelines/469815)