### PR TITLE
Remove _deps directory from coverage report

### DIFF
--- a/cmake/modules/H2RunCoverage.cmake
+++ b/cmake/modules/H2RunCoverage.cmake
@@ -146,5 +146,5 @@ h2_run_process(
   ${LCOV_PROGRAM}
   --gcov-tool ${GCOV_PROGRAM}
   -r ${OUTPUT_INFO_DIR}/${COVERAGE_TGT}.info
-  "${SOURCE_DIR}/install-deps*" "${SOURCE_DIR}/test/*"
+  "${BUILD_DIR}/_deps*" "${SOURCE_DIR}/install-deps*" "${SOURCE_DIR}/test/*"
   -o ${OUTPUT_INFO_DIR}/${COVERAGE_TGT}.final.info)


### PR DESCRIPTION
Well that turned out to be super easy. Thanks, past-@benson31.

[Latest CI](https://lc.llnl.gov/gitlab/benson31/h2/-/pipelines/no-deps-in-coverage-report/latest)