### PR TITLE
Update Aluminum FetchContent hash

### DIFF
--- a/.gitlab/build-and-test-corona.yml
+++ b/.gitlab/build-and-test-corona.yml
@@ -23,10 +23,10 @@ include:
 # build systems (in particular, it's not clear that all the
 # includes/libs are setup properly under the "/usr/tce" prefix). So I
 # load a module to get a real prefix.
-rocm-6-0-2-corona:
+rocm-6-2-4-corona:
   variables:
     COMPILER_FAMILY: amdclang
-    MODULES: "gcc/10.3.1-magic mvapich2/2.3.7 rocm/6.0.2 cmake/3.26.3 python"
+    MODULES: "gcc/12.1.1-magic mvapich2/2.3.7 rocm/6.2.4 cmake/3.26.3 python"
   extends: [.build-and-test-on-corona, .build-and-test]
 
 gcc-12-1-1-cpu-corona:

--- a/.gitlab/build-and-test.sh
+++ b/.gitlab/build-and-test.sh
@@ -36,6 +36,11 @@ build_distconv=${WITH_DISTCONV:-""}
 job_unique_id=${CI_JOB_ID:-""}
 prefix=""
 
+if [[ "${cluster}" = "corona" ]]
+then
+    module use $HOME/.modulefiles/corona
+fi
+
 # Setup the module environment
 if [[ -n "${modules}" ]]
 then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -496,12 +496,6 @@ if (H2_HAS_CUDA)
 endif ()
 
 if (H2_HAS_ROCM)
-  if (CMAKE_HIP_COMPILER_VERSION VERSION_GREATER_EQUAL "5.5.0")
-    target_compile_features(H2Core PUBLIC hip_std_17)
-  else ()
-    target_compile_options(H2Core PUBLIC
-      $<$<COMPILE_LANGUAGE:HIP>:-std=c++17>)
-  endif ()
   set_target_properties(H2Core
     PROPERTIES
     HIP_STANDARD 17

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,7 +204,7 @@ endmacro()
 FetchContent_Declare(
   Aluminum
   GIT_REPOSITORY https://github.com/LLNL/Aluminum.git
-  GIT_TAG 672bbb782dccf41e3db99d58ddbd2ad0de7e266a # 'master' at 23 Oct 2024
+  GIT_TAG b4e1fc307bf1df8f73e455591d70aac667052e7b # master on 9 Jan 2025
   GIT_SHALLOW 1
   FIND_PACKAGE_ARGS 1.0.0 CONFIG
 )

--- a/include/h2/gpu/runtime.hpp
+++ b/include/h2/gpu/runtime.hpp
@@ -127,7 +127,7 @@ constexpr static bool is_maybe_lambda_or_functor =
 
 template <typename T,
           typename = std::enable_if_t<is_maybe_lambda_or_functor<T>>>
-std::string convert_for_fmt(T const& v) noexcept
+std::string convert_for_fmt(T const&) noexcept
 {
   return "<callable>";
 }

--- a/src/core/dispatch.cpp
+++ b/src/core/dispatch.cpp
@@ -86,7 +86,7 @@ void dispatch_test_impl(CPUDev_t, T* v)
 
 #ifdef H2_HAS_GPU
 template <typename T>
-void dispatch_test_impl(GPUDev_t, T* v)
+void dispatch_test_impl(GPUDev_t, T*)
 {}
 #endif
 


### PR DESCRIPTION
This also requires us to use ROCm 6.2, so the CI had to be updated accordingly. Note the addition of a custom module for ROCm 6.2.4 since LC has not exposed one on Corona.