### PR TITLE
GPU initialization changes

### DIFF
--- a/cmake/modules/H2SetupCUDAToolkit.cmake
+++ b/cmake/modules/H2SetupCUDAToolkit.cmake
@@ -33,7 +33,7 @@ endif ()
 target_link_libraries(
   h2::cuda_toolkit
   INTERFACE
-  CUDA::nvToolsExt
+  $<TARGET_NAME_IF_EXISTS:CUDA::nvToolsExt>
   CUDA::nvml
   CUDA::cuda_driver
   CUDA::cudart)

--- a/include/h2/gpu/runtime.hpp
+++ b/include/h2/gpu/runtime.hpp
@@ -20,7 +20,7 @@
  *  int current_gpu();
  *  void set_gpu(int id);
  *
- *  void init_runtime();
+ *  void init_runtime(int device_id);
  *  void finalize_runtime();
  *  bool runtime_is_initialized();
  *  bool runtime_is_finalized();
@@ -74,7 +74,13 @@ int num_gpus();
 int current_gpu();
 void set_gpu(int id);
 
-void init_runtime();
+/** @brief Ensure the GPU runtime is initialized.
+ *  @param device_id[in] The initial device ID to select. If -1, this
+ *                       will attempt to select something reasonable
+ *                       using environment variables and, possibly,
+ *                       MPI, if available.
+ */
+void init_runtime(int device_id = -1);
 void finalize_runtime();
 bool runtime_is_initialized();
 bool runtime_is_finalized();

--- a/src/gpu/cuda/runtime.cpp
+++ b/src/gpu/cuda/runtime.cpp
@@ -210,14 +210,21 @@ void h2::gpu::set_gpu(int id)
   H2_CHECK_CUDA(cudaSetDevice(id));
 }
 
-void h2::gpu::init_runtime()
+void h2::gpu::init_runtime(int const device_id)
 {
   if (initialized_)
     return;
 
   H2_GPU_TRACE("initializing gpu runtime");
   H2_GPU_TRACE("found {} devices", num_gpus());
-  set_reasonable_default_gpu();
+
+  if (device_id == -1)
+      set_reasonable_default_gpu();
+  else
+  {
+      H2_ASSERT_ALWAYS(device_id >= 0 && device_id < num_gpus);
+      set_device(device_id);
+  }
   initialized_ = true;
 }
 

--- a/src/gpu/cuda/runtime.cpp
+++ b/src/gpu/cuda/runtime.cpp
@@ -222,8 +222,8 @@ void h2::gpu::init_runtime(int const device_id)
       set_reasonable_default_gpu();
   else
   {
-      H2_ASSERT_ALWAYS(device_id >= 0 && device_id < num_gpus);
-      set_device(device_id);
+      H2_ASSERT_ALWAYS(device_id >= 0 && device_id < num_gpus());
+      set_gpu(device_id);
   }
   initialized_ = true;
 }

--- a/src/gpu/rocm/runtime.cpp
+++ b/src/gpu/rocm/runtime.cpp
@@ -345,16 +345,23 @@ void h2::gpu::set_gpu(int id)
   H2_CHECK_HIP(hipSetDevice(id));
 }
 
-void h2::gpu::init_runtime()
+void h2::gpu::init_runtime(int const dev_id)
 {
   if (!initialized_)
   {
-    H2_GPU_TRACE("initializing gpu runtime");
-    H2_CHECK_HIP(hipInit(0));
+    H2_GPU_TRACE("initializing h2 gpu runtime");
     H2_GPU_TRACE("found {} devices", num_gpus());
-    set_reasonable_default_gpu();
+    if (dev_id == -1)
+        set_reasonable_default_gpu();
+    else
+    {
+        H2_ASSERT_ALWAYS(dev_id >= 0 && dev_id < num_gpus());
+        set_gpu(dev_id);
+    }
     initialized_ = true;
 
+    // FIXME (trb): This assumes that the current GPU is
+    // representative of all GPUs we expect to see.
     hipDeviceProp_t props;
     H2_CHECK_HIP(hipGetDeviceProperties(&props, current_gpu()));
     is_integrated_ = props.integrated;


### PR DESCRIPTION
The primary change is allowing the user to explicitly set the GPU device ID to use when they initialize the GPU runtime. If the default value of -1 is used, it will fall back to the round-robin/local-rank method of trying to choose a "reasonable" default device (of course users can always `h2::gpu::set_gpu(whatever)` later, too).

There were some build issues on CUDA platforms so I also cleaned those up.
